### PR TITLE
v2.0.0-rc.2: auto body theme classes for portal components

### DIFF
--- a/src/Lumeo/Lumeo.csproj
+++ b/src/Lumeo/Lumeo.csproj
@@ -8,7 +8,7 @@
 
     <!-- NuGet Package Metadata -->
     <PackageId>Lumeo</PackageId>
-    <Version>2.0.0-rc.1</Version>
+    <Version>2.0.0-rc.2</Version>
     <Title>Lumeo</Title>
     <Authors>bemi</Authors>
     <Description>Lumeo is a modern, accessible Blazor component library with 135+ production-ready components. Built on Tailwind CSS v4 with 8 color themes, dark mode, and 14 locales. Features AI chat primitives (PromptInput, StreamingText, AgentMessage), motion primitives, Scheduler (FullCalendar), Gantt (Frappe), RichTextEditor (TipTap), 30+ ECharts, enterprise DataGrid with Excel/PDF/CSV export, programmatic overlay service, [LumeoForm] Roslyn source generator, RTL support, and 1,564 unit tests. Inspired by shadcn/ui and Radix.</Description>

--- a/src/Lumeo/wwwroot/js/theme.js
+++ b/src/Lumeo/wwwroot/js/theme.js
@@ -1,5 +1,27 @@
 window.themeManager = {
     init: function () {
+        // Ensure portal-rendered components (Dialog / Sheet / Drawer / Toast /
+        // Popover / Tooltip / DataGrid fullscreen) inherit Lumeo's theme tokens.
+        // These overlays sit at the document root, outside any app-level wrapper,
+        // so the theme classes MUST live on <body> — otherwise they render with
+        // the browser's default white/transparent background and look broken in
+        // dark mode. We apply this at init so consumers don't have to remember
+        // to add the classes to their index.html / _Host.cshtml manually.
+        if (document.body) {
+            if (!document.body.classList.contains('bg-background')) {
+                document.body.classList.add('bg-background');
+            }
+            if (!document.body.classList.contains('text-foreground')) {
+                document.body.classList.add('text-foreground');
+            }
+        } else {
+            // theme.js may load before <body> is parsed (head <script>). Re-run
+            // once DOM is ready so the classes still land.
+            document.addEventListener('DOMContentLoaded', function () {
+                document.body.classList.add('bg-background', 'text-foreground');
+            }, { once: true });
+        }
+
         // Dark mode
         const mode = localStorage.getItem('theme-mode') || localStorage.getItem('theme');
         if (mode === 'dark' || (!mode && window.matchMedia('(prefers-color-scheme: dark)').matches)) {

--- a/templates/Lumeo.Templates/Lumeo.Templates.csproj
+++ b/templates/Lumeo.Templates/Lumeo.Templates.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <PackageType>Template</PackageType>
     <PackageId>Lumeo.Templates</PackageId>
-    <Version>2.0.0-rc.1</Version>
+    <Version>2.0.0-rc.2</Version>
     <Title>Lumeo item templates</Title>
     <Authors>bemi</Authors>
     <Description>Scaffolding templates for Lumeo Blazor projects: pages, forms, and components.</Description>

--- a/tools/Lumeo.Cli/Lumeo.Cli.csproj
+++ b/tools/Lumeo.Cli/Lumeo.Cli.csproj
@@ -9,7 +9,7 @@
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>lumeo</ToolCommandName>
     <PackageId>Lumeo.Cli</PackageId>
-    <Version>2.0.0-rc.1</Version>
+    <Version>2.0.0-rc.2</Version>
     <Description>Vendorize Lumeo components directly into your project.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <Authors>bemi</Authors>


### PR DESCRIPTION
## Summary
Follow-up fix after rc.1 consumer feedback: portal-rendered components (Dialog, Sheet, Drawer, Toast, Popover, Tooltip, DataGrid fullscreen) need `bg-background text-foreground` on `<body>` to inherit theme tokens. Consumers who installed Lumeo via NuGet hit this — overlays rendered transparent/white against the dark theme.

## Change
`theme.js` now applies the classes automatically at init (with a DOMContentLoaded fallback when it loads in `<head>` before body is parsed). Zero consumer action needed.

## Version
2.0.0-rc.1 → 2.0.0-rc.2 on all four packages.

## Test plan
- [x] library + docs + tests build clean
- [x] 1,697 / 1,697 tests pass
- [ ] Merge + create GitHub Release `v2.0.0-rc.2` → publish workflow fires 4 jobs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured proper theme styling is applied on initial page load.

* **Chores**
  * Released version 2.0.0-rc.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->