### PR TITLE
v2.0.0-rc.3: chart loading skeletons

### DIFF
--- a/docs/Lumeo.Docs/Layout/NavMenu.razor
+++ b/docs/Lumeo.Docs/Layout/NavMenu.razor
@@ -279,18 +279,71 @@
     </text>;
 }
 
+@inject NavigationManager Nav
+@inject IJSRuntime JS
+@implements IDisposable
+
+@* Active-link highlight is applied to NavLink's auto-generated `.active` class via an
+   arbitrary Tailwind variant on the <nav>. Active-item scroll-into-view happens on
+   every render once we have the nav ref (see OnAfterRenderAsync). *@
+
 @if (IsMobile)
 {
-    <nav class="p-4 space-y-6 text-sm">@navContent</nav>
+    <nav class="p-4 space-y-6 text-sm [&_a.active]:bg-accent [&_a.active]:text-foreground [&_a.active]:font-medium" @ref="_navRef">@navContent</nav>
 }
 else
 {
     <aside class="hidden lg:block w-64 shrink-0 m-3 rounded-[var(--radius-xl)] border border-border/60 bg-card shadow-lg overflow-y-auto sticky top-[84px]" style="max-height: calc(100vh - 100px)">
-        <nav class="p-4 space-y-6 text-sm">@navContent</nav>
+        <nav class="p-4 space-y-6 text-sm [&_a.active]:bg-accent [&_a.active]:text-foreground [&_a.active]:font-medium" @ref="_navRef">@navContent</nav>
     </aside>
 }
 
 @code {
     [Parameter] public bool IsMobile { get; set; }
     private bool _chartsExpanded;
+    private ElementReference _navRef;
+    private string? _lastLocation;
+
+    protected override void OnInitialized()
+    {
+        Nav.LocationChanged += OnLocationChanged;
+        SyncChartsExpanded();
+    }
+
+    private void OnLocationChanged(object? sender, Microsoft.AspNetCore.Components.Routing.LocationChangedEventArgs e)
+    {
+        SyncChartsExpanded();
+        InvokeAsync(StateHasChanged);
+    }
+
+    // When the user lands on any /components/charts/* URL, auto-open the Charts subtree
+    // so the active link is actually visible in the sidebar.
+    private void SyncChartsExpanded()
+    {
+        var uri = Nav.ToBaseRelativePath(Nav.Uri).TrimEnd('/');
+        if (uri.StartsWith("components/charts", StringComparison.OrdinalIgnoreCase))
+        {
+            _chartsExpanded = true;
+        }
+    }
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        // Scroll the active nav item into view after each location change.
+        if (Nav.Uri != _lastLocation)
+        {
+            _lastLocation = Nav.Uri;
+            try
+            {
+                await JS.InvokeVoidAsync("lumeoNavScrollActiveIntoView", _navRef);
+            }
+            catch (JSDisconnectedException) { }
+            catch (Microsoft.JSInterop.JSException) { /* nav ref not ready yet */ }
+        }
+    }
+
+    public void Dispose()
+    {
+        Nav.LocationChanged -= OnLocationChanged;
+    }
 }

--- a/docs/Lumeo.Docs/Pages/Components/Charts/AreaChartPage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/Charts/AreaChartPage.razor
@@ -44,8 +44,16 @@
                         <Switch @bind-Value="_keepLoading" Id="keep-loading" />
                         <label for="keep-loading" class="text-sm text-muted-foreground cursor-pointer">Hold skeleton open</label>
                     </Stack>
+                    <Stack Direction="Stack.StackDirection.Horizontal" Gap="2" Align="center">
+                        <label class="text-sm text-muted-foreground">Duration: @(_simulateDurationMs / 1000.0)s</label>
+                        <input type="range" min="500" max="10000" step="500" @bind-value="_simulateDurationMs" @bind-value:event="oninput" class="w-32 accent-primary" />
+                    </Stack>
+                    <Stack Direction="Stack.StackDirection.Horizontal" Gap="2" Align="center">
+                        <label class="text-sm text-muted-foreground">Cycle: @_phantomCycleMs ms</label>
+                        <input type="range" min="300" max="3000" step="100" @bind-value="_phantomCycleMs" @bind-value:event="oninput" class="w-32 accent-primary" />
+                    </Stack>
                 </Stack>
-                <AreaChart Categories="_categories" Series="_series" Smooth="true" Gradient="true" IsLoading="@LoadingComputed" Height="320px" />
+                <AreaChart Categories="_categories" Series="_series" Smooth="true" Gradient="true" PhantomCycleMs="@_phantomCycleMs" IsLoading="@LoadingComputed" Height="320px" />
             </Stack>
         </Container>
     </ComponentDemo>
@@ -215,11 +223,13 @@
     private bool _loading;
     private bool _keepLoading;
     private bool LoadingComputed => _loading || _keepLoading;
+    private int _simulateDurationMs = 2000;
+    private int _phantomCycleMs = 1400;
 
     private async Task SimulateLoadingAsync()
     {
         _loading = true;
-        await Task.Delay(2000);
+        await Task.Delay(_simulateDurationMs);
         _loading = false;
     }
 }

--- a/docs/Lumeo.Docs/Pages/Components/Charts/AreaChartPage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/Charts/AreaChartPage.razor
@@ -127,6 +127,24 @@
                             <td class="p-3 font-mono text-xs text-muted-foreground">null</td>
                             <td class="p-3 text-muted-foreground">Manual rotation override in degrees on top of LabelStrategy.</td>
                         </tr>
+                        <tr>
+                            <td class="p-3 font-mono text-xs text-primary">IsLoading</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">bool</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">false</td>
+                            <td class="p-3 text-muted-foreground">When true, renders a shape-matched loading skeleton in place of the chart. Bind to your async fetch state.</td>
+                        </tr>
+                        <tr>
+                            <td class="p-3 font-mono text-xs text-primary">ShowLoadingSkeleton</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">bool</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">true</td>
+                            <td class="p-3 text-muted-foreground">Set to false to opt out of the skeleton (chart area stays empty while IsLoading is true).</td>
+                        </tr>
+                        <tr>
+                            <td class="p-3 font-mono text-xs text-primary">SkeletonKind</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">ChartSkeletonKind</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">(chart default)</td>
+                            <td class="p-3 text-muted-foreground">Override the skeleton silhouette (Bars, Line, Area, Pie, Scatter, Grid, Generic).</td>
+                        </tr>
                     </tbody>
                 </table>
             </Stack>

--- a/docs/Lumeo.Docs/Pages/Components/Charts/AreaChartPage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/Charts/AreaChartPage.razor
@@ -145,6 +145,12 @@
                             <td class="p-3 font-mono text-xs text-muted-foreground">(chart default)</td>
                             <td class="p-3 text-muted-foreground">Override the skeleton silhouette (Bars, Line, Area, Pie, Scatter, Grid, Generic).</td>
                         </tr>
+                        <tr>
+                            <td class="p-3 font-mono text-xs text-primary">SkeletonStyle</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">ChartSkeletonStyle</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">Phantom</td>
+                            <td class="p-3 text-muted-foreground">Phantom renders the real chart with placeholder data and morphs to real data via ECharts animation. Silhouette falls back to the legacy SVG skeleton overlay.</td>
+                        </tr>
                     </tbody>
                 </table>
             </Stack>

--- a/docs/Lumeo.Docs/Pages/Components/Charts/AreaChartPage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/Charts/AreaChartPage.razor
@@ -34,6 +34,21 @@
             <AreaChart Categories="_days" Series="_bandwidthSeries" Smooth="true" Gradient="true" ShowDots="false" DataZoom="true" />
         </Container>
     </ComponentDemo>
+
+    <ComponentDemo Title="Loading state" Description="Shape-aware skeleton with reserved space for legend and axes — no layout shift when real data arrives.">
+        <Container>
+            <Stack Gap="4">
+                <Stack Direction="Stack.StackDirection.Horizontal" Gap="4" Align="center" Wrap="true">
+                    <Button OnClick="SimulateLoadingAsync" Disabled="@_loading">Simulate loading</Button>
+                    <Stack Direction="Stack.StackDirection.Horizontal" Gap="2" Align="center">
+                        <Switch @bind-Value="_keepLoading" Id="keep-loading" />
+                        <label for="keep-loading" class="text-sm text-muted-foreground cursor-pointer">Hold skeleton open</label>
+                    </Stack>
+                </Stack>
+                <AreaChart Categories="_categories" Series="_series" Smooth="true" Gradient="true" IsLoading="@LoadingComputed" Height="320px" />
+            </Stack>
+        </Container>
+    </ComponentDemo>
 </Stack>
 
 <Stack Gap="6" Class="mt-12">
@@ -172,4 +187,15 @@
     private string _multiCode = @"<AreaChart Categories=""_months"" Series=""_channelSeries"" Smooth=""true"" Gradient=""true"" />";
     private string _stackedGradientCode = @"<AreaChart Categories=""_months"" Series=""_revenueSeries"" Smooth=""true"" Stacked=""true"" Gradient=""true"" />";
     private string _zoomCode = @"<AreaChart Categories=""_days"" Series=""_bandwidthSeries"" Smooth=""true"" Gradient=""true"" ShowDots=""false"" DataZoom=""true"" />";
+
+    private bool _loading;
+    private bool _keepLoading;
+    private bool LoadingComputed => _loading || _keepLoading;
+
+    private async Task SimulateLoadingAsync()
+    {
+        _loading = true;
+        await Task.Delay(2000);
+        _loading = false;
+    }
 }

--- a/docs/Lumeo.Docs/Pages/Components/Charts/BarChartPage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/Charts/BarChartPage.razor
@@ -64,7 +64,7 @@
         </Container>
     </ComponentDemo>
 
-    <ComponentDemo Title="Loading state" Description="Shape-aware skeletons render automatically before ECharts mounts and while IsLoading is true — no empty-whitespace flash, no layout shift. Click Simulate to fake a 2-second fetch, or flip the switch to pin the skeleton for inspection." Code="@_loadingCode">
+    <ComponentDemo Title="Loading state" Description="Shape-aware skeleton renders automatically before ECharts mounts and while IsLoading is true — no empty-whitespace flash, no layout shift. Click Simulate to fake a 2-second fetch, or flip the switch to pin the skeleton for inspection." Code="@_loadingCode">
         <Container>
             <Stack Gap="4">
                 <Stack Direction="Stack.StackDirection.Horizontal" Gap="4" Align="center" Wrap="true">
@@ -74,20 +74,7 @@
                         <label for="keep-loading" class="text-sm text-muted-foreground cursor-pointer">Hold skeleton open</label>
                     </Stack>
                 </Stack>
-                <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
-                    <Stack Gap="2">
-                        <span class="text-xs font-medium text-muted-foreground uppercase tracking-wide">Bars</span>
-                        <BarChart Categories="_shortCategories" Series="_labelSeries" IsLoading="@IsLoadingComputed" Height="220px" />
-                    </Stack>
-                    <Stack Gap="2">
-                        <span class="text-xs font-medium text-muted-foreground uppercase tracking-wide">Line</span>
-                        <LineChart Categories="_shortCategories" Series="_loadingLineSeries" IsLoading="@IsLoadingComputed" Height="220px" />
-                    </Stack>
-                    <Stack Gap="2">
-                        <span class="text-xs font-medium text-muted-foreground uppercase tracking-wide">Pie</span>
-                        <PieChart Data="_loadingPieData" IsLoading="@IsLoadingComputed" Height="220px" ShowLegend="false" />
-                    </Stack>
-                </div>
+                <BarChart Categories="_shortCategories" Series="_labelSeries" IsLoading="@IsLoadingComputed" Height="320px" />
             </Stack>
         </Container>
     </ComponentDemo>

--- a/docs/Lumeo.Docs/Pages/Components/Charts/BarChartPage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/Charts/BarChartPage.razor
@@ -73,8 +73,16 @@
                         <Switch @bind-Value="_keepLoading" Id="keep-loading" />
                         <label for="keep-loading" class="text-sm text-muted-foreground cursor-pointer">Hold skeleton open</label>
                     </Stack>
+                    <Stack Direction="Stack.StackDirection.Horizontal" Gap="2" Align="center">
+                        <label class="text-sm text-muted-foreground">Duration: @(_simulateBarDurationMs / 1000.0)s</label>
+                        <input type="range" min="500" max="10000" step="500" @bind-value="_simulateBarDurationMs" @bind-value:event="oninput" class="w-32 accent-primary" />
+                    </Stack>
+                    <Stack Direction="Stack.StackDirection.Horizontal" Gap="2" Align="center">
+                        <label class="text-sm text-muted-foreground">Cycle: @_phantomBarCycleMs ms</label>
+                        <input type="range" min="300" max="3000" step="100" @bind-value="_phantomBarCycleMs" @bind-value:event="oninput" class="w-32 accent-primary" />
+                    </Stack>
                 </Stack>
-                <BarChart Categories="_shortCategories" Series="_labelSeries" IsLoading="@IsLoadingComputed" Height="320px" />
+                <BarChart Categories="_shortCategories" Series="_labelSeries" PhantomCycleMs="@_phantomBarCycleMs" IsLoading="@IsLoadingComputed" Height="320px" />
             </Stack>
         </Container>
     </ComponentDemo>
@@ -319,6 +327,8 @@
     // Skeleton shows whenever either toggle is active — simulate flips on for 2s, the switch
     // latches it permanently for inspection/design-review.
     private bool IsLoadingComputed => _isLoading || _keepLoading;
+    private int _simulateBarDurationMs = 2000;
+    private int _phantomBarCycleMs = 1400;
 
     private List<LineChart.ChartSeriesData> _loadingLineSeries = new()
     {
@@ -337,7 +347,7 @@
     {
         _isLoading = true;
         StateHasChanged();
-        await Task.Delay(2000);
+        await Task.Delay(_simulateBarDurationMs);
         _isLoading = false;
         StateHasChanged();
     }

--- a/docs/Lumeo.Docs/Pages/Components/Charts/BarChartPage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/Charts/BarChartPage.razor
@@ -174,6 +174,24 @@
                             <td class="p-3 font-mono text-xs text-muted-foreground">null</td>
                             <td class="p-3 text-muted-foreground">Manual rotation override in degrees on top of LabelStrategy.</td>
                         </tr>
+                        <tr>
+                            <td class="p-3 font-mono text-xs text-primary">IsLoading</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">bool</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">false</td>
+                            <td class="p-3 text-muted-foreground">When true, renders a shape-matched loading skeleton in place of the chart. Bind to your async fetch state.</td>
+                        </tr>
+                        <tr>
+                            <td class="p-3 font-mono text-xs text-primary">ShowLoadingSkeleton</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">bool</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">true</td>
+                            <td class="p-3 text-muted-foreground">Set to false to opt out of the skeleton (chart area stays empty while IsLoading is true).</td>
+                        </tr>
+                        <tr>
+                            <td class="p-3 font-mono text-xs text-primary">SkeletonKind</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">ChartSkeletonKind</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">(chart default)</td>
+                            <td class="p-3 text-muted-foreground">Override the skeleton silhouette (Bars, Line, Area, Pie, Scatter, Grid, Generic).</td>
+                        </tr>
                     </tbody>
                 </table>
             </Stack>

--- a/docs/Lumeo.Docs/Pages/Components/Charts/BarChartPage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/Charts/BarChartPage.razor
@@ -192,6 +192,12 @@
                             <td class="p-3 font-mono text-xs text-muted-foreground">(chart default)</td>
                             <td class="p-3 text-muted-foreground">Override the skeleton silhouette (Bars, Line, Area, Pie, Scatter, Grid, Generic).</td>
                         </tr>
+                        <tr>
+                            <td class="p-3 font-mono text-xs text-primary">SkeletonStyle</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">ChartSkeletonStyle</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">Phantom</td>
+                            <td class="p-3 text-muted-foreground">Phantom renders the real chart with placeholder data and morphs to real data via ECharts animation. Silhouette falls back to the legacy SVG skeleton overlay.</td>
+                        </tr>
                     </tbody>
                 </table>
             </Stack>

--- a/docs/Lumeo.Docs/Pages/Components/Charts/BarChartPage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/Charts/BarChartPage.razor
@@ -63,6 +63,34 @@
             </Stack>
         </Container>
     </ComponentDemo>
+
+    <ComponentDemo Title="Loading state" Description="Shape-aware skeletons render automatically before ECharts mounts and while IsLoading is true — no empty-whitespace flash, no layout shift. Click Simulate to fake a 2-second fetch, or flip the switch to pin the skeleton for inspection." Code="@_loadingCode">
+        <Container>
+            <Stack Gap="4">
+                <Stack Direction="Stack.StackDirection.Horizontal" Gap="4" Align="center" Wrap="true">
+                    <Button OnClick="SimulateLoadingAsync" Disabled="@_isLoading">Simulate loading</Button>
+                    <Stack Direction="Stack.StackDirection.Horizontal" Gap="2" Align="center">
+                        <Switch @bind-Value="_keepLoading" Id="keep-loading" />
+                        <label for="keep-loading" class="text-sm text-muted-foreground cursor-pointer">Hold skeleton open</label>
+                    </Stack>
+                </Stack>
+                <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+                    <Stack Gap="2">
+                        <span class="text-xs font-medium text-muted-foreground uppercase tracking-wide">Bars</span>
+                        <BarChart Categories="_shortCategories" Series="_labelSeries" IsLoading="@IsLoadingComputed" Height="220px" />
+                    </Stack>
+                    <Stack Gap="2">
+                        <span class="text-xs font-medium text-muted-foreground uppercase tracking-wide">Line</span>
+                        <LineChart Categories="_shortCategories" Series="_loadingLineSeries" IsLoading="@IsLoadingComputed" Height="220px" />
+                    </Stack>
+                    <Stack Gap="2">
+                        <span class="text-xs font-medium text-muted-foreground uppercase tracking-wide">Pie</span>
+                        <PieChart Data="_loadingPieData" IsLoading="@IsLoadingComputed" Height="220px" ShowLegend="false" />
+                    </Stack>
+                </div>
+            </Stack>
+        </Container>
+    </ComponentDemo>
 </Stack>
 
 <Stack Gap="6" Class="mt-12">
@@ -273,4 +301,54 @@
     <ToggleGroupItem Value=""Auto"">Auto</ToggleGroupItem>
 </ToggleGroup>
 <BarChart Categories=""@_interactiveLabels"" Series=""@_interactiveSeries"" LabelStrategy=""@_strategy"" Height=""300px"" />";
+
+    // --- Loading state demo ---
+    private bool _isLoading;
+    private bool _keepLoading;
+    // Skeleton shows whenever either toggle is active — simulate flips on for 2s, the switch
+    // latches it permanently for inspection/design-review.
+    private bool IsLoadingComputed => _isLoading || _keepLoading;
+
+    private List<LineChart.ChartSeriesData> _loadingLineSeries = new()
+    {
+        new() { Name = "Revenue", Values = new() { 120, 148, 135, 172 } }
+    };
+
+    private List<PieChart.PieChartData> _loadingPieData = new()
+    {
+        new() { Name = "Direct",  Value = 42 },
+        new() { Name = "Organic", Value = 31 },
+        new() { Name = "Referral",Value = 18 },
+        new() { Name = "Social",  Value = 9  }
+    };
+
+    private async Task SimulateLoadingAsync()
+    {
+        _isLoading = true;
+        StateHasChanged();
+        await Task.Delay(2000);
+        _isLoading = false;
+        StateHasChanged();
+    }
+
+    private string _loadingCode = @"<Button OnClick=""SimulateLoadingAsync"" Disabled=""@_isLoading"">Simulate loading</Button>
+<Switch @bind-Value=""_keepLoading"" />
+
+<BarChart Categories=""_shortCategories"" Series=""_labelSeries"" IsLoading=""@IsLoadingComputed"" />
+<LineChart Categories=""_shortCategories"" Series=""_loadingLineSeries"" IsLoading=""@IsLoadingComputed"" />
+<PieChart Data=""_loadingPieData"" IsLoading=""@IsLoadingComputed"" />
+
+@code {
+    private bool _isLoading;
+    private bool _keepLoading;
+    private bool IsLoadingComputed => _isLoading || _keepLoading;
+
+    private async Task SimulateLoadingAsync()
+    {
+        _isLoading = true;
+        StateHasChanged();
+        await Task.Delay(2000);
+        _isLoading = false;
+    }
+}";
 }

--- a/docs/Lumeo.Docs/Pages/Components/Charts/BoxPlotChartPage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/Charts/BoxPlotChartPage.razor
@@ -10,6 +10,20 @@
             <BoxPlotChart Categories="_categories" Data="_data" />
         </Container>
     </ComponentDemo>
+    <ComponentDemo Title="Loading state" Description="Shape-aware skeleton with reserved space for legend and axes — no layout shift when real data arrives.">
+        <Container>
+            <Stack Gap="4">
+                <Stack Direction="Stack.StackDirection.Horizontal" Gap="4" Align="center" Wrap="true">
+                    <Button OnClick="SimulateLoadingAsync" Disabled="@_loading">Simulate loading</Button>
+                    <Stack Direction="Stack.StackDirection.Horizontal" Gap="2" Align="center">
+                        <Switch @bind-Value="_keepLoading" Id="keep-loading" />
+                        <label for="keep-loading" class="text-sm text-muted-foreground cursor-pointer">Hold skeleton open</label>
+                    </Stack>
+                </Stack>
+                <BoxPlotChart Categories="_categories" Data="_data" IsLoading="@LoadingComputed" Height="320px" />
+            </Stack>
+        </Container>
+    </ComponentDemo>
 </Stack>
 
 <!-- API Reference -->
@@ -71,4 +85,15 @@
     };
 
     private string _basicCode = @"<BoxPlotChart Categories=""_categories"" Data=""_data"" />";
+
+    private bool _loading;
+    private bool _keepLoading;
+    private bool LoadingComputed => _loading || _keepLoading;
+
+    private async Task SimulateLoadingAsync()
+    {
+        _loading = true;
+        await Task.Delay(2000);
+        _loading = false;
+    }
 }

--- a/docs/Lumeo.Docs/Pages/Components/Charts/BoxPlotChartPage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/Charts/BoxPlotChartPage.razor
@@ -67,6 +67,24 @@
                             <td class="p-3 font-mono text-xs text-muted-foreground">null</td>
                             <td class="p-3 text-muted-foreground">Manual rotation override in degrees on top of LabelStrategy.</td>
                         </tr>
+                        <tr>
+                            <td class="p-3 font-mono text-xs text-primary">IsLoading</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">bool</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">false</td>
+                            <td class="p-3 text-muted-foreground">When true, renders a shape-matched loading skeleton in place of the chart. Bind to your async fetch state.</td>
+                        </tr>
+                        <tr>
+                            <td class="p-3 font-mono text-xs text-primary">ShowLoadingSkeleton</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">bool</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">true</td>
+                            <td class="p-3 text-muted-foreground">Set to false to opt out of the skeleton (chart area stays empty while IsLoading is true).</td>
+                        </tr>
+                        <tr>
+                            <td class="p-3 font-mono text-xs text-primary">SkeletonKind</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">ChartSkeletonKind</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">(chart default)</td>
+                            <td class="p-3 text-muted-foreground">Override the skeleton silhouette (Bars, Line, Area, Pie, Scatter, Grid, Generic).</td>
+                        </tr>
                     </tbody>
                 </table>
             </Stack>

--- a/docs/Lumeo.Docs/Pages/Components/Charts/BoxPlotChartPage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/Charts/BoxPlotChartPage.razor
@@ -19,8 +19,16 @@
                         <Switch @bind-Value="_keepLoading" Id="keep-loading" />
                         <label for="keep-loading" class="text-sm text-muted-foreground cursor-pointer">Hold skeleton open</label>
                     </Stack>
+                    <Stack Direction="Stack.StackDirection.Horizontal" Gap="2" Align="center">
+                        <label class="text-sm text-muted-foreground">Duration: @(_simulateDurationMs / 1000.0)s</label>
+                        <input type="range" min="500" max="10000" step="500" @bind-value="_simulateDurationMs" @bind-value:event="oninput" class="w-32 accent-primary" />
+                    </Stack>
+                    <Stack Direction="Stack.StackDirection.Horizontal" Gap="2" Align="center">
+                        <label class="text-sm text-muted-foreground">Cycle: @_phantomCycleMs ms</label>
+                        <input type="range" min="300" max="3000" step="100" @bind-value="_phantomCycleMs" @bind-value:event="oninput" class="w-32 accent-primary" />
+                    </Stack>
                 </Stack>
-                <BoxPlotChart Categories="_categories" Data="_data" IsLoading="@LoadingComputed" Height="320px" />
+                <BoxPlotChart Categories="_categories" Data="_data" PhantomCycleMs="@_phantomCycleMs" IsLoading="@LoadingComputed" Height="320px" />
             </Stack>
         </Container>
     </ComponentDemo>
@@ -113,11 +121,13 @@
     private bool _loading;
     private bool _keepLoading;
     private bool LoadingComputed => _loading || _keepLoading;
+    private int _simulateDurationMs = 2000;
+    private int _phantomCycleMs = 1400;
 
     private async Task SimulateLoadingAsync()
     {
         _loading = true;
-        await Task.Delay(2000);
+        await Task.Delay(_simulateDurationMs);
         _loading = false;
     }
 }

--- a/docs/Lumeo.Docs/Pages/Components/Charts/BoxPlotChartPage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/Charts/BoxPlotChartPage.razor
@@ -85,6 +85,12 @@
                             <td class="p-3 font-mono text-xs text-muted-foreground">(chart default)</td>
                             <td class="p-3 text-muted-foreground">Override the skeleton silhouette (Bars, Line, Area, Pie, Scatter, Grid, Generic).</td>
                         </tr>
+                        <tr>
+                            <td class="p-3 font-mono text-xs text-primary">SkeletonStyle</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">ChartSkeletonStyle</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">Phantom</td>
+                            <td class="p-3 text-muted-foreground">Phantom renders the real chart with placeholder data and morphs to real data via ECharts animation. Silhouette falls back to the legacy SVG skeleton overlay.</td>
+                        </tr>
                     </tbody>
                 </table>
             </Stack>

--- a/docs/Lumeo.Docs/Pages/Components/Charts/CalendarHeatmapChartPage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/Charts/CalendarHeatmapChartPage.razor
@@ -19,8 +19,16 @@
                         <Switch @bind-Value="_keepLoading" Id="keep-loading" />
                         <label for="keep-loading" class="text-sm text-muted-foreground cursor-pointer">Hold skeleton open</label>
                     </Stack>
+                    <Stack Direction="Stack.StackDirection.Horizontal" Gap="2" Align="center">
+                        <label class="text-sm text-muted-foreground">Duration: @(_simulateDurationMs / 1000.0)s</label>
+                        <input type="range" min="500" max="10000" step="500" @bind-value="_simulateDurationMs" @bind-value:event="oninput" class="w-32 accent-primary" />
+                    </Stack>
+                    <Stack Direction="Stack.StackDirection.Horizontal" Gap="2" Align="center">
+                        <label class="text-sm text-muted-foreground">Cycle: @_phantomCycleMs ms</label>
+                        <input type="range" min="300" max="3000" step="100" @bind-value="_phantomCycleMs" @bind-value:event="oninput" class="w-32 accent-primary" />
+                    </Stack>
                 </Stack>
-                <CalendarHeatmapChart Data="_data" Year="2025" VisualMapMin="0" VisualMapMax="10" IsLoading="@LoadingComputed" Height="320px" />
+                <CalendarHeatmapChart Data="_data" Year="2025" VisualMapMin="0" VisualMapMax="10" PhantomCycleMs="@_phantomCycleMs" IsLoading="@LoadingComputed" Height="320px" />
             </Stack>
         </Container>
     </ComponentDemo>
@@ -125,11 +133,13 @@
     private bool _loading;
     private bool _keepLoading;
     private bool LoadingComputed => _loading || _keepLoading;
+    private int _simulateDurationMs = 2000;
+    private int _phantomCycleMs = 1400;
 
     private async Task SimulateLoadingAsync()
     {
         _loading = true;
-        await Task.Delay(2000);
+        await Task.Delay(_simulateDurationMs);
         _loading = false;
     }
 }

--- a/docs/Lumeo.Docs/Pages/Components/Charts/CalendarHeatmapChartPage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/Charts/CalendarHeatmapChartPage.razor
@@ -73,6 +73,24 @@
                             <td class="p-3 font-mono text-xs text-muted-foreground">null</td>
                             <td class="p-3 text-muted-foreground">Custom color range (defaults to green shades).</td>
                         </tr>
+                        <tr>
+                            <td class="p-3 font-mono text-xs text-primary">IsLoading</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">bool</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">false</td>
+                            <td class="p-3 text-muted-foreground">When true, renders a shape-matched loading skeleton in place of the chart. Bind to your async fetch state.</td>
+                        </tr>
+                        <tr>
+                            <td class="p-3 font-mono text-xs text-primary">ShowLoadingSkeleton</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">bool</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">true</td>
+                            <td class="p-3 text-muted-foreground">Set to false to opt out of the skeleton (chart area stays empty while IsLoading is true).</td>
+                        </tr>
+                        <tr>
+                            <td class="p-3 font-mono text-xs text-primary">SkeletonKind</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">ChartSkeletonKind</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">(chart default)</td>
+                            <td class="p-3 text-muted-foreground">Override the skeleton silhouette (Bars, Line, Area, Pie, Scatter, Grid, Generic).</td>
+                        </tr>
                     </tbody>
                 </table>
             </Stack>

--- a/docs/Lumeo.Docs/Pages/Components/Charts/CalendarHeatmapChartPage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/Charts/CalendarHeatmapChartPage.razor
@@ -91,6 +91,12 @@
                             <td class="p-3 font-mono text-xs text-muted-foreground">(chart default)</td>
                             <td class="p-3 text-muted-foreground">Override the skeleton silhouette (Bars, Line, Area, Pie, Scatter, Grid, Generic).</td>
                         </tr>
+                        <tr>
+                            <td class="p-3 font-mono text-xs text-primary">SkeletonStyle</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">ChartSkeletonStyle</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">Phantom</td>
+                            <td class="p-3 text-muted-foreground">Phantom renders the real chart with placeholder data and morphs to real data via ECharts animation. Silhouette falls back to the legacy SVG skeleton overlay.</td>
+                        </tr>
                     </tbody>
                 </table>
             </Stack>

--- a/docs/Lumeo.Docs/Pages/Components/Charts/CalendarHeatmapChartPage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/Charts/CalendarHeatmapChartPage.razor
@@ -10,6 +10,20 @@
             <CalendarHeatmapChart Data="_data" Year="2025" VisualMapMin="0" VisualMapMax="10" Height="200px" />
         </Container>
     </ComponentDemo>
+    <ComponentDemo Title="Loading state" Description="Shape-aware skeleton with reserved space for legend and axes — no layout shift when real data arrives.">
+        <Container>
+            <Stack Gap="4">
+                <Stack Direction="Stack.StackDirection.Horizontal" Gap="4" Align="center" Wrap="true">
+                    <Button OnClick="SimulateLoadingAsync" Disabled="@_loading">Simulate loading</Button>
+                    <Stack Direction="Stack.StackDirection.Horizontal" Gap="2" Align="center">
+                        <Switch @bind-Value="_keepLoading" Id="keep-loading" />
+                        <label for="keep-loading" class="text-sm text-muted-foreground cursor-pointer">Hold skeleton open</label>
+                    </Stack>
+                </Stack>
+                <CalendarHeatmapChart Data="_data" Year="2025" VisualMapMin="0" VisualMapMax="10" IsLoading="@LoadingComputed" Height="320px" />
+            </Stack>
+        </Container>
+    </ComponentDemo>
 </Stack>
 
 <!-- API Reference -->
@@ -83,4 +97,15 @@
     }
 
     private string _basicCode = @"<CalendarHeatmapChart Data=""_data"" Year=""2025"" VisualMapMin=""0"" VisualMapMax=""10"" />";
+
+    private bool _loading;
+    private bool _keepLoading;
+    private bool LoadingComputed => _loading || _keepLoading;
+
+    private async Task SimulateLoadingAsync()
+    {
+        _loading = true;
+        await Task.Delay(2000);
+        _loading = false;
+    }
 }

--- a/docs/Lumeo.Docs/Pages/Components/Charts/CandlestickChartPage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/Charts/CandlestickChartPage.razor
@@ -19,8 +19,16 @@
                         <Switch @bind-Value="_keepLoading" Id="keep-loading" />
                         <label for="keep-loading" class="text-sm text-muted-foreground cursor-pointer">Hold skeleton open</label>
                     </Stack>
+                    <Stack Direction="Stack.StackDirection.Horizontal" Gap="2" Align="center">
+                        <label class="text-sm text-muted-foreground">Duration: @(_simulateDurationMs / 1000.0)s</label>
+                        <input type="range" min="500" max="10000" step="500" @bind-value="_simulateDurationMs" @bind-value:event="oninput" class="w-32 accent-primary" />
+                    </Stack>
+                    <Stack Direction="Stack.StackDirection.Horizontal" Gap="2" Align="center">
+                        <label class="text-sm text-muted-foreground">Cycle: @_phantomCycleMs ms</label>
+                        <input type="range" min="300" max="3000" step="100" @bind-value="_phantomCycleMs" @bind-value:event="oninput" class="w-32 accent-primary" />
+                    </Stack>
                 </Stack>
-                <CandlestickChart Categories="_categories" Data="_data" IsLoading="@LoadingComputed" Height="320px" />
+                <CandlestickChart Categories="_categories" Data="_data" PhantomCycleMs="@_phantomCycleMs" IsLoading="@LoadingComputed" Height="320px" />
             </Stack>
         </Container>
     </ComponentDemo>
@@ -122,11 +130,13 @@
     private bool _loading;
     private bool _keepLoading;
     private bool LoadingComputed => _loading || _keepLoading;
+    private int _simulateDurationMs = 2000;
+    private int _phantomCycleMs = 1400;
 
     private async Task SimulateLoadingAsync()
     {
         _loading = true;
-        await Task.Delay(2000);
+        await Task.Delay(_simulateDurationMs);
         _loading = false;
     }
 }

--- a/docs/Lumeo.Docs/Pages/Components/Charts/CandlestickChartPage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/Charts/CandlestickChartPage.razor
@@ -73,6 +73,24 @@
                             <td class="p-3 font-mono text-xs text-muted-foreground">null</td>
                             <td class="p-3 text-muted-foreground">Manual rotation override in degrees on top of LabelStrategy.</td>
                         </tr>
+                        <tr>
+                            <td class="p-3 font-mono text-xs text-primary">IsLoading</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">bool</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">false</td>
+                            <td class="p-3 text-muted-foreground">When true, renders a shape-matched loading skeleton in place of the chart. Bind to your async fetch state.</td>
+                        </tr>
+                        <tr>
+                            <td class="p-3 font-mono text-xs text-primary">ShowLoadingSkeleton</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">bool</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">true</td>
+                            <td class="p-3 text-muted-foreground">Set to false to opt out of the skeleton (chart area stays empty while IsLoading is true).</td>
+                        </tr>
+                        <tr>
+                            <td class="p-3 font-mono text-xs text-primary">SkeletonKind</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">ChartSkeletonKind</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">(chart default)</td>
+                            <td class="p-3 text-muted-foreground">Override the skeleton silhouette (Bars, Line, Area, Pie, Scatter, Grid, Generic).</td>
+                        </tr>
                     </tbody>
                 </table>
             </Stack>

--- a/docs/Lumeo.Docs/Pages/Components/Charts/CandlestickChartPage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/Charts/CandlestickChartPage.razor
@@ -10,6 +10,20 @@
             <CandlestickChart Categories="_categories" Data="_data" />
         </Container>
     </ComponentDemo>
+    <ComponentDemo Title="Loading state" Description="Shape-aware skeleton with reserved space for legend and axes — no layout shift when real data arrives.">
+        <Container>
+            <Stack Gap="4">
+                <Stack Direction="Stack.StackDirection.Horizontal" Gap="4" Align="center" Wrap="true">
+                    <Button OnClick="SimulateLoadingAsync" Disabled="@_loading">Simulate loading</Button>
+                    <Stack Direction="Stack.StackDirection.Horizontal" Gap="2" Align="center">
+                        <Switch @bind-Value="_keepLoading" Id="keep-loading" />
+                        <label for="keep-loading" class="text-sm text-muted-foreground cursor-pointer">Hold skeleton open</label>
+                    </Stack>
+                </Stack>
+                <CandlestickChart Categories="_categories" Data="_data" IsLoading="@LoadingComputed" Height="320px" />
+            </Stack>
+        </Container>
+    </ComponentDemo>
 </Stack>
 
 <!-- API Reference -->
@@ -80,4 +94,15 @@
     };
 
     private string _basicCode = @"<CandlestickChart Categories=""_categories"" Data=""_data"" />";
+
+    private bool _loading;
+    private bool _keepLoading;
+    private bool LoadingComputed => _loading || _keepLoading;
+
+    private async Task SimulateLoadingAsync()
+    {
+        _loading = true;
+        await Task.Delay(2000);
+        _loading = false;
+    }
 }

--- a/docs/Lumeo.Docs/Pages/Components/Charts/CandlestickChartPage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/Charts/CandlestickChartPage.razor
@@ -91,6 +91,12 @@
                             <td class="p-3 font-mono text-xs text-muted-foreground">(chart default)</td>
                             <td class="p-3 text-muted-foreground">Override the skeleton silhouette (Bars, Line, Area, Pie, Scatter, Grid, Generic).</td>
                         </tr>
+                        <tr>
+                            <td class="p-3 font-mono text-xs text-primary">SkeletonStyle</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">ChartSkeletonStyle</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">Phantom</td>
+                            <td class="p-3 text-muted-foreground">Phantom renders the real chart with placeholder data and morphs to real data via ECharts animation. Silhouette falls back to the legacy SVG skeleton overlay.</td>
+                        </tr>
                     </tbody>
                 </table>
             </Stack>

--- a/docs/Lumeo.Docs/Pages/Components/Charts/DonutChartPage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/Charts/DonutChartPage.razor
@@ -133,6 +133,12 @@
                             <td class="p-3 font-mono text-xs text-muted-foreground">(chart default)</td>
                             <td class="p-3 text-muted-foreground">Override the skeleton silhouette (Bars, Line, Area, Pie, Scatter, Grid, Generic).</td>
                         </tr>
+                        <tr>
+                            <td class="p-3 font-mono text-xs text-primary">SkeletonStyle</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">ChartSkeletonStyle</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">Phantom</td>
+                            <td class="p-3 text-muted-foreground">Phantom renders the real chart with placeholder data and morphs to real data via ECharts animation. Silhouette falls back to the legacy SVG skeleton overlay.</td>
+                        </tr>
                     </tbody>
                 </table>
             </Stack>

--- a/docs/Lumeo.Docs/Pages/Components/Charts/DonutChartPage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/Charts/DonutChartPage.razor
@@ -49,8 +49,16 @@
                         <Switch @bind-Value="_keepLoading" Id="keep-loading" />
                         <label for="keep-loading" class="text-sm text-muted-foreground cursor-pointer">Hold skeleton open</label>
                     </Stack>
+                    <Stack Direction="Stack.StackDirection.Horizontal" Gap="2" Align="center">
+                        <label class="text-sm text-muted-foreground">Duration: @(_simulateDurationMs / 1000.0)s</label>
+                        <input type="range" min="500" max="10000" step="500" @bind-value="_simulateDurationMs" @bind-value:event="oninput" class="w-32 accent-primary" />
+                    </Stack>
+                    <Stack Direction="Stack.StackDirection.Horizontal" Gap="2" Align="center">
+                        <label class="text-sm text-muted-foreground">Cycle: @_phantomCycleMs ms</label>
+                        <input type="range" min="300" max="3000" step="100" @bind-value="_phantomCycleMs" @bind-value:event="oninput" class="w-32 accent-primary" />
+                    </Stack>
                 </Stack>
-                <DonutChart Data="_data" CenterLabel="$128K" InnerRadius="55%" OuterRadius="75%" IsLoading="@LoadingComputed" Height="320px" />
+                <DonutChart Data="_data" CenterLabel="$128K" InnerRadius="55%" OuterRadius="75%" PhantomCycleMs="@_phantomCycleMs" IsLoading="@LoadingComputed" Height="320px" />
             </Stack>
         </Container>
     </ComponentDemo>
@@ -184,11 +192,13 @@
     private bool _loading;
     private bool _keepLoading;
     private bool LoadingComputed => _loading || _keepLoading;
+    private int _simulateDurationMs = 2000;
+    private int _phantomCycleMs = 1400;
 
     private async Task SimulateLoadingAsync()
     {
         _loading = true;
-        await Task.Delay(2000);
+        await Task.Delay(_simulateDurationMs);
         _loading = false;
     }
 }

--- a/docs/Lumeo.Docs/Pages/Components/Charts/DonutChartPage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/Charts/DonutChartPage.razor
@@ -40,6 +40,20 @@
             <DonutChart Data="_storageData" CenterLabel="4 TB" InnerRadius="52%" OuterRadius="72%" />
         </Container>
     </ComponentDemo>
+    <ComponentDemo Title="Loading state" Description="Shape-aware skeleton with reserved space for legend and axes — no layout shift when real data arrives.">
+        <Container>
+            <Stack Gap="4">
+                <Stack Direction="Stack.StackDirection.Horizontal" Gap="4" Align="center" Wrap="true">
+                    <Button OnClick="SimulateLoadingAsync" Disabled="@_loading">Simulate loading</Button>
+                    <Stack Direction="Stack.StackDirection.Horizontal" Gap="2" Align="center">
+                        <Switch @bind-Value="_keepLoading" Id="keep-loading" />
+                        <label for="keep-loading" class="text-sm text-muted-foreground cursor-pointer">Hold skeleton open</label>
+                    </Stack>
+                </Stack>
+                <DonutChart Data="_data" CenterLabel="$128K" InnerRadius="55%" OuterRadius="75%" IsLoading="@LoadingComputed" Height="320px" />
+            </Stack>
+        </Container>
+    </ComponentDemo>
 </Stack>
 
 <!-- API Reference -->
@@ -142,4 +156,15 @@
     private string _ticketsCode = @"<DonutChart Data=""_ticketData"" CenterLabel=""1 247"" InnerRadius=""50%"" OuterRadius=""70%"" />";
     private string _customCode = @"<DonutChart Data=""_data"" Colors=""_brandColors"" ShowLabels=""false"" />";
     private string _storageCode = @"<DonutChart Data=""_storageData"" CenterLabel=""4 TB"" InnerRadius=""52%"" OuterRadius=""72%"" />";
+
+    private bool _loading;
+    private bool _keepLoading;
+    private bool LoadingComputed => _loading || _keepLoading;
+
+    private async Task SimulateLoadingAsync()
+    {
+        _loading = true;
+        await Task.Delay(2000);
+        _loading = false;
+    }
 }

--- a/docs/Lumeo.Docs/Pages/Components/Charts/DonutChartPage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/Charts/DonutChartPage.razor
@@ -115,6 +115,24 @@
                             <td class="p-3 font-mono text-xs text-muted-foreground">null</td>
                             <td class="p-3 text-muted-foreground">Custom color palette for slices.</td>
                         </tr>
+                        <tr>
+                            <td class="p-3 font-mono text-xs text-primary">IsLoading</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">bool</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">false</td>
+                            <td class="p-3 text-muted-foreground">When true, renders a shape-matched loading skeleton in place of the chart. Bind to your async fetch state.</td>
+                        </tr>
+                        <tr>
+                            <td class="p-3 font-mono text-xs text-primary">ShowLoadingSkeleton</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">bool</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">true</td>
+                            <td class="p-3 text-muted-foreground">Set to false to opt out of the skeleton (chart area stays empty while IsLoading is true).</td>
+                        </tr>
+                        <tr>
+                            <td class="p-3 font-mono text-xs text-primary">SkeletonKind</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">ChartSkeletonKind</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">(chart default)</td>
+                            <td class="p-3 text-muted-foreground">Override the skeleton silhouette (Bars, Line, Area, Pie, Scatter, Grid, Generic).</td>
+                        </tr>
                     </tbody>
                 </table>
             </Stack>

--- a/docs/Lumeo.Docs/Pages/Components/Charts/EffectScatterChartPage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/Charts/EffectScatterChartPage.razor
@@ -19,8 +19,16 @@
                         <Switch @bind-Value="_keepLoading" Id="keep-loading" />
                         <label for="keep-loading" class="text-sm text-muted-foreground cursor-pointer">Hold skeleton open</label>
                     </Stack>
+                    <Stack Direction="Stack.StackDirection.Horizontal" Gap="2" Align="center">
+                        <label class="text-sm text-muted-foreground">Duration: @(_simulateDurationMs / 1000.0)s</label>
+                        <input type="range" min="500" max="10000" step="500" @bind-value="_simulateDurationMs" @bind-value:event="oninput" class="w-32 accent-primary" />
+                    </Stack>
+                    <Stack Direction="Stack.StackDirection.Horizontal" Gap="2" Align="center">
+                        <label class="text-sm text-muted-foreground">Cycle: @_phantomCycleMs ms</label>
+                        <input type="range" min="300" max="3000" step="100" @bind-value="_phantomCycleMs" @bind-value:event="oninput" class="w-32 accent-primary" />
+                    </Stack>
                 </Stack>
-                <EffectScatterChart Series="_series" IsLoading="@LoadingComputed" Height="320px" />
+                <EffectScatterChart Series="_series" PhantomCycleMs="@_phantomCycleMs" IsLoading="@LoadingComputed" Height="320px" />
             </Stack>
         </Container>
     </ComponentDemo>
@@ -109,11 +117,13 @@
     private bool _loading;
     private bool _keepLoading;
     private bool LoadingComputed => _loading || _keepLoading;
+    private int _simulateDurationMs = 2000;
+    private int _phantomCycleMs = 1400;
 
     private async Task SimulateLoadingAsync()
     {
         _loading = true;
-        await Task.Delay(2000);
+        await Task.Delay(_simulateDurationMs);
         _loading = false;
     }
 }

--- a/docs/Lumeo.Docs/Pages/Components/Charts/EffectScatterChartPage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/Charts/EffectScatterChartPage.razor
@@ -55,6 +55,24 @@
                             <td class="p-3 font-mono text-xs text-muted-foreground">true</td>
                             <td class="p-3 text-muted-foreground">Shows legend when multiple series present.</td>
                         </tr>
+                        <tr>
+                            <td class="p-3 font-mono text-xs text-primary">IsLoading</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">bool</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">false</td>
+                            <td class="p-3 text-muted-foreground">When true, renders a shape-matched loading skeleton in place of the chart. Bind to your async fetch state.</td>
+                        </tr>
+                        <tr>
+                            <td class="p-3 font-mono text-xs text-primary">ShowLoadingSkeleton</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">bool</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">true</td>
+                            <td class="p-3 text-muted-foreground">Set to false to opt out of the skeleton (chart area stays empty while IsLoading is true).</td>
+                        </tr>
+                        <tr>
+                            <td class="p-3 font-mono text-xs text-primary">SkeletonKind</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">ChartSkeletonKind</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">(chart default)</td>
+                            <td class="p-3 text-muted-foreground">Override the skeleton silhouette (Bars, Line, Area, Pie, Scatter, Grid, Generic).</td>
+                        </tr>
                     </tbody>
                 </table>
             </Stack>

--- a/docs/Lumeo.Docs/Pages/Components/Charts/EffectScatterChartPage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/Charts/EffectScatterChartPage.razor
@@ -10,6 +10,20 @@
             <EffectScatterChart Series="_series" />
         </Container>
     </ComponentDemo>
+    <ComponentDemo Title="Loading state" Description="Shape-aware skeleton with reserved space for legend and axes — no layout shift when real data arrives.">
+        <Container>
+            <Stack Gap="4">
+                <Stack Direction="Stack.StackDirection.Horizontal" Gap="4" Align="center" Wrap="true">
+                    <Button OnClick="SimulateLoadingAsync" Disabled="@_loading">Simulate loading</Button>
+                    <Stack Direction="Stack.StackDirection.Horizontal" Gap="2" Align="center">
+                        <Switch @bind-Value="_keepLoading" Id="keep-loading" />
+                        <label for="keep-loading" class="text-sm text-muted-foreground cursor-pointer">Hold skeleton open</label>
+                    </Stack>
+                </Stack>
+                <EffectScatterChart Series="_series" IsLoading="@LoadingComputed" Height="320px" />
+            </Stack>
+        </Container>
+    </ComponentDemo>
 </Stack>
 
 <!-- API Reference -->
@@ -67,4 +81,15 @@
     };
 
     private string _basicCode = @"<EffectScatterChart Series=""_series"" />";
+
+    private bool _loading;
+    private bool _keepLoading;
+    private bool LoadingComputed => _loading || _keepLoading;
+
+    private async Task SimulateLoadingAsync()
+    {
+        _loading = true;
+        await Task.Delay(2000);
+        _loading = false;
+    }
 }

--- a/docs/Lumeo.Docs/Pages/Components/Charts/EffectScatterChartPage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/Charts/EffectScatterChartPage.razor
@@ -73,6 +73,12 @@
                             <td class="p-3 font-mono text-xs text-muted-foreground">(chart default)</td>
                             <td class="p-3 text-muted-foreground">Override the skeleton silhouette (Bars, Line, Area, Pie, Scatter, Grid, Generic).</td>
                         </tr>
+                        <tr>
+                            <td class="p-3 font-mono text-xs text-primary">SkeletonStyle</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">ChartSkeletonStyle</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">Phantom</td>
+                            <td class="p-3 text-muted-foreground">Phantom renders the real chart with placeholder data and morphs to real data via ECharts animation. Silhouette falls back to the legacy SVG skeleton overlay.</td>
+                        </tr>
                     </tbody>
                 </table>
             </Stack>

--- a/docs/Lumeo.Docs/Pages/Components/Charts/FunnelChartPage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/Charts/FunnelChartPage.razor
@@ -37,8 +37,16 @@
                         <Switch @bind-Value="_keepLoading" Id="keep-loading" />
                         <label for="keep-loading" class="text-sm text-muted-foreground cursor-pointer">Hold skeleton open</label>
                     </Stack>
+                    <Stack Direction="Stack.StackDirection.Horizontal" Gap="2" Align="center">
+                        <label class="text-sm text-muted-foreground">Duration: @(_simulateDurationMs / 1000.0)s</label>
+                        <input type="range" min="500" max="10000" step="500" @bind-value="_simulateDurationMs" @bind-value:event="oninput" class="w-32 accent-primary" />
+                    </Stack>
+                    <Stack Direction="Stack.StackDirection.Horizontal" Gap="2" Align="center">
+                        <label class="text-sm text-muted-foreground">Cycle: @_phantomCycleMs ms</label>
+                        <input type="range" min="300" max="3000" step="100" @bind-value="_phantomCycleMs" @bind-value:event="oninput" class="w-32 accent-primary" />
+                    </Stack>
                 </Stack>
-                <FunnelChart Data="_data" IsLoading="@LoadingComputed" Height="320px" />
+                <FunnelChart Data="_data" PhantomCycleMs="@_phantomCycleMs" IsLoading="@LoadingComputed" Height="320px" />
             </Stack>
         </Container>
     </ComponentDemo>
@@ -157,11 +165,13 @@
     private bool _loading;
     private bool _keepLoading;
     private bool LoadingComputed => _loading || _keepLoading;
+    private int _simulateDurationMs = 2000;
+    private int _phantomCycleMs = 1400;
 
     private async Task SimulateLoadingAsync()
     {
         _loading = true;
-        await Task.Delay(2000);
+        await Task.Delay(_simulateDurationMs);
         _loading = false;
     }
 }

--- a/docs/Lumeo.Docs/Pages/Components/Charts/FunnelChartPage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/Charts/FunnelChartPage.razor
@@ -103,6 +103,12 @@
                             <td class="p-3 font-mono text-xs text-muted-foreground">(chart default)</td>
                             <td class="p-3 text-muted-foreground">Override the skeleton silhouette (Bars, Line, Area, Pie, Scatter, Grid, Generic).</td>
                         </tr>
+                        <tr>
+                            <td class="p-3 font-mono text-xs text-primary">SkeletonStyle</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">ChartSkeletonStyle</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">Phantom</td>
+                            <td class="p-3 text-muted-foreground">Phantom renders the real chart with placeholder data and morphs to real data via ECharts animation. Silhouette falls back to the legacy SVG skeleton overlay.</td>
+                        </tr>
                     </tbody>
                 </table>
             </Stack>

--- a/docs/Lumeo.Docs/Pages/Components/Charts/FunnelChartPage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/Charts/FunnelChartPage.razor
@@ -28,6 +28,20 @@
             <FunnelChart Data="_onboardingData" Toolbox="true" Colors="_warmColors" />
         </Container>
     </ComponentDemo>
+    <ComponentDemo Title="Loading state" Description="Shape-aware skeleton with reserved space for legend and axes — no layout shift when real data arrives.">
+        <Container>
+            <Stack Gap="4">
+                <Stack Direction="Stack.StackDirection.Horizontal" Gap="4" Align="center" Wrap="true">
+                    <Button OnClick="SimulateLoadingAsync" Disabled="@_loading">Simulate loading</Button>
+                    <Stack Direction="Stack.StackDirection.Horizontal" Gap="2" Align="center">
+                        <Switch @bind-Value="_keepLoading" Id="keep-loading" />
+                        <label for="keep-loading" class="text-sm text-muted-foreground cursor-pointer">Hold skeleton open</label>
+                    </Stack>
+                </Stack>
+                <FunnelChart Data="_data" IsLoading="@LoadingComputed" Height="320px" />
+            </Stack>
+        </Container>
+    </ComponentDemo>
 </Stack>
 
 <!-- API Reference -->
@@ -115,4 +129,15 @@
     private string _pipelineCode = @"<FunnelChart Data=""_pipelineData"" ShowLegend=""false"" />";
     private string _labelCode    = @"<FunnelChart Data=""_data"" ShowDataLabels=""true"" />";
     private string _colorCode    = @"<FunnelChart Data=""_onboardingData"" Toolbox=""true"" Colors=""_warmColors"" />";
+
+    private bool _loading;
+    private bool _keepLoading;
+    private bool LoadingComputed => _loading || _keepLoading;
+
+    private async Task SimulateLoadingAsync()
+    {
+        _loading = true;
+        await Task.Delay(2000);
+        _loading = false;
+    }
 }

--- a/docs/Lumeo.Docs/Pages/Components/Charts/FunnelChartPage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/Charts/FunnelChartPage.razor
@@ -85,6 +85,24 @@
                             <td class="p-3 font-mono text-xs text-muted-foreground">null</td>
                             <td class="p-3 text-muted-foreground">Custom color palette.</td>
                         </tr>
+                        <tr>
+                            <td class="p-3 font-mono text-xs text-primary">IsLoading</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">bool</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">false</td>
+                            <td class="p-3 text-muted-foreground">When true, renders a shape-matched loading skeleton in place of the chart. Bind to your async fetch state.</td>
+                        </tr>
+                        <tr>
+                            <td class="p-3 font-mono text-xs text-primary">ShowLoadingSkeleton</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">bool</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">true</td>
+                            <td class="p-3 text-muted-foreground">Set to false to opt out of the skeleton (chart area stays empty while IsLoading is true).</td>
+                        </tr>
+                        <tr>
+                            <td class="p-3 font-mono text-xs text-primary">SkeletonKind</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">ChartSkeletonKind</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">(chart default)</td>
+                            <td class="p-3 text-muted-foreground">Override the skeleton silhouette (Bars, Line, Area, Pie, Scatter, Grid, Generic).</td>
+                        </tr>
                     </tbody>
                 </table>
             </Stack>

--- a/docs/Lumeo.Docs/Pages/Components/Charts/GaugeChartPage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/Charts/GaugeChartPage.razor
@@ -111,6 +111,24 @@
                             <td class="p-3 font-mono text-xs text-muted-foreground">null</td>
                             <td class="p-3 text-muted-foreground">Color zones with Threshold and Color values.</td>
                         </tr>
+                        <tr>
+                            <td class="p-3 font-mono text-xs text-primary">IsLoading</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">bool</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">false</td>
+                            <td class="p-3 text-muted-foreground">When true, renders a shape-matched loading skeleton in place of the chart. Bind to your async fetch state.</td>
+                        </tr>
+                        <tr>
+                            <td class="p-3 font-mono text-xs text-primary">ShowLoadingSkeleton</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">bool</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">true</td>
+                            <td class="p-3 text-muted-foreground">Set to false to opt out of the skeleton (chart area stays empty while IsLoading is true).</td>
+                        </tr>
+                        <tr>
+                            <td class="p-3 font-mono text-xs text-primary">SkeletonKind</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">ChartSkeletonKind</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">(chart default)</td>
+                            <td class="p-3 text-muted-foreground">Override the skeleton silhouette (Bars, Line, Area, Pie, Scatter, Grid, Generic).</td>
+                        </tr>
                     </tbody>
                 </table>
             </Stack>

--- a/docs/Lumeo.Docs/Pages/Components/Charts/GaugeChartPage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/Charts/GaugeChartPage.razor
@@ -45,8 +45,16 @@
                         <Switch @bind-Value="_keepLoading" Id="keep-loading" />
                         <label for="keep-loading" class="text-sm text-muted-foreground cursor-pointer">Hold skeleton open</label>
                     </Stack>
+                    <Stack Direction="Stack.StackDirection.Horizontal" Gap="2" Align="center">
+                        <label class="text-sm text-muted-foreground">Duration: @(_simulateDurationMs / 1000.0)s</label>
+                        <input type="range" min="500" max="10000" step="500" @bind-value="_simulateDurationMs" @bind-value:event="oninput" class="w-32 accent-primary" />
+                    </Stack>
+                    <Stack Direction="Stack.StackDirection.Horizontal" Gap="2" Align="center">
+                        <label class="text-sm text-muted-foreground">Cycle: @_phantomCycleMs ms</label>
+                        <input type="range" min="300" max="3000" step="100" @bind-value="_phantomCycleMs" @bind-value:event="oninput" class="w-32 accent-primary" />
+                    </Stack>
                 </Stack>
-                <GaugeChart Value="68" Title="Speed" Unit="km/h" Max="200" IsLoading="@LoadingComputed" Height="320px" />
+                <GaugeChart Value="68" Title="Speed" Unit="km/h" Max="200" PhantomCycleMs="@_phantomCycleMs" IsLoading="@LoadingComputed" Height="320px" />
             </Stack>
         </Container>
     </ComponentDemo>
@@ -185,11 +193,13 @@
     private bool _loading;
     private bool _keepLoading;
     private bool LoadingComputed => _loading || _keepLoading;
+    private int _simulateDurationMs = 2000;
+    private int _phantomCycleMs = 1400;
 
     private async Task SimulateLoadingAsync()
     {
         _loading = true;
-        await Task.Delay(2000);
+        await Task.Delay(_simulateDurationMs);
         _loading = false;
     }
 }

--- a/docs/Lumeo.Docs/Pages/Components/Charts/GaugeChartPage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/Charts/GaugeChartPage.razor
@@ -36,6 +36,20 @@
                         Toolbox="true" Ranges="_diskRanges" />
         </Container>
     </ComponentDemo>
+    <ComponentDemo Title="Loading state" Description="Shape-aware skeleton with reserved space for legend and axes — no layout shift when real data arrives.">
+        <Container>
+            <Stack Gap="4">
+                <Stack Direction="Stack.StackDirection.Horizontal" Gap="4" Align="center" Wrap="true">
+                    <Button OnClick="SimulateLoadingAsync" Disabled="@_loading">Simulate loading</Button>
+                    <Stack Direction="Stack.StackDirection.Horizontal" Gap="2" Align="center">
+                        <Switch @bind-Value="_keepLoading" Id="keep-loading" />
+                        <label for="keep-loading" class="text-sm text-muted-foreground cursor-pointer">Hold skeleton open</label>
+                    </Stack>
+                </Stack>
+                <GaugeChart Value="68" Title="Speed" Unit="km/h" Max="200" IsLoading="@LoadingComputed" Height="320px" />
+            </Stack>
+        </Container>
+    </ComponentDemo>
 </Stack>
 
 <!-- API Reference -->
@@ -143,4 +157,15 @@
     private string _conversionCode = @"<GaugeChart Value=""34"" Title=""Conversion Rate"" Unit=""%"" Min=""0"" Max=""100"" Ranges=""_conversionRanges"" />";
     private string _npsCode        = @"<GaugeChart Value=""62"" Title=""NPS"" Min=""-100"" Max=""100"" Ranges=""_npsRanges"" />";
     private string _diskCode       = @"<GaugeChart Value=""78"" Title=""Disk Used"" Unit=""%"" ShowPointer=""false"" Toolbox=""true"" Ranges=""_diskRanges"" />";
+
+    private bool _loading;
+    private bool _keepLoading;
+    private bool LoadingComputed => _loading || _keepLoading;
+
+    private async Task SimulateLoadingAsync()
+    {
+        _loading = true;
+        await Task.Delay(2000);
+        _loading = false;
+    }
 }

--- a/docs/Lumeo.Docs/Pages/Components/Charts/GaugeChartPage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/Charts/GaugeChartPage.razor
@@ -129,6 +129,12 @@
                             <td class="p-3 font-mono text-xs text-muted-foreground">(chart default)</td>
                             <td class="p-3 text-muted-foreground">Override the skeleton silhouette (Bars, Line, Area, Pie, Scatter, Grid, Generic).</td>
                         </tr>
+                        <tr>
+                            <td class="p-3 font-mono text-xs text-primary">SkeletonStyle</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">ChartSkeletonStyle</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">Phantom</td>
+                            <td class="p-3 text-muted-foreground">Phantom renders the real chart with placeholder data and morphs to real data via ECharts animation. Silhouette falls back to the legacy SVG skeleton overlay.</td>
+                        </tr>
                     </tbody>
                 </table>
             </Stack>

--- a/docs/Lumeo.Docs/Pages/Components/Charts/GeoMapChartPage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/Charts/GeoMapChartPage.razor
@@ -39,8 +39,16 @@
                         <Switch @bind-Value="_keepLoading" Id="keep-loading" />
                         <label for="keep-loading" class="text-sm text-muted-foreground cursor-pointer">Hold skeleton open</label>
                     </Stack>
+                    <Stack Direction="Stack.StackDirection.Horizontal" Gap="2" Align="center">
+                        <label class="text-sm text-muted-foreground">Duration: @(_simulateDurationMs / 1000.0)s</label>
+                        <input type="range" min="500" max="10000" step="500" @bind-value="_simulateDurationMs" @bind-value:event="oninput" class="w-32 accent-primary" />
+                    </Stack>
+                    <Stack Direction="Stack.StackDirection.Horizontal" Gap="2" Align="center">
+                        <label class="text-sm text-muted-foreground">Cycle: @_phantomCycleMs ms</label>
+                        <input type="range" min="300" max="3000" step="100" @bind-value="_phantomCycleMs" @bind-value:event="oninput" class="w-32 accent-primary" />
+                    </Stack>
                 </Stack>
-                <GeoMapChart MapName="world" MapJson="@_mapJson" Data="_mapData" VisualMapMin="0" VisualMapMax="500" IsLoading="@LoadingComputed" Height="320px" />
+                <GeoMapChart MapName="world" MapJson="@_mapJson" Data="_mapData" VisualMapMin="0" VisualMapMax="500" PhantomCycleMs="@_phantomCycleMs" IsLoading="@LoadingComputed" Height="320px" />
             </Stack>
         </Container>
     </ComponentDemo>
@@ -181,11 +189,13 @@
     private bool _simLoading;
     private bool _keepLoading;
     private bool LoadingComputed => _simLoading || _keepLoading;
+    private int _simulateDurationMs = 2000;
+    private int _phantomCycleMs = 1400;
 
     private async Task SimulateLoadingAsync()
     {
         _simLoading = true;
-        await Task.Delay(2000);
+        await Task.Delay(_simulateDurationMs);
         _simLoading = false;
     }
 

--- a/docs/Lumeo.Docs/Pages/Components/Charts/GeoMapChartPage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/Charts/GeoMapChartPage.razor
@@ -123,6 +123,12 @@
                             <td class="p-3 font-mono text-xs text-muted-foreground">(chart default)</td>
                             <td class="p-3 text-muted-foreground">Override the skeleton silhouette (Bars, Line, Area, Pie, Scatter, Grid, Generic).</td>
                         </tr>
+                        <tr>
+                            <td class="p-3 font-mono text-xs text-primary">SkeletonStyle</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">ChartSkeletonStyle</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">Phantom</td>
+                            <td class="p-3 text-muted-foreground">Phantom renders the real chart with placeholder data and morphs to real data via ECharts animation. Silhouette falls back to the legacy SVG skeleton overlay.</td>
+                        </tr>
                     </tbody>
                 </table>
             </Stack>

--- a/docs/Lumeo.Docs/Pages/Components/Charts/GeoMapChartPage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/Charts/GeoMapChartPage.razor
@@ -29,6 +29,21 @@
             }
         </Container>
     </ComponentDemo>
+
+    <ComponentDemo Title="Loading state" Description="Shape-aware skeleton with reserved space for legend and axes — no layout shift when real data arrives.">
+        <Container>
+            <Stack Gap="4">
+                <Stack Direction="Stack.StackDirection.Horizontal" Gap="4" Align="center" Wrap="true">
+                    <Button OnClick="SimulateLoadingAsync" Disabled="@_simLoading">Simulate loading</Button>
+                    <Stack Direction="Stack.StackDirection.Horizontal" Gap="2" Align="center">
+                        <Switch @bind-Value="_keepLoading" Id="keep-loading" />
+                        <label for="keep-loading" class="text-sm text-muted-foreground cursor-pointer">Hold skeleton open</label>
+                    </Stack>
+                </Stack>
+                <GeoMapChart MapName="world" MapJson="@_mapJson" Data="_mapData" VisualMapMin="0" VisualMapMax="500" IsLoading="@LoadingComputed" Height="320px" />
+            </Stack>
+        </Container>
+    </ComponentDemo>
 </Stack>
 
 <!-- API Reference -->
@@ -137,6 +152,17 @@
             _mapJson = null;
         }
         _loading = false;
+    }
+
+    private bool _simLoading;
+    private bool _keepLoading;
+    private bool LoadingComputed => _simLoading || _keepLoading;
+
+    private async Task SimulateLoadingAsync()
+    {
+        _simLoading = true;
+        await Task.Delay(2000);
+        _simLoading = false;
     }
 
     private string _basicCode = @"@inject HttpClient Http

--- a/docs/Lumeo.Docs/Pages/Components/Charts/GeoMapChartPage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/Charts/GeoMapChartPage.razor
@@ -105,6 +105,24 @@
                             <td class="p-3 font-mono text-xs text-muted-foreground">Blue gradient</td>
                             <td class="p-3 text-muted-foreground">Color range for the visual map (low to high).</td>
                         </tr>
+                        <tr>
+                            <td class="p-3 font-mono text-xs text-primary">IsLoading</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">bool</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">false</td>
+                            <td class="p-3 text-muted-foreground">When true, renders a shape-matched loading skeleton in place of the chart. Bind to your async fetch state.</td>
+                        </tr>
+                        <tr>
+                            <td class="p-3 font-mono text-xs text-primary">ShowLoadingSkeleton</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">bool</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">true</td>
+                            <td class="p-3 text-muted-foreground">Set to false to opt out of the skeleton (chart area stays empty while IsLoading is true).</td>
+                        </tr>
+                        <tr>
+                            <td class="p-3 font-mono text-xs text-primary">SkeletonKind</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">ChartSkeletonKind</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">(chart default)</td>
+                            <td class="p-3 text-muted-foreground">Override the skeleton silhouette (Bars, Line, Area, Pie, Scatter, Grid, Generic).</td>
+                        </tr>
                     </tbody>
                 </table>
             </Stack>

--- a/docs/Lumeo.Docs/Pages/Components/Charts/GraphChartPage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/Charts/GraphChartPage.razor
@@ -10,6 +10,20 @@
             <GraphChart Nodes="_nodes" Links="_links" Categories="_categories" Layout="force" />
         </Container>
     </ComponentDemo>
+    <ComponentDemo Title="Loading state" Description="Shape-aware skeleton with reserved space for legend and axes — no layout shift when real data arrives.">
+        <Container>
+            <Stack Gap="4">
+                <Stack Direction="Stack.StackDirection.Horizontal" Gap="4" Align="center" Wrap="true">
+                    <Button OnClick="SimulateLoadingAsync" Disabled="@_loading">Simulate loading</Button>
+                    <Stack Direction="Stack.StackDirection.Horizontal" Gap="2" Align="center">
+                        <Switch @bind-Value="_keepLoading" Id="keep-loading" />
+                        <label for="keep-loading" class="text-sm text-muted-foreground cursor-pointer">Hold skeleton open</label>
+                    </Stack>
+                </Stack>
+                <GraphChart Nodes="_nodes" Links="_links" Categories="_categories" Layout="force" IsLoading="@LoadingComputed" Height="320px" />
+            </Stack>
+        </Container>
+    </ComponentDemo>
 </Stack>
 
 <!-- API Reference -->
@@ -92,4 +106,15 @@
     };
 
     private string _basicCode = @"<GraphChart Nodes=""_nodes"" Links=""_links"" Categories=""_cats"" Layout=""force"" />";
+
+    private bool _loading;
+    private bool _keepLoading;
+    private bool LoadingComputed => _loading || _keepLoading;
+
+    private async Task SimulateLoadingAsync()
+    {
+        _loading = true;
+        await Task.Delay(2000);
+        _loading = false;
+    }
 }

--- a/docs/Lumeo.Docs/Pages/Components/Charts/GraphChartPage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/Charts/GraphChartPage.razor
@@ -91,6 +91,12 @@
                             <td class="p-3 font-mono text-xs text-muted-foreground">(chart default)</td>
                             <td class="p-3 text-muted-foreground">Override the skeleton silhouette (Bars, Line, Area, Pie, Scatter, Grid, Generic).</td>
                         </tr>
+                        <tr>
+                            <td class="p-3 font-mono text-xs text-primary">SkeletonStyle</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">ChartSkeletonStyle</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">Phantom</td>
+                            <td class="p-3 text-muted-foreground">Phantom renders the real chart with placeholder data and morphs to real data via ECharts animation. Silhouette falls back to the legacy SVG skeleton overlay.</td>
+                        </tr>
                     </tbody>
                 </table>
             </Stack>

--- a/docs/Lumeo.Docs/Pages/Components/Charts/GraphChartPage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/Charts/GraphChartPage.razor
@@ -73,6 +73,24 @@
                             <td class="p-3 font-mono text-xs text-muted-foreground">true</td>
                             <td class="p-3 text-muted-foreground">Enables pan and zoom.</td>
                         </tr>
+                        <tr>
+                            <td class="p-3 font-mono text-xs text-primary">IsLoading</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">bool</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">false</td>
+                            <td class="p-3 text-muted-foreground">When true, renders a shape-matched loading skeleton in place of the chart. Bind to your async fetch state.</td>
+                        </tr>
+                        <tr>
+                            <td class="p-3 font-mono text-xs text-primary">ShowLoadingSkeleton</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">bool</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">true</td>
+                            <td class="p-3 text-muted-foreground">Set to false to opt out of the skeleton (chart area stays empty while IsLoading is true).</td>
+                        </tr>
+                        <tr>
+                            <td class="p-3 font-mono text-xs text-primary">SkeletonKind</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">ChartSkeletonKind</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">(chart default)</td>
+                            <td class="p-3 text-muted-foreground">Override the skeleton silhouette (Bars, Line, Area, Pie, Scatter, Grid, Generic).</td>
+                        </tr>
                     </tbody>
                 </table>
             </Stack>

--- a/docs/Lumeo.Docs/Pages/Components/Charts/GraphChartPage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/Charts/GraphChartPage.razor
@@ -19,8 +19,16 @@
                         <Switch @bind-Value="_keepLoading" Id="keep-loading" />
                         <label for="keep-loading" class="text-sm text-muted-foreground cursor-pointer">Hold skeleton open</label>
                     </Stack>
+                    <Stack Direction="Stack.StackDirection.Horizontal" Gap="2" Align="center">
+                        <label class="text-sm text-muted-foreground">Duration: @(_simulateDurationMs / 1000.0)s</label>
+                        <input type="range" min="500" max="10000" step="500" @bind-value="_simulateDurationMs" @bind-value:event="oninput" class="w-32 accent-primary" />
+                    </Stack>
+                    <Stack Direction="Stack.StackDirection.Horizontal" Gap="2" Align="center">
+                        <label class="text-sm text-muted-foreground">Cycle: @_phantomCycleMs ms</label>
+                        <input type="range" min="300" max="3000" step="100" @bind-value="_phantomCycleMs" @bind-value:event="oninput" class="w-32 accent-primary" />
+                    </Stack>
                 </Stack>
-                <GraphChart Nodes="_nodes" Links="_links" Categories="_categories" Layout="force" IsLoading="@LoadingComputed" Height="320px" />
+                <GraphChart Nodes="_nodes" Links="_links" Categories="_categories" Layout="force" PhantomCycleMs="@_phantomCycleMs" IsLoading="@LoadingComputed" Height="320px" />
             </Stack>
         </Container>
     </ComponentDemo>
@@ -134,11 +142,13 @@
     private bool _loading;
     private bool _keepLoading;
     private bool LoadingComputed => _loading || _keepLoading;
+    private int _simulateDurationMs = 2000;
+    private int _phantomCycleMs = 1400;
 
     private async Task SimulateLoadingAsync()
     {
         _loading = true;
-        await Task.Delay(2000);
+        await Task.Delay(_simulateDurationMs);
         _loading = false;
     }
 }

--- a/docs/Lumeo.Docs/Pages/Components/Charts/HeatmapChartPage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/Charts/HeatmapChartPage.razor
@@ -40,8 +40,16 @@
                         <Switch @bind-Value="_keepLoading" Id="keep-loading" />
                         <label for="keep-loading" class="text-sm text-muted-foreground cursor-pointer">Hold skeleton open</label>
                     </Stack>
+                    <Stack Direction="Stack.StackDirection.Horizontal" Gap="2" Align="center">
+                        <label class="text-sm text-muted-foreground">Duration: @(_simulateDurationMs / 1000.0)s</label>
+                        <input type="range" min="500" max="10000" step="500" @bind-value="_simulateDurationMs" @bind-value:event="oninput" class="w-32 accent-primary" />
+                    </Stack>
+                    <Stack Direction="Stack.StackDirection.Horizontal" Gap="2" Align="center">
+                        <label class="text-sm text-muted-foreground">Cycle: @_phantomCycleMs ms</label>
+                        <input type="range" min="300" max="3000" step="100" @bind-value="_phantomCycleMs" @bind-value:event="oninput" class="w-32 accent-primary" />
+                    </Stack>
                 </Stack>
-                <HeatmapChart XCategories="_xCats" YCategories="_yCats" Data="_data" IsLoading="@LoadingComputed" Height="320px" />
+                <HeatmapChart XCategories="_xCats" YCategories="_yCats" Data="_data" PhantomCycleMs="@_phantomCycleMs" IsLoading="@LoadingComputed" Height="320px" />
             </Stack>
         </Container>
     </ComponentDemo>
@@ -181,11 +189,13 @@
     private bool _loading;
     private bool _keepLoading;
     private bool LoadingComputed => _loading || _keepLoading;
+    private int _simulateDurationMs = 2000;
+    private int _phantomCycleMs = 1400;
 
     private async Task SimulateLoadingAsync()
     {
         _loading = true;
-        await Task.Delay(2000);
+        await Task.Delay(_simulateDurationMs);
         _loading = false;
     }
 }

--- a/docs/Lumeo.Docs/Pages/Components/Charts/HeatmapChartPage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/Charts/HeatmapChartPage.razor
@@ -88,6 +88,24 @@
                             <td class="p-3 font-mono text-xs text-muted-foreground">null</td>
                             <td class="p-3 text-muted-foreground">Custom color range for the visual map.</td>
                         </tr>
+                        <tr>
+                            <td class="p-3 font-mono text-xs text-primary">IsLoading</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">bool</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">false</td>
+                            <td class="p-3 text-muted-foreground">When true, renders a shape-matched loading skeleton in place of the chart. Bind to your async fetch state.</td>
+                        </tr>
+                        <tr>
+                            <td class="p-3 font-mono text-xs text-primary">ShowLoadingSkeleton</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">bool</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">true</td>
+                            <td class="p-3 text-muted-foreground">Set to false to opt out of the skeleton (chart area stays empty while IsLoading is true).</td>
+                        </tr>
+                        <tr>
+                            <td class="p-3 font-mono text-xs text-primary">SkeletonKind</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">ChartSkeletonKind</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">(chart default)</td>
+                            <td class="p-3 text-muted-foreground">Override the skeleton silhouette (Bars, Line, Area, Pie, Scatter, Grid, Generic).</td>
+                        </tr>
                     </tbody>
                 </table>
             </Stack>

--- a/docs/Lumeo.Docs/Pages/Components/Charts/HeatmapChartPage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/Charts/HeatmapChartPage.razor
@@ -106,6 +106,12 @@
                             <td class="p-3 font-mono text-xs text-muted-foreground">(chart default)</td>
                             <td class="p-3 text-muted-foreground">Override the skeleton silhouette (Bars, Line, Area, Pie, Scatter, Grid, Generic).</td>
                         </tr>
+                        <tr>
+                            <td class="p-3 font-mono text-xs text-primary">SkeletonStyle</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">ChartSkeletonStyle</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">Phantom</td>
+                            <td class="p-3 text-muted-foreground">Phantom renders the real chart with placeholder data and morphs to real data via ECharts animation. Silhouette falls back to the legacy SVG skeleton overlay.</td>
+                        </tr>
                     </tbody>
                 </table>
             </Stack>

--- a/docs/Lumeo.Docs/Pages/Components/Charts/HeatmapChartPage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/Charts/HeatmapChartPage.razor
@@ -31,6 +31,20 @@
                           Colors="_adoptionColors" />
         </Container>
     </ComponentDemo>
+    <ComponentDemo Title="Loading state" Description="Shape-aware skeleton with reserved space for legend and axes — no layout shift when real data arrives.">
+        <Container>
+            <Stack Gap="4">
+                <Stack Direction="Stack.StackDirection.Horizontal" Gap="4" Align="center" Wrap="true">
+                    <Button OnClick="SimulateLoadingAsync" Disabled="@_loading">Simulate loading</Button>
+                    <Stack Direction="Stack.StackDirection.Horizontal" Gap="2" Align="center">
+                        <Switch @bind-Value="_keepLoading" Id="keep-loading" />
+                        <label for="keep-loading" class="text-sm text-muted-foreground cursor-pointer">Hold skeleton open</label>
+                    </Stack>
+                </Stack>
+                <HeatmapChart XCategories="_xCats" YCategories="_yCats" Data="_data" IsLoading="@LoadingComputed" Height="320px" />
+            </Stack>
+        </Container>
+    </ComponentDemo>
 </Stack>
 
 <!-- API Reference -->
@@ -139,4 +153,15 @@
     private string _salesCode    = @"<HeatmapChart XCategories=""_monthCats"" YCategories=""_regionCats"" Data=""_salesData"" Colors=""_warmSalesColors"" />";
     private string _errorCode    = @"<HeatmapChart XCategories=""_hourCats"" YCategories=""_weekdayCats"" Data=""_errorData"" ShowDataLabels=""true"" DataZoom=""true"" Toolbox=""true"" />";
     private string _adoptionCode = @"<HeatmapChart XCategories=""_featureCats"" YCategories=""_segmentCats"" Data=""_adoptionData"" Colors=""_adoptionColors"" />";
+
+    private bool _loading;
+    private bool _keepLoading;
+    private bool LoadingComputed => _loading || _keepLoading;
+
+    private async Task SimulateLoadingAsync()
+    {
+        _loading = true;
+        await Task.Delay(2000);
+        _loading = false;
+    }
 }

--- a/docs/Lumeo.Docs/Pages/Components/Charts/LineChartPage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/Charts/LineChartPage.razor
@@ -134,6 +134,24 @@
                             <td class="p-3 font-mono text-xs text-muted-foreground">null</td>
                             <td class="p-3 text-muted-foreground">Manual rotation override in degrees on top of LabelStrategy.</td>
                         </tr>
+                        <tr>
+                            <td class="p-3 font-mono text-xs text-primary">IsLoading</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">bool</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">false</td>
+                            <td class="p-3 text-muted-foreground">When true, renders a shape-matched loading skeleton in place of the chart. Bind to your async fetch state.</td>
+                        </tr>
+                        <tr>
+                            <td class="p-3 font-mono text-xs text-primary">ShowLoadingSkeleton</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">bool</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">true</td>
+                            <td class="p-3 text-muted-foreground">Set to false to opt out of the skeleton (chart area stays empty while IsLoading is true).</td>
+                        </tr>
+                        <tr>
+                            <td class="p-3 font-mono text-xs text-primary">SkeletonKind</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">ChartSkeletonKind</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">(chart default)</td>
+                            <td class="p-3 text-muted-foreground">Override the skeleton silhouette (Bars, Line, Area, Pie, Scatter, Grid, Generic).</td>
+                        </tr>
                     </tbody>
                 </table>
             </Stack>

--- a/docs/Lumeo.Docs/Pages/Components/Charts/LineChartPage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/Charts/LineChartPage.razor
@@ -50,8 +50,16 @@
                         <Switch @bind-Value="_keepLineLoading" Id="keep-line-loading" />
                         <label for="keep-line-loading" class="text-sm text-muted-foreground cursor-pointer">Hold skeleton open</label>
                     </Stack>
+                    <Stack Direction="Stack.StackDirection.Horizontal" Gap="2" Align="center">
+                        <label class="text-sm text-muted-foreground">Duration: @(_simulateLineDurationMs / 1000.0)s</label>
+                        <input type="range" min="500" max="10000" step="500" @bind-value="_simulateLineDurationMs" @bind-value:event="oninput" class="w-32 accent-primary" />
+                    </Stack>
+                    <Stack Direction="Stack.StackDirection.Horizontal" Gap="2" Align="center">
+                        <label class="text-sm text-muted-foreground">Cycle: @_phantomLineCycleMs ms</label>
+                        <input type="range" min="300" max="3000" step="100" @bind-value="_phantomLineCycleMs" @bind-value:event="oninput" class="w-32 accent-primary" />
+                    </Stack>
                 </Stack>
-                <LineChart Categories="_categories" Series="_minimalSeries" IsLoading="@LineLoadingComputed" Height="320px" />
+                <LineChart Categories="_categories" Series="_minimalSeries" PhantomCycleMs="@_phantomLineCycleMs" IsLoading="@LineLoadingComputed" Height="320px" />
             </Stack>
         </Container>
     </ComponentDemo>
@@ -169,11 +177,13 @@
     private bool _lineLoading;
     private bool _keepLineLoading;
     private bool LineLoadingComputed => _lineLoading || _keepLineLoading;
+    private int _simulateLineDurationMs = 2000;
+    private int _phantomLineCycleMs = 1400;
 
     private async Task SimulateLineLoadingAsync()
     {
         _lineLoading = true;
-        await Task.Delay(2000);
+        await Task.Delay(_simulateLineDurationMs);
         _lineLoading = false;
     }
 

--- a/docs/Lumeo.Docs/Pages/Components/Charts/LineChartPage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/Charts/LineChartPage.razor
@@ -152,6 +152,12 @@
                             <td class="p-3 font-mono text-xs text-muted-foreground">(chart default)</td>
                             <td class="p-3 text-muted-foreground">Override the skeleton silhouette (Bars, Line, Area, Pie, Scatter, Grid, Generic).</td>
                         </tr>
+                        <tr>
+                            <td class="p-3 font-mono text-xs text-primary">SkeletonStyle</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">ChartSkeletonStyle</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">Phantom</td>
+                            <td class="p-3 text-muted-foreground">Phantom renders the real chart with placeholder data and morphs to real data via ECharts animation. Silhouette falls back to the legacy SVG skeleton overlay.</td>
+                        </tr>
                     </tbody>
                 </table>
             </Stack>

--- a/docs/Lumeo.Docs/Pages/Components/Charts/LineChartPage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/Charts/LineChartPage.razor
@@ -40,6 +40,21 @@
             <LineChart Categories="_categories" Series="_minimalSeries" Smooth="true" ShowLegend="false" Colors="_brandColors" />
         </Container>
     </ComponentDemo>
+
+    <ComponentDemo Title="Loading state" Description="Multi-series line skeleton draws itself across the path. IsLoading binds to your async fetch; ShowLoadingSkeleton=false opts out.">
+        <Container>
+            <Stack Gap="4">
+                <Stack Direction="Stack.StackDirection.Horizontal" Gap="4" Align="center" Wrap="true">
+                    <Button OnClick="SimulateLineLoadingAsync" Disabled="@_lineLoading">Simulate loading</Button>
+                    <Stack Direction="Stack.StackDirection.Horizontal" Gap="2" Align="center">
+                        <Switch @bind-Value="_keepLineLoading" Id="keep-line-loading" />
+                        <label for="keep-line-loading" class="text-sm text-muted-foreground cursor-pointer">Hold skeleton open</label>
+                    </Stack>
+                </Stack>
+                <LineChart Categories="_categories" Series="_minimalSeries" IsLoading="@LineLoadingComputed" Height="320px" />
+            </Stack>
+        </Container>
+    </ComponentDemo>
 </Stack>
 
 <!-- API Reference -->
@@ -127,6 +142,17 @@
 </Stack>
 
 @code {
+    private bool _lineLoading;
+    private bool _keepLineLoading;
+    private bool LineLoadingComputed => _lineLoading || _keepLineLoading;
+
+    private async Task SimulateLineLoadingAsync()
+    {
+        _lineLoading = true;
+        await Task.Delay(2000);
+        _lineLoading = false;
+    }
+
     private List<string> _categories = new() { "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec" };
     private List<string> _shortCategories = new() { "Q1", "Q2", "Q3", "Q4" };
 

--- a/docs/Lumeo.Docs/Pages/Components/Charts/LiquidFillChartPage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/Charts/LiquidFillChartPage.razor
@@ -85,6 +85,24 @@
                             <td class="p-3 font-mono text-xs text-muted-foreground">true</td>
                             <td class="p-3 text-muted-foreground">Enables the wave animation effect.</td>
                         </tr>
+                        <tr>
+                            <td class="p-3 font-mono text-xs text-primary">IsLoading</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">bool</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">false</td>
+                            <td class="p-3 text-muted-foreground">When true, renders a shape-matched loading skeleton in place of the chart. Bind to your async fetch state.</td>
+                        </tr>
+                        <tr>
+                            <td class="p-3 font-mono text-xs text-primary">ShowLoadingSkeleton</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">bool</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">true</td>
+                            <td class="p-3 text-muted-foreground">Set to false to opt out of the skeleton (chart area stays empty while IsLoading is true).</td>
+                        </tr>
+                        <tr>
+                            <td class="p-3 font-mono text-xs text-primary">SkeletonKind</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">ChartSkeletonKind</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">(chart default)</td>
+                            <td class="p-3 text-muted-foreground">Override the skeleton silhouette (Bars, Line, Area, Pie, Scatter, Grid, Generic).</td>
+                        </tr>
                     </tbody>
                 </table>
             </Stack>

--- a/docs/Lumeo.Docs/Pages/Components/Charts/LiquidFillChartPage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/Charts/LiquidFillChartPage.razor
@@ -103,6 +103,12 @@
                             <td class="p-3 font-mono text-xs text-muted-foreground">(chart default)</td>
                             <td class="p-3 text-muted-foreground">Override the skeleton silhouette (Bars, Line, Area, Pie, Scatter, Grid, Generic).</td>
                         </tr>
+                        <tr>
+                            <td class="p-3 font-mono text-xs text-primary">SkeletonStyle</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">ChartSkeletonStyle</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">Phantom</td>
+                            <td class="p-3 text-muted-foreground">Phantom renders the real chart with placeholder data and morphs to real data via ECharts animation. Silhouette falls back to the legacy SVG skeleton overlay.</td>
+                        </tr>
                     </tbody>
                 </table>
             </Stack>

--- a/docs/Lumeo.Docs/Pages/Components/Charts/LiquidFillChartPage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/Charts/LiquidFillChartPage.razor
@@ -25,8 +25,16 @@
                         <Switch @bind-Value="_keepLoading" Id="keep-loading" />
                         <label for="keep-loading" class="text-sm text-muted-foreground cursor-pointer">Hold skeleton open</label>
                     </Stack>
+                    <Stack Direction="Stack.StackDirection.Horizontal" Gap="2" Align="center">
+                        <label class="text-sm text-muted-foreground">Duration: @(_simulateDurationMs / 1000.0)s</label>
+                        <input type="range" min="500" max="10000" step="500" @bind-value="_simulateDurationMs" @bind-value:event="oninput" class="w-32 accent-primary" />
+                    </Stack>
+                    <Stack Direction="Stack.StackDirection.Horizontal" Gap="2" Align="center">
+                        <label class="text-sm text-muted-foreground">Cycle: @_phantomCycleMs ms</label>
+                        <input type="range" min="300" max="3000" step="100" @bind-value="_phantomCycleMs" @bind-value:event="oninput" class="w-32 accent-primary" />
+                    </Stack>
                 </Stack>
-                <LiquidFillChart Value="0.72" Title="Completion" Shape="circle" Color="#6366f1" IsLoading="@LoadingComputed" Height="320px" />
+                <LiquidFillChart Value="0.72" Title="Completion" Shape="circle" Color="#6366f1" PhantomCycleMs="@_phantomCycleMs" IsLoading="@LoadingComputed" Height="320px" />
             </Stack>
         </Container>
     </ComponentDemo>
@@ -123,11 +131,13 @@
     private bool _loading;
     private bool _keepLoading;
     private bool LoadingComputed => _loading || _keepLoading;
+    private int _simulateDurationMs = 2000;
+    private int _phantomCycleMs = 1400;
 
     private async Task SimulateLoadingAsync()
     {
         _loading = true;
-        await Task.Delay(2000);
+        await Task.Delay(_simulateDurationMs);
         _loading = false;
     }
 }

--- a/docs/Lumeo.Docs/Pages/Components/Charts/LiquidFillChartPage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/Charts/LiquidFillChartPage.razor
@@ -16,6 +16,20 @@
             <LiquidFillChart Value="0.58" Shape="diamond" Color="#10b981" />
         </Container>
     </ComponentDemo>
+    <ComponentDemo Title="Loading state" Description="Shape-aware skeleton with reserved space for legend and axes — no layout shift when real data arrives.">
+        <Container>
+            <Stack Gap="4">
+                <Stack Direction="Stack.StackDirection.Horizontal" Gap="4" Align="center" Wrap="true">
+                    <Button OnClick="SimulateLoadingAsync" Disabled="@_loading">Simulate loading</Button>
+                    <Stack Direction="Stack.StackDirection.Horizontal" Gap="2" Align="center">
+                        <Switch @bind-Value="_keepLoading" Id="keep-loading" />
+                        <label for="keep-loading" class="text-sm text-muted-foreground cursor-pointer">Hold skeleton open</label>
+                    </Stack>
+                </Stack>
+                <LiquidFillChart Value="0.72" Title="Completion" Shape="circle" Color="#6366f1" IsLoading="@LoadingComputed" Height="320px" />
+            </Stack>
+        </Container>
+    </ComponentDemo>
 </Stack>
 
 <!-- API Reference -->
@@ -81,4 +95,15 @@
 @code {
     private string _basicCode = @"<LiquidFillChart Value=""0.72"" Title=""Completion"" Shape=""circle"" Color=""#6366f1"" />";
     private string _diamondCode = @"<LiquidFillChart Value=""0.58"" Shape=""diamond"" Color=""#10b981"" />";
+
+    private bool _loading;
+    private bool _keepLoading;
+    private bool LoadingComputed => _loading || _keepLoading;
+
+    private async Task SimulateLoadingAsync()
+    {
+        _loading = true;
+        await Task.Delay(2000);
+        _loading = false;
+    }
 }

--- a/docs/Lumeo.Docs/Pages/Components/Charts/MixedChartPage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/Charts/MixedChartPage.razor
@@ -29,6 +29,20 @@
             <MixedChart Categories="_categories" Series="_multiSeries" Toolbox="true" Colors="_multiColors" />
         </Container>
     </ComponentDemo>
+    <ComponentDemo Title="Loading state" Description="Shape-aware skeleton with reserved space for legend and axes — no layout shift when real data arrives.">
+        <Container>
+            <Stack Gap="4">
+                <Stack Direction="Stack.StackDirection.Horizontal" Gap="4" Align="center" Wrap="true">
+                    <Button OnClick="SimulateLoadingAsync" Disabled="@_loading">Simulate loading</Button>
+                    <Stack Direction="Stack.StackDirection.Horizontal" Gap="2" Align="center">
+                        <Switch @bind-Value="_keepLoading" Id="keep-loading" />
+                        <label for="keep-loading" class="text-sm text-muted-foreground cursor-pointer">Hold skeleton open</label>
+                    </Stack>
+                </Stack>
+                <MixedChart Categories="_categories" Series="_series" IsLoading="@LoadingComputed" Height="320px" />
+            </Stack>
+        </Container>
+    </ComponentDemo>
 </Stack>
 
 <!-- API Reference -->
@@ -131,4 +145,15 @@
     private string _growthCode   = @"<MixedChart Categories=""_quarterCats"" Series=""_growthSeries"" />";
     private string _supportCode  = @"<MixedChart Categories=""_weekCats"" Series=""_supportSeries"" ShowDataLabels=""true"" DataZoom=""true"" />";
     private string _multiCode    = @"<MixedChart Categories=""_categories"" Series=""_multiSeries"" Toolbox=""true"" Colors=""_multiColors"" />";
+
+    private bool _loading;
+    private bool _keepLoading;
+    private bool LoadingComputed => _loading || _keepLoading;
+
+    private async Task SimulateLoadingAsync()
+    {
+        _loading = true;
+        await Task.Delay(2000);
+        _loading = false;
+    }
 }

--- a/docs/Lumeo.Docs/Pages/Components/Charts/MixedChartPage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/Charts/MixedChartPage.razor
@@ -38,8 +38,16 @@
                         <Switch @bind-Value="_keepLoading" Id="keep-loading" />
                         <label for="keep-loading" class="text-sm text-muted-foreground cursor-pointer">Hold skeleton open</label>
                     </Stack>
+                    <Stack Direction="Stack.StackDirection.Horizontal" Gap="2" Align="center">
+                        <label class="text-sm text-muted-foreground">Duration: @(_simulateDurationMs / 1000.0)s</label>
+                        <input type="range" min="500" max="10000" step="500" @bind-value="_simulateDurationMs" @bind-value:event="oninput" class="w-32 accent-primary" />
+                    </Stack>
+                    <Stack Direction="Stack.StackDirection.Horizontal" Gap="2" Align="center">
+                        <label class="text-sm text-muted-foreground">Cycle: @_phantomCycleMs ms</label>
+                        <input type="range" min="300" max="3000" step="100" @bind-value="_phantomCycleMs" @bind-value:event="oninput" class="w-32 accent-primary" />
+                    </Stack>
                 </Stack>
-                <MixedChart Categories="_categories" Series="_series" IsLoading="@LoadingComputed" Height="320px" />
+                <MixedChart Categories="_categories" Series="_series" PhantomCycleMs="@_phantomCycleMs" IsLoading="@LoadingComputed" Height="320px" />
             </Stack>
         </Container>
     </ComponentDemo>
@@ -173,11 +181,13 @@
     private bool _loading;
     private bool _keepLoading;
     private bool LoadingComputed => _loading || _keepLoading;
+    private int _simulateDurationMs = 2000;
+    private int _phantomCycleMs = 1400;
 
     private async Task SimulateLoadingAsync()
     {
         _loading = true;
-        await Task.Delay(2000);
+        await Task.Delay(_simulateDurationMs);
         _loading = false;
     }
 }

--- a/docs/Lumeo.Docs/Pages/Components/Charts/MixedChartPage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/Charts/MixedChartPage.razor
@@ -116,6 +116,12 @@
                             <td class="p-3 font-mono text-xs text-muted-foreground">(chart default)</td>
                             <td class="p-3 text-muted-foreground">Override the skeleton silhouette (Bars, Line, Area, Pie, Scatter, Grid, Generic).</td>
                         </tr>
+                        <tr>
+                            <td class="p-3 font-mono text-xs text-primary">SkeletonStyle</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">ChartSkeletonStyle</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">Phantom</td>
+                            <td class="p-3 text-muted-foreground">Phantom renders the real chart with placeholder data and morphs to real data via ECharts animation. Silhouette falls back to the legacy SVG skeleton overlay.</td>
+                        </tr>
                     </tbody>
                 </table>
             </Stack>

--- a/docs/Lumeo.Docs/Pages/Components/Charts/MixedChartPage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/Charts/MixedChartPage.razor
@@ -98,6 +98,24 @@
                             <td class="p-3 font-mono text-xs text-muted-foreground">null</td>
                             <td class="p-3 text-muted-foreground">Manual rotation override in degrees on top of LabelStrategy.</td>
                         </tr>
+                        <tr>
+                            <td class="p-3 font-mono text-xs text-primary">IsLoading</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">bool</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">false</td>
+                            <td class="p-3 text-muted-foreground">When true, renders a shape-matched loading skeleton in place of the chart. Bind to your async fetch state.</td>
+                        </tr>
+                        <tr>
+                            <td class="p-3 font-mono text-xs text-primary">ShowLoadingSkeleton</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">bool</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">true</td>
+                            <td class="p-3 text-muted-foreground">Set to false to opt out of the skeleton (chart area stays empty while IsLoading is true).</td>
+                        </tr>
+                        <tr>
+                            <td class="p-3 font-mono text-xs text-primary">SkeletonKind</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">ChartSkeletonKind</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">(chart default)</td>
+                            <td class="p-3 text-muted-foreground">Override the skeleton silhouette (Bars, Line, Area, Pie, Scatter, Grid, Generic).</td>
+                        </tr>
                     </tbody>
                 </table>
             </Stack>

--- a/docs/Lumeo.Docs/Pages/Components/Charts/NightingaleChartPage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/Charts/NightingaleChartPage.razor
@@ -10,6 +10,20 @@
             <NightingaleChart Data="_data" />
         </Container>
     </ComponentDemo>
+    <ComponentDemo Title="Loading state" Description="Shape-aware skeleton with reserved space for legend and axes — no layout shift when real data arrives.">
+        <Container>
+            <Stack Gap="4">
+                <Stack Direction="Stack.StackDirection.Horizontal" Gap="4" Align="center" Wrap="true">
+                    <Button OnClick="SimulateLoadingAsync" Disabled="@_loading">Simulate loading</Button>
+                    <Stack Direction="Stack.StackDirection.Horizontal" Gap="2" Align="center">
+                        <Switch @bind-Value="_keepLoading" Id="keep-loading" />
+                        <label for="keep-loading" class="text-sm text-muted-foreground cursor-pointer">Hold skeleton open</label>
+                    </Stack>
+                </Stack>
+                <NightingaleChart Data="_data" IsLoading="@LoadingComputed" Height="320px" />
+            </Stack>
+        </Container>
+    </ComponentDemo>
 </Stack>
 
 <!-- API Reference -->
@@ -71,4 +85,15 @@
     };
 
     private string _basicCode = @"<NightingaleChart Data=""_data"" />";
+
+    private bool _loading;
+    private bool _keepLoading;
+    private bool LoadingComputed => _loading || _keepLoading;
+
+    private async Task SimulateLoadingAsync()
+    {
+        _loading = true;
+        await Task.Delay(2000);
+        _loading = false;
+    }
 }

--- a/docs/Lumeo.Docs/Pages/Components/Charts/NightingaleChartPage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/Charts/NightingaleChartPage.razor
@@ -67,6 +67,24 @@
                             <td class="p-3 font-mono text-xs text-muted-foreground">null</td>
                             <td class="p-3 text-muted-foreground">Custom color palette.</td>
                         </tr>
+                        <tr>
+                            <td class="p-3 font-mono text-xs text-primary">IsLoading</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">bool</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">false</td>
+                            <td class="p-3 text-muted-foreground">When true, renders a shape-matched loading skeleton in place of the chart. Bind to your async fetch state.</td>
+                        </tr>
+                        <tr>
+                            <td class="p-3 font-mono text-xs text-primary">ShowLoadingSkeleton</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">bool</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">true</td>
+                            <td class="p-3 text-muted-foreground">Set to false to opt out of the skeleton (chart area stays empty while IsLoading is true).</td>
+                        </tr>
+                        <tr>
+                            <td class="p-3 font-mono text-xs text-primary">SkeletonKind</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">ChartSkeletonKind</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">(chart default)</td>
+                            <td class="p-3 text-muted-foreground">Override the skeleton silhouette (Bars, Line, Area, Pie, Scatter, Grid, Generic).</td>
+                        </tr>
                     </tbody>
                 </table>
             </Stack>

--- a/docs/Lumeo.Docs/Pages/Components/Charts/NightingaleChartPage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/Charts/NightingaleChartPage.razor
@@ -19,8 +19,16 @@
                         <Switch @bind-Value="_keepLoading" Id="keep-loading" />
                         <label for="keep-loading" class="text-sm text-muted-foreground cursor-pointer">Hold skeleton open</label>
                     </Stack>
+                    <Stack Direction="Stack.StackDirection.Horizontal" Gap="2" Align="center">
+                        <label class="text-sm text-muted-foreground">Duration: @(_simulateDurationMs / 1000.0)s</label>
+                        <input type="range" min="500" max="10000" step="500" @bind-value="_simulateDurationMs" @bind-value:event="oninput" class="w-32 accent-primary" />
+                    </Stack>
+                    <Stack Direction="Stack.StackDirection.Horizontal" Gap="2" Align="center">
+                        <label class="text-sm text-muted-foreground">Cycle: @_phantomCycleMs ms</label>
+                        <input type="range" min="300" max="3000" step="100" @bind-value="_phantomCycleMs" @bind-value:event="oninput" class="w-32 accent-primary" />
+                    </Stack>
                 </Stack>
-                <NightingaleChart Data="_data" IsLoading="@LoadingComputed" Height="320px" />
+                <NightingaleChart Data="_data" PhantomCycleMs="@_phantomCycleMs" IsLoading="@LoadingComputed" Height="320px" />
             </Stack>
         </Container>
     </ComponentDemo>
@@ -113,11 +121,13 @@
     private bool _loading;
     private bool _keepLoading;
     private bool LoadingComputed => _loading || _keepLoading;
+    private int _simulateDurationMs = 2000;
+    private int _phantomCycleMs = 1400;
 
     private async Task SimulateLoadingAsync()
     {
         _loading = true;
-        await Task.Delay(2000);
+        await Task.Delay(_simulateDurationMs);
         _loading = false;
     }
 }

--- a/docs/Lumeo.Docs/Pages/Components/Charts/NightingaleChartPage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/Charts/NightingaleChartPage.razor
@@ -85,6 +85,12 @@
                             <td class="p-3 font-mono text-xs text-muted-foreground">(chart default)</td>
                             <td class="p-3 text-muted-foreground">Override the skeleton silhouette (Bars, Line, Area, Pie, Scatter, Grid, Generic).</td>
                         </tr>
+                        <tr>
+                            <td class="p-3 font-mono text-xs text-primary">SkeletonStyle</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">ChartSkeletonStyle</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">Phantom</td>
+                            <td class="p-3 text-muted-foreground">Phantom renders the real chart with placeholder data and morphs to real data via ECharts animation. Silhouette falls back to the legacy SVG skeleton overlay.</td>
+                        </tr>
                     </tbody>
                 </table>
             </Stack>

--- a/docs/Lumeo.Docs/Pages/Components/Charts/ParallelChartPage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/Charts/ParallelChartPage.razor
@@ -10,6 +10,20 @@
             <ParallelChart Dimensions="_dimensions" Series="_series" />
         </Container>
     </ComponentDemo>
+    <ComponentDemo Title="Loading state" Description="Shape-aware skeleton with reserved space for legend and axes — no layout shift when real data arrives.">
+        <Container>
+            <Stack Gap="4">
+                <Stack Direction="Stack.StackDirection.Horizontal" Gap="4" Align="center" Wrap="true">
+                    <Button OnClick="SimulateLoadingAsync" Disabled="@_loading">Simulate loading</Button>
+                    <Stack Direction="Stack.StackDirection.Horizontal" Gap="2" Align="center">
+                        <Switch @bind-Value="_keepLoading" Id="keep-loading" />
+                        <label for="keep-loading" class="text-sm text-muted-foreground cursor-pointer">Hold skeleton open</label>
+                    </Stack>
+                </Stack>
+                <ParallelChart Dimensions="_dimensions" Series="_series" IsLoading="@LoadingComputed" Height="320px" />
+            </Stack>
+        </Container>
+    </ComponentDemo>
 </Stack>
 
 <!-- API Reference -->
@@ -80,4 +94,15 @@
     };
 
     private string _basicCode = @"<ParallelChart Dimensions=""_dims"" Series=""_series"" />";
+
+    private bool _loading;
+    private bool _keepLoading;
+    private bool LoadingComputed => _loading || _keepLoading;
+
+    private async Task SimulateLoadingAsync()
+    {
+        _loading = true;
+        await Task.Delay(2000);
+        _loading = false;
+    }
 }

--- a/docs/Lumeo.Docs/Pages/Components/Charts/ParallelChartPage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/Charts/ParallelChartPage.razor
@@ -61,6 +61,24 @@
                             <td class="p-3 font-mono text-xs text-muted-foreground">true</td>
                             <td class="p-3 text-muted-foreground">Shows or hides the chart legend.</td>
                         </tr>
+                        <tr>
+                            <td class="p-3 font-mono text-xs text-primary">IsLoading</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">bool</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">false</td>
+                            <td class="p-3 text-muted-foreground">When true, renders a shape-matched loading skeleton in place of the chart. Bind to your async fetch state.</td>
+                        </tr>
+                        <tr>
+                            <td class="p-3 font-mono text-xs text-primary">ShowLoadingSkeleton</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">bool</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">true</td>
+                            <td class="p-3 text-muted-foreground">Set to false to opt out of the skeleton (chart area stays empty while IsLoading is true).</td>
+                        </tr>
+                        <tr>
+                            <td class="p-3 font-mono text-xs text-primary">SkeletonKind</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">ChartSkeletonKind</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">(chart default)</td>
+                            <td class="p-3 text-muted-foreground">Override the skeleton silhouette (Bars, Line, Area, Pie, Scatter, Grid, Generic).</td>
+                        </tr>
                     </tbody>
                 </table>
             </Stack>

--- a/docs/Lumeo.Docs/Pages/Components/Charts/ParallelChartPage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/Charts/ParallelChartPage.razor
@@ -79,6 +79,12 @@
                             <td class="p-3 font-mono text-xs text-muted-foreground">(chart default)</td>
                             <td class="p-3 text-muted-foreground">Override the skeleton silhouette (Bars, Line, Area, Pie, Scatter, Grid, Generic).</td>
                         </tr>
+                        <tr>
+                            <td class="p-3 font-mono text-xs text-primary">SkeletonStyle</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">ChartSkeletonStyle</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">Phantom</td>
+                            <td class="p-3 text-muted-foreground">Phantom renders the real chart with placeholder data and morphs to real data via ECharts animation. Silhouette falls back to the legacy SVG skeleton overlay.</td>
+                        </tr>
                     </tbody>
                 </table>
             </Stack>

--- a/docs/Lumeo.Docs/Pages/Components/Charts/ParallelChartPage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/Charts/ParallelChartPage.razor
@@ -19,8 +19,16 @@
                         <Switch @bind-Value="_keepLoading" Id="keep-loading" />
                         <label for="keep-loading" class="text-sm text-muted-foreground cursor-pointer">Hold skeleton open</label>
                     </Stack>
+                    <Stack Direction="Stack.StackDirection.Horizontal" Gap="2" Align="center">
+                        <label class="text-sm text-muted-foreground">Duration: @(_simulateDurationMs / 1000.0)s</label>
+                        <input type="range" min="500" max="10000" step="500" @bind-value="_simulateDurationMs" @bind-value:event="oninput" class="w-32 accent-primary" />
+                    </Stack>
+                    <Stack Direction="Stack.StackDirection.Horizontal" Gap="2" Align="center">
+                        <label class="text-sm text-muted-foreground">Cycle: @_phantomCycleMs ms</label>
+                        <input type="range" min="300" max="3000" step="100" @bind-value="_phantomCycleMs" @bind-value:event="oninput" class="w-32 accent-primary" />
+                    </Stack>
                 </Stack>
-                <ParallelChart Dimensions="_dimensions" Series="_series" IsLoading="@LoadingComputed" Height="320px" />
+                <ParallelChart Dimensions="_dimensions" Series="_series" PhantomCycleMs="@_phantomCycleMs" IsLoading="@LoadingComputed" Height="320px" />
             </Stack>
         </Container>
     </ComponentDemo>
@@ -122,11 +130,13 @@
     private bool _loading;
     private bool _keepLoading;
     private bool LoadingComputed => _loading || _keepLoading;
+    private int _simulateDurationMs = 2000;
+    private int _phantomCycleMs = 1400;
 
     private async Task SimulateLoadingAsync()
     {
         _loading = true;
-        await Task.Delay(2000);
+        await Task.Delay(_simulateDurationMs);
         _loading = false;
     }
 }

--- a/docs/Lumeo.Docs/Pages/Components/Charts/PictorialBarChartPage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/Charts/PictorialBarChartPage.razor
@@ -73,6 +73,24 @@
                             <td class="p-3 font-mono text-xs text-muted-foreground">null</td>
                             <td class="p-3 text-muted-foreground">Manual rotation override in degrees on top of LabelStrategy.</td>
                         </tr>
+                        <tr>
+                            <td class="p-3 font-mono text-xs text-primary">IsLoading</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">bool</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">false</td>
+                            <td class="p-3 text-muted-foreground">When true, renders a shape-matched loading skeleton in place of the chart. Bind to your async fetch state.</td>
+                        </tr>
+                        <tr>
+                            <td class="p-3 font-mono text-xs text-primary">ShowLoadingSkeleton</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">bool</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">true</td>
+                            <td class="p-3 text-muted-foreground">Set to false to opt out of the skeleton (chart area stays empty while IsLoading is true).</td>
+                        </tr>
+                        <tr>
+                            <td class="p-3 font-mono text-xs text-primary">SkeletonKind</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">ChartSkeletonKind</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">(chart default)</td>
+                            <td class="p-3 text-muted-foreground">Override the skeleton silhouette (Bars, Line, Area, Pie, Scatter, Grid, Generic).</td>
+                        </tr>
                     </tbody>
                 </table>
             </Stack>

--- a/docs/Lumeo.Docs/Pages/Components/Charts/PictorialBarChartPage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/Charts/PictorialBarChartPage.razor
@@ -91,6 +91,12 @@
                             <td class="p-3 font-mono text-xs text-muted-foreground">(chart default)</td>
                             <td class="p-3 text-muted-foreground">Override the skeleton silhouette (Bars, Line, Area, Pie, Scatter, Grid, Generic).</td>
                         </tr>
+                        <tr>
+                            <td class="p-3 font-mono text-xs text-primary">SkeletonStyle</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">ChartSkeletonStyle</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">Phantom</td>
+                            <td class="p-3 text-muted-foreground">Phantom renders the real chart with placeholder data and morphs to real data via ECharts animation. Silhouette falls back to the legacy SVG skeleton overlay.</td>
+                        </tr>
                     </tbody>
                 </table>
             </Stack>

--- a/docs/Lumeo.Docs/Pages/Components/Charts/PictorialBarChartPage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/Charts/PictorialBarChartPage.razor
@@ -10,6 +10,20 @@
             <PictorialBarChart Categories="_categories" Series="_series" />
         </Container>
     </ComponentDemo>
+    <ComponentDemo Title="Loading state" Description="Shape-aware skeleton with reserved space for legend and axes — no layout shift when real data arrives.">
+        <Container>
+            <Stack Gap="4">
+                <Stack Direction="Stack.StackDirection.Horizontal" Gap="4" Align="center" Wrap="true">
+                    <Button OnClick="SimulateLoadingAsync" Disabled="@_loading">Simulate loading</Button>
+                    <Stack Direction="Stack.StackDirection.Horizontal" Gap="2" Align="center">
+                        <Switch @bind-Value="_keepLoading" Id="keep-loading" />
+                        <label for="keep-loading" class="text-sm text-muted-foreground cursor-pointer">Hold skeleton open</label>
+                    </Stack>
+                </Stack>
+                <PictorialBarChart Categories="_categories" Series="_series" IsLoading="@LoadingComputed" Height="320px" />
+            </Stack>
+        </Container>
+    </ComponentDemo>
 </Stack>
 
 <!-- API Reference -->
@@ -74,4 +88,15 @@
     };
 
     private string _basicCode = @"<PictorialBarChart Categories=""_categories"" Series=""_series"" />";
+
+    private bool _loading;
+    private bool _keepLoading;
+    private bool LoadingComputed => _loading || _keepLoading;
+
+    private async Task SimulateLoadingAsync()
+    {
+        _loading = true;
+        await Task.Delay(2000);
+        _loading = false;
+    }
 }

--- a/docs/Lumeo.Docs/Pages/Components/Charts/PictorialBarChartPage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/Charts/PictorialBarChartPage.razor
@@ -19,8 +19,16 @@
                         <Switch @bind-Value="_keepLoading" Id="keep-loading" />
                         <label for="keep-loading" class="text-sm text-muted-foreground cursor-pointer">Hold skeleton open</label>
                     </Stack>
+                    <Stack Direction="Stack.StackDirection.Horizontal" Gap="2" Align="center">
+                        <label class="text-sm text-muted-foreground">Duration: @(_simulateDurationMs / 1000.0)s</label>
+                        <input type="range" min="500" max="10000" step="500" @bind-value="_simulateDurationMs" @bind-value:event="oninput" class="w-32 accent-primary" />
+                    </Stack>
+                    <Stack Direction="Stack.StackDirection.Horizontal" Gap="2" Align="center">
+                        <label class="text-sm text-muted-foreground">Cycle: @_phantomCycleMs ms</label>
+                        <input type="range" min="300" max="3000" step="100" @bind-value="_phantomCycleMs" @bind-value:event="oninput" class="w-32 accent-primary" />
+                    </Stack>
                 </Stack>
-                <PictorialBarChart Categories="_categories" Series="_series" IsLoading="@LoadingComputed" Height="320px" />
+                <PictorialBarChart Categories="_categories" Series="_series" PhantomCycleMs="@_phantomCycleMs" IsLoading="@LoadingComputed" Height="320px" />
             </Stack>
         </Container>
     </ComponentDemo>
@@ -116,11 +124,13 @@
     private bool _loading;
     private bool _keepLoading;
     private bool LoadingComputed => _loading || _keepLoading;
+    private int _simulateDurationMs = 2000;
+    private int _phantomCycleMs = 1400;
 
     private async Task SimulateLoadingAsync()
     {
         _loading = true;
-        await Task.Delay(2000);
+        await Task.Delay(_simulateDurationMs);
         _loading = false;
     }
 }

--- a/docs/Lumeo.Docs/Pages/Components/Charts/PieChartPage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/Charts/PieChartPage.razor
@@ -98,6 +98,24 @@
                             <td class="p-3 font-mono text-xs text-muted-foreground">true</td>
                             <td class="p-3 text-muted-foreground">Enables the hover tooltip.</td>
                         </tr>
+                        <tr>
+                            <td class="p-3 font-mono text-xs text-primary">IsLoading</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">bool</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">false</td>
+                            <td class="p-3 text-muted-foreground">When true, renders a shape-matched loading skeleton in place of the chart. Bind to your async fetch state.</td>
+                        </tr>
+                        <tr>
+                            <td class="p-3 font-mono text-xs text-primary">ShowLoadingSkeleton</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">bool</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">true</td>
+                            <td class="p-3 text-muted-foreground">Set to false to opt out of the skeleton (chart area stays empty while IsLoading is true).</td>
+                        </tr>
+                        <tr>
+                            <td class="p-3 font-mono text-xs text-primary">SkeletonKind</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">ChartSkeletonKind</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">(chart default)</td>
+                            <td class="p-3 text-muted-foreground">Override the skeleton silhouette (Bars, Line, Area, Pie, Scatter, Grid, Generic).</td>
+                        </tr>
                     </tbody>
                 </table>
             </Stack>

--- a/docs/Lumeo.Docs/Pages/Components/Charts/PieChartPage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/Charts/PieChartPage.razor
@@ -44,8 +44,16 @@
                         <Switch @bind-Value="_keepPieLoading" Id="keep-pie-loading" />
                         <label for="keep-pie-loading" class="text-sm text-muted-foreground cursor-pointer">Hold skeleton open</label>
                     </Stack>
+                    <Stack Direction="Stack.StackDirection.Horizontal" Gap="2" Align="center">
+                        <label class="text-sm text-muted-foreground">Duration: @(_simulatePieDurationMs / 1000.0)s</label>
+                        <input type="range" min="500" max="10000" step="500" @bind-value="_simulatePieDurationMs" @bind-value:event="oninput" class="w-32 accent-primary" />
+                    </Stack>
+                    <Stack Direction="Stack.StackDirection.Horizontal" Gap="2" Align="center">
+                        <label class="text-sm text-muted-foreground">Cycle: @_phantomPieCycleMs ms</label>
+                        <input type="range" min="300" max="3000" step="100" @bind-value="_phantomPieCycleMs" @bind-value:event="oninput" class="w-32 accent-primary" />
+                    </Stack>
                 </Stack>
-                <PieChart Data="_data" IsLoading="@PieLoadingComputed" Height="320px" />
+                <PieChart Data="_data" PhantomCycleMs="@_phantomPieCycleMs" IsLoading="@PieLoadingComputed" Height="320px" />
             </Stack>
         </Container>
     </ComponentDemo>
@@ -133,11 +141,13 @@
     private bool _pieLoading;
     private bool _keepPieLoading;
     private bool PieLoadingComputed => _pieLoading || _keepPieLoading;
+    private int _simulatePieDurationMs = 2000;
+    private int _phantomPieCycleMs = 1400;
 
     private async Task SimulatePieLoadingAsync()
     {
         _pieLoading = true;
-        await Task.Delay(2000);
+        await Task.Delay(_simulatePieDurationMs);
         _pieLoading = false;
     }
 

--- a/docs/Lumeo.Docs/Pages/Components/Charts/PieChartPage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/Charts/PieChartPage.razor
@@ -116,6 +116,12 @@
                             <td class="p-3 font-mono text-xs text-muted-foreground">(chart default)</td>
                             <td class="p-3 text-muted-foreground">Override the skeleton silhouette (Bars, Line, Area, Pie, Scatter, Grid, Generic).</td>
                         </tr>
+                        <tr>
+                            <td class="p-3 font-mono text-xs text-primary">SkeletonStyle</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">ChartSkeletonStyle</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">Phantom</td>
+                            <td class="p-3 text-muted-foreground">Phantom renders the real chart with placeholder data and morphs to real data via ECharts animation. Silhouette falls back to the legacy SVG skeleton overlay.</td>
+                        </tr>
                     </tbody>
                 </table>
             </Stack>

--- a/docs/Lumeo.Docs/Pages/Components/Charts/PieChartPage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/Charts/PieChartPage.razor
@@ -34,6 +34,21 @@
             <PieChart Data="_data" ShowLegend="false" />
         </Container>
     </ComponentDemo>
+
+    <ComponentDemo Title="Loading state" Description="Four flat slices rotate slowly while the chart data arrives. Matches the shape of the real pie — no 3D burst.">
+        <Container>
+            <Stack Gap="4">
+                <Stack Direction="Stack.StackDirection.Horizontal" Gap="4" Align="center" Wrap="true">
+                    <Button OnClick="SimulatePieLoadingAsync" Disabled="@_pieLoading">Simulate loading</Button>
+                    <Stack Direction="Stack.StackDirection.Horizontal" Gap="2" Align="center">
+                        <Switch @bind-Value="_keepPieLoading" Id="keep-pie-loading" />
+                        <label for="keep-pie-loading" class="text-sm text-muted-foreground cursor-pointer">Hold skeleton open</label>
+                    </Stack>
+                </Stack>
+                <PieChart Data="_data" IsLoading="@PieLoadingComputed" Height="320px" />
+            </Stack>
+        </Container>
+    </ComponentDemo>
 </Stack>
 
 <!-- API Reference -->
@@ -91,6 +106,17 @@
 </Stack>
 
 @code {
+    private bool _pieLoading;
+    private bool _keepPieLoading;
+    private bool PieLoadingComputed => _pieLoading || _keepPieLoading;
+
+    private async Task SimulatePieLoadingAsync()
+    {
+        _pieLoading = true;
+        await Task.Delay(2000);
+        _pieLoading = false;
+    }
+
     private List<PieChart.PieChartData> _data = new()
     {
         new() { Name = "Products",      Value = 48 },

--- a/docs/Lumeo.Docs/Pages/Components/Charts/PolarBarChartPage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/Charts/PolarBarChartPage.razor
@@ -19,8 +19,16 @@
                         <Switch @bind-Value="_keepLoading" Id="keep-loading" />
                         <label for="keep-loading" class="text-sm text-muted-foreground cursor-pointer">Hold skeleton open</label>
                     </Stack>
+                    <Stack Direction="Stack.StackDirection.Horizontal" Gap="2" Align="center">
+                        <label class="text-sm text-muted-foreground">Duration: @(_simulateDurationMs / 1000.0)s</label>
+                        <input type="range" min="500" max="10000" step="500" @bind-value="_simulateDurationMs" @bind-value:event="oninput" class="w-32 accent-primary" />
+                    </Stack>
+                    <Stack Direction="Stack.StackDirection.Horizontal" Gap="2" Align="center">
+                        <label class="text-sm text-muted-foreground">Cycle: @_phantomCycleMs ms</label>
+                        <input type="range" min="300" max="3000" step="100" @bind-value="_phantomCycleMs" @bind-value:event="oninput" class="w-32 accent-primary" />
+                    </Stack>
                 </Stack>
-                <PolarBarChart Categories="_categories" Values="_values" IsLoading="@LoadingComputed" Height="320px" />
+                <PolarBarChart Categories="_categories" Values="_values" PhantomCycleMs="@_phantomCycleMs" IsLoading="@LoadingComputed" Height="320px" />
             </Stack>
         </Container>
     </ComponentDemo>
@@ -101,11 +109,13 @@
     private bool _loading;
     private bool _keepLoading;
     private bool LoadingComputed => _loading || _keepLoading;
+    private int _simulateDurationMs = 2000;
+    private int _phantomCycleMs = 1400;
 
     private async Task SimulateLoadingAsync()
     {
         _loading = true;
-        await Task.Delay(2000);
+        await Task.Delay(_simulateDurationMs);
         _loading = false;
     }
 }

--- a/docs/Lumeo.Docs/Pages/Components/Charts/PolarBarChartPage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/Charts/PolarBarChartPage.razor
@@ -61,6 +61,24 @@
                             <td class="p-3 font-mono text-xs text-muted-foreground">false</td>
                             <td class="p-3 text-muted-foreground">Shows or hides the chart legend.</td>
                         </tr>
+                        <tr>
+                            <td class="p-3 font-mono text-xs text-primary">IsLoading</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">bool</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">false</td>
+                            <td class="p-3 text-muted-foreground">When true, renders a shape-matched loading skeleton in place of the chart. Bind to your async fetch state.</td>
+                        </tr>
+                        <tr>
+                            <td class="p-3 font-mono text-xs text-primary">ShowLoadingSkeleton</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">bool</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">true</td>
+                            <td class="p-3 text-muted-foreground">Set to false to opt out of the skeleton (chart area stays empty while IsLoading is true).</td>
+                        </tr>
+                        <tr>
+                            <td class="p-3 font-mono text-xs text-primary">SkeletonKind</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">ChartSkeletonKind</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">(chart default)</td>
+                            <td class="p-3 text-muted-foreground">Override the skeleton silhouette (Bars, Line, Area, Pie, Scatter, Grid, Generic).</td>
+                        </tr>
                     </tbody>
                 </table>
             </Stack>

--- a/docs/Lumeo.Docs/Pages/Components/Charts/PolarBarChartPage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/Charts/PolarBarChartPage.razor
@@ -10,6 +10,20 @@
             <PolarBarChart Categories="_categories" Values="_values" />
         </Container>
     </ComponentDemo>
+    <ComponentDemo Title="Loading state" Description="Shape-aware skeleton with reserved space for legend and axes — no layout shift when real data arrives.">
+        <Container>
+            <Stack Gap="4">
+                <Stack Direction="Stack.StackDirection.Horizontal" Gap="4" Align="center" Wrap="true">
+                    <Button OnClick="SimulateLoadingAsync" Disabled="@_loading">Simulate loading</Button>
+                    <Stack Direction="Stack.StackDirection.Horizontal" Gap="2" Align="center">
+                        <Switch @bind-Value="_keepLoading" Id="keep-loading" />
+                        <label for="keep-loading" class="text-sm text-muted-foreground cursor-pointer">Hold skeleton open</label>
+                    </Stack>
+                </Stack>
+                <PolarBarChart Categories="_categories" Values="_values" IsLoading="@LoadingComputed" Height="320px" />
+            </Stack>
+        </Container>
+    </ComponentDemo>
 </Stack>
 
 <!-- API Reference -->
@@ -59,4 +73,15 @@
     private List<double> _values = new() { 3240, 4180, 3870, 5120, 6340, 4980, 3650 };
 
     private string _basicCode = @"<PolarBarChart Categories=""_categories"" Values=""_values"" />";
+
+    private bool _loading;
+    private bool _keepLoading;
+    private bool LoadingComputed => _loading || _keepLoading;
+
+    private async Task SimulateLoadingAsync()
+    {
+        _loading = true;
+        await Task.Delay(2000);
+        _loading = false;
+    }
 }

--- a/docs/Lumeo.Docs/Pages/Components/Charts/PolarBarChartPage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/Charts/PolarBarChartPage.razor
@@ -79,6 +79,12 @@
                             <td class="p-3 font-mono text-xs text-muted-foreground">(chart default)</td>
                             <td class="p-3 text-muted-foreground">Override the skeleton silhouette (Bars, Line, Area, Pie, Scatter, Grid, Generic).</td>
                         </tr>
+                        <tr>
+                            <td class="p-3 font-mono text-xs text-primary">SkeletonStyle</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">ChartSkeletonStyle</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">Phantom</td>
+                            <td class="p-3 text-muted-foreground">Phantom renders the real chart with placeholder data and morphs to real data via ECharts animation. Silhouette falls back to the legacy SVG skeleton overlay.</td>
+                        </tr>
                     </tbody>
                 </table>
             </Stack>

--- a/docs/Lumeo.Docs/Pages/Components/Charts/RadarChartPage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/Charts/RadarChartPage.razor
@@ -93,6 +93,24 @@
                             <td class="p-3 font-mono text-xs text-muted-foreground">"polygon"</td>
                             <td class="p-3 text-muted-foreground">Radar shape: "polygon" or "circle".</td>
                         </tr>
+                        <tr>
+                            <td class="p-3 font-mono text-xs text-primary">IsLoading</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">bool</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">false</td>
+                            <td class="p-3 text-muted-foreground">When true, renders a shape-matched loading skeleton in place of the chart. Bind to your async fetch state.</td>
+                        </tr>
+                        <tr>
+                            <td class="p-3 font-mono text-xs text-primary">ShowLoadingSkeleton</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">bool</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">true</td>
+                            <td class="p-3 text-muted-foreground">Set to false to opt out of the skeleton (chart area stays empty while IsLoading is true).</td>
+                        </tr>
+                        <tr>
+                            <td class="p-3 font-mono text-xs text-primary">SkeletonKind</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">ChartSkeletonKind</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">(chart default)</td>
+                            <td class="p-3 text-muted-foreground">Override the skeleton silhouette (Bars, Line, Area, Pie, Scatter, Grid, Generic).</td>
+                        </tr>
                     </tbody>
                 </table>
             </Stack>

--- a/docs/Lumeo.Docs/Pages/Components/Charts/RadarChartPage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/Charts/RadarChartPage.razor
@@ -45,8 +45,16 @@
                         <Switch @bind-Value="_keepLoading" Id="keep-loading" />
                         <label for="keep-loading" class="text-sm text-muted-foreground cursor-pointer">Hold skeleton open</label>
                     </Stack>
+                    <Stack Direction="Stack.StackDirection.Horizontal" Gap="2" Align="center">
+                        <label class="text-sm text-muted-foreground">Duration: @(_simulateDurationMs / 1000.0)s</label>
+                        <input type="range" min="500" max="10000" step="500" @bind-value="_simulateDurationMs" @bind-value:event="oninput" class="w-32 accent-primary" />
+                    </Stack>
+                    <Stack Direction="Stack.StackDirection.Horizontal" Gap="2" Align="center">
+                        <label class="text-sm text-muted-foreground">Cycle: @_phantomCycleMs ms</label>
+                        <input type="range" min="300" max="3000" step="100" @bind-value="_phantomCycleMs" @bind-value:event="oninput" class="w-32 accent-primary" />
+                    </Stack>
                 </Stack>
-                <RadarChart Indicators="_indicators" Series="_series" FillArea="true" IsLoading="@LoadingComputed" Height="320px" />
+                <RadarChart Indicators="_indicators" Series="_series" FillArea="true" PhantomCycleMs="@_phantomCycleMs" IsLoading="@LoadingComputed" Height="320px" />
             </Stack>
         </Container>
     </ComponentDemo>
@@ -196,11 +204,13 @@
     private bool _loading;
     private bool _keepLoading;
     private bool LoadingComputed => _loading || _keepLoading;
+    private int _simulateDurationMs = 2000;
+    private int _phantomCycleMs = 1400;
 
     private async Task SimulateLoadingAsync()
     {
         _loading = true;
-        await Task.Delay(2000);
+        await Task.Delay(_simulateDurationMs);
         _loading = false;
     }
 }

--- a/docs/Lumeo.Docs/Pages/Components/Charts/RadarChartPage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/Charts/RadarChartPage.razor
@@ -111,6 +111,12 @@
                             <td class="p-3 font-mono text-xs text-muted-foreground">(chart default)</td>
                             <td class="p-3 text-muted-foreground">Override the skeleton silhouette (Bars, Line, Area, Pie, Scatter, Grid, Generic).</td>
                         </tr>
+                        <tr>
+                            <td class="p-3 font-mono text-xs text-primary">SkeletonStyle</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">ChartSkeletonStyle</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">Phantom</td>
+                            <td class="p-3 text-muted-foreground">Phantom renders the real chart with placeholder data and morphs to real data via ECharts animation. Silhouette falls back to the legacy SVG skeleton overlay.</td>
+                        </tr>
                     </tbody>
                 </table>
             </Stack>

--- a/docs/Lumeo.Docs/Pages/Components/Charts/RadarChartPage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/Charts/RadarChartPage.razor
@@ -36,6 +36,20 @@
             <RadarChart Indicators="_npsIndicators" Series="_npsSeries" FillArea="true" Height="280px" />
         </Container>
     </ComponentDemo>
+    <ComponentDemo Title="Loading state" Description="Shape-aware skeleton with reserved space for legend and axes — no layout shift when real data arrives.">
+        <Container>
+            <Stack Gap="4">
+                <Stack Direction="Stack.StackDirection.Horizontal" Gap="4" Align="center" Wrap="true">
+                    <Button OnClick="SimulateLoadingAsync" Disabled="@_loading">Simulate loading</Button>
+                    <Stack Direction="Stack.StackDirection.Horizontal" Gap="2" Align="center">
+                        <Switch @bind-Value="_keepLoading" Id="keep-loading" />
+                        <label for="keep-loading" class="text-sm text-muted-foreground cursor-pointer">Hold skeleton open</label>
+                    </Stack>
+                </Stack>
+                <RadarChart Indicators="_indicators" Series="_series" FillArea="true" IsLoading="@LoadingComputed" Height="320px" />
+            </Stack>
+        </Container>
+    </ComponentDemo>
 </Stack>
 
 <!-- API Reference -->
@@ -154,4 +168,15 @@
     private string _skillCode   = @"<RadarChart Indicators=""_skillIndicators"" Series=""_skillSeries"" FillArea=""true"" Colors=""_skillColors"" />";
     private string _toolboxCode = @"<RadarChart Indicators=""_productIndicators"" Series=""_productSeries"" FillArea=""true"" ShowDataLabels=""true"" Toolbox=""true"" />";
     private string _npsCode     = @"<RadarChart Indicators=""_npsIndicators"" Series=""_npsSeries"" FillArea=""true"" Height=""280px"" />";
+
+    private bool _loading;
+    private bool _keepLoading;
+    private bool LoadingComputed => _loading || _keepLoading;
+
+    private async Task SimulateLoadingAsync()
+    {
+        _loading = true;
+        await Task.Delay(2000);
+        _loading = false;
+    }
 }

--- a/docs/Lumeo.Docs/Pages/Components/Charts/RadialChartPage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/Charts/RadialChartPage.razor
@@ -103,6 +103,12 @@
                             <td class="p-3 font-mono text-xs text-muted-foreground">(chart default)</td>
                             <td class="p-3 text-muted-foreground">Override the skeleton silhouette (Bars, Line, Area, Pie, Scatter, Grid, Generic).</td>
                         </tr>
+                        <tr>
+                            <td class="p-3 font-mono text-xs text-primary">SkeletonStyle</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">ChartSkeletonStyle</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">Phantom</td>
+                            <td class="p-3 text-muted-foreground">Phantom renders the real chart with placeholder data and morphs to real data via ECharts animation. Silhouette falls back to the legacy SVG skeleton overlay.</td>
+                        </tr>
                     </tbody>
                 </table>
             </Stack>

--- a/docs/Lumeo.Docs/Pages/Components/Charts/RadialChartPage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/Charts/RadialChartPage.razor
@@ -25,8 +25,16 @@
                         <Switch @bind-Value="_keepLoading" Id="keep-loading" />
                         <label for="keep-loading" class="text-sm text-muted-foreground cursor-pointer">Hold skeleton open</label>
                     </Stack>
+                    <Stack Direction="Stack.StackDirection.Horizontal" Gap="2" Align="center">
+                        <label class="text-sm text-muted-foreground">Duration: @(_simulateDurationMs / 1000.0)s</label>
+                        <input type="range" min="500" max="10000" step="500" @bind-value="_simulateDurationMs" @bind-value:event="oninput" class="w-32 accent-primary" />
+                    </Stack>
+                    <Stack Direction="Stack.StackDirection.Horizontal" Gap="2" Align="center">
+                        <label class="text-sm text-muted-foreground">Cycle: @_phantomCycleMs ms</label>
+                        <input type="range" min="300" max="3000" step="100" @bind-value="_phantomCycleMs" @bind-value:event="oninput" class="w-32 accent-primary" />
+                    </Stack>
                 </Stack>
-                <RadialChart Value="72" Label="Performance" Color="#6366f1" ShowProgress="true" IsLoading="@LoadingComputed" Height="320px" />
+                <RadialChart Value="72" Label="Performance" Color="#6366f1" ShowProgress="true" PhantomCycleMs="@_phantomCycleMs" IsLoading="@LoadingComputed" Height="320px" />
             </Stack>
         </Container>
     </ComponentDemo>
@@ -123,11 +131,13 @@
     private bool _loading;
     private bool _keepLoading;
     private bool LoadingComputed => _loading || _keepLoading;
+    private int _simulateDurationMs = 2000;
+    private int _phantomCycleMs = 1400;
 
     private async Task SimulateLoadingAsync()
     {
         _loading = true;
-        await Task.Delay(2000);
+        await Task.Delay(_simulateDurationMs);
         _loading = false;
     }
 }

--- a/docs/Lumeo.Docs/Pages/Components/Charts/RadialChartPage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/Charts/RadialChartPage.razor
@@ -16,6 +16,20 @@
             <RadialChart Value="42" Min="0" Max="50" Label="Score" Color="#10b981" ShowProgress="true" />
         </Container>
     </ComponentDemo>
+    <ComponentDemo Title="Loading state" Description="Shape-aware skeleton with reserved space for legend and axes — no layout shift when real data arrives.">
+        <Container>
+            <Stack Gap="4">
+                <Stack Direction="Stack.StackDirection.Horizontal" Gap="4" Align="center" Wrap="true">
+                    <Button OnClick="SimulateLoadingAsync" Disabled="@_loading">Simulate loading</Button>
+                    <Stack Direction="Stack.StackDirection.Horizontal" Gap="2" Align="center">
+                        <Switch @bind-Value="_keepLoading" Id="keep-loading" />
+                        <label for="keep-loading" class="text-sm text-muted-foreground cursor-pointer">Hold skeleton open</label>
+                    </Stack>
+                </Stack>
+                <RadialChart Value="72" Label="Performance" Color="#6366f1" ShowProgress="true" IsLoading="@LoadingComputed" Height="320px" />
+            </Stack>
+        </Container>
+    </ComponentDemo>
 </Stack>
 
 <!-- API Reference -->
@@ -81,4 +95,15 @@
 @code {
     private string _basicCode = @"<RadialChart Value=""72"" Label=""Performance"" Color=""#6366f1"" ShowProgress=""true"" />";
     private string _rangeCode = @"<RadialChart Value=""42"" Min=""0"" Max=""50"" Label=""Score"" Color=""#10b981"" ShowProgress=""true"" />";
+
+    private bool _loading;
+    private bool _keepLoading;
+    private bool LoadingComputed => _loading || _keepLoading;
+
+    private async Task SimulateLoadingAsync()
+    {
+        _loading = true;
+        await Task.Delay(2000);
+        _loading = false;
+    }
 }

--- a/docs/Lumeo.Docs/Pages/Components/Charts/RadialChartPage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/Charts/RadialChartPage.razor
@@ -85,6 +85,24 @@
                             <td class="p-3 font-mono text-xs text-muted-foreground">true</td>
                             <td class="p-3 text-muted-foreground">Renders the filled progress arc.</td>
                         </tr>
+                        <tr>
+                            <td class="p-3 font-mono text-xs text-primary">IsLoading</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">bool</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">false</td>
+                            <td class="p-3 text-muted-foreground">When true, renders a shape-matched loading skeleton in place of the chart. Bind to your async fetch state.</td>
+                        </tr>
+                        <tr>
+                            <td class="p-3 font-mono text-xs text-primary">ShowLoadingSkeleton</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">bool</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">true</td>
+                            <td class="p-3 text-muted-foreground">Set to false to opt out of the skeleton (chart area stays empty while IsLoading is true).</td>
+                        </tr>
+                        <tr>
+                            <td class="p-3 font-mono text-xs text-primary">SkeletonKind</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">ChartSkeletonKind</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">(chart default)</td>
+                            <td class="p-3 text-muted-foreground">Override the skeleton silhouette (Bars, Line, Area, Pie, Scatter, Grid, Generic).</td>
+                        </tr>
                     </tbody>
                 </table>
             </Stack>

--- a/docs/Lumeo.Docs/Pages/Components/Charts/SankeyChartPage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/Charts/SankeyChartPage.razor
@@ -28,6 +28,20 @@
             <SankeyChart Nodes="_journeyNodes" Links="_journeyLinks" Toolbox="true" />
         </Container>
     </ComponentDemo>
+    <ComponentDemo Title="Loading state" Description="Shape-aware skeleton with reserved space for legend and axes — no layout shift when real data arrives.">
+        <Container>
+            <Stack Gap="4">
+                <Stack Direction="Stack.StackDirection.Horizontal" Gap="4" Align="center" Wrap="true">
+                    <Button OnClick="SimulateLoadingAsync" Disabled="@_loading">Simulate loading</Button>
+                    <Stack Direction="Stack.StackDirection.Horizontal" Gap="2" Align="center">
+                        <Switch @bind-Value="_keepLoading" Id="keep-loading" />
+                        <label for="keep-loading" class="text-sm text-muted-foreground cursor-pointer">Hold skeleton open</label>
+                    </Stack>
+                </Stack>
+                <SankeyChart Nodes="_nodes" Links="_links" IsLoading="@LoadingComputed" Height="320px" />
+            </Stack>
+        </Container>
+    </ComponentDemo>
 </Stack>
 
 <!-- API Reference -->
@@ -154,4 +168,15 @@
     private string _trafficCode = @"<SankeyChart Nodes=""_trafficNodes"" Links=""_trafficLinks"" />";
     private string _budgetCode  = @"<SankeyChart Nodes=""_budgetNodes"" Links=""_budgetLinks"" ShowDataLabels=""true"" />";
     private string _journeyCode = @"<SankeyChart Nodes=""_journeyNodes"" Links=""_journeyLinks"" Toolbox=""true"" />";
+
+    private bool _loading;
+    private bool _keepLoading;
+    private bool LoadingComputed => _loading || _keepLoading;
+
+    private async Task SimulateLoadingAsync()
+    {
+        _loading = true;
+        await Task.Delay(2000);
+        _loading = false;
+    }
 }

--- a/docs/Lumeo.Docs/Pages/Components/Charts/SankeyChartPage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/Charts/SankeyChartPage.razor
@@ -97,6 +97,12 @@
                             <td class="p-3 font-mono text-xs text-muted-foreground">(chart default)</td>
                             <td class="p-3 text-muted-foreground">Override the skeleton silhouette (Bars, Line, Area, Pie, Scatter, Grid, Generic).</td>
                         </tr>
+                        <tr>
+                            <td class="p-3 font-mono text-xs text-primary">SkeletonStyle</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">ChartSkeletonStyle</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">Phantom</td>
+                            <td class="p-3 text-muted-foreground">Phantom renders the real chart with placeholder data and morphs to real data via ECharts animation. Silhouette falls back to the legacy SVG skeleton overlay.</td>
+                        </tr>
                     </tbody>
                 </table>
             </Stack>

--- a/docs/Lumeo.Docs/Pages/Components/Charts/SankeyChartPage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/Charts/SankeyChartPage.razor
@@ -37,8 +37,16 @@
                         <Switch @bind-Value="_keepLoading" Id="keep-loading" />
                         <label for="keep-loading" class="text-sm text-muted-foreground cursor-pointer">Hold skeleton open</label>
                     </Stack>
+                    <Stack Direction="Stack.StackDirection.Horizontal" Gap="2" Align="center">
+                        <label class="text-sm text-muted-foreground">Duration: @(_simulateDurationMs / 1000.0)s</label>
+                        <input type="range" min="500" max="10000" step="500" @bind-value="_simulateDurationMs" @bind-value:event="oninput" class="w-32 accent-primary" />
+                    </Stack>
+                    <Stack Direction="Stack.StackDirection.Horizontal" Gap="2" Align="center">
+                        <label class="text-sm text-muted-foreground">Cycle: @_phantomCycleMs ms</label>
+                        <input type="range" min="300" max="3000" step="100" @bind-value="_phantomCycleMs" @bind-value:event="oninput" class="w-32 accent-primary" />
+                    </Stack>
                 </Stack>
-                <SankeyChart Nodes="_nodes" Links="_links" IsLoading="@LoadingComputed" Height="320px" />
+                <SankeyChart Nodes="_nodes" Links="_links" PhantomCycleMs="@_phantomCycleMs" IsLoading="@LoadingComputed" Height="320px" />
             </Stack>
         </Container>
     </ComponentDemo>
@@ -196,11 +204,13 @@
     private bool _loading;
     private bool _keepLoading;
     private bool LoadingComputed => _loading || _keepLoading;
+    private int _simulateDurationMs = 2000;
+    private int _phantomCycleMs = 1400;
 
     private async Task SimulateLoadingAsync()
     {
         _loading = true;
-        await Task.Delay(2000);
+        await Task.Delay(_simulateDurationMs);
         _loading = false;
     }
 }

--- a/docs/Lumeo.Docs/Pages/Components/Charts/SankeyChartPage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/Charts/SankeyChartPage.razor
@@ -79,6 +79,24 @@
                             <td class="p-3 font-mono text-xs text-muted-foreground">true</td>
                             <td class="p-3 text-muted-foreground">Shows or hides the chart legend.</td>
                         </tr>
+                        <tr>
+                            <td class="p-3 font-mono text-xs text-primary">IsLoading</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">bool</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">false</td>
+                            <td class="p-3 text-muted-foreground">When true, renders a shape-matched loading skeleton in place of the chart. Bind to your async fetch state.</td>
+                        </tr>
+                        <tr>
+                            <td class="p-3 font-mono text-xs text-primary">ShowLoadingSkeleton</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">bool</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">true</td>
+                            <td class="p-3 text-muted-foreground">Set to false to opt out of the skeleton (chart area stays empty while IsLoading is true).</td>
+                        </tr>
+                        <tr>
+                            <td class="p-3 font-mono text-xs text-primary">SkeletonKind</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">ChartSkeletonKind</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">(chart default)</td>
+                            <td class="p-3 text-muted-foreground">Override the skeleton silhouette (Bars, Line, Area, Pie, Scatter, Grid, Generic).</td>
+                        </tr>
                     </tbody>
                 </table>
             </Stack>

--- a/docs/Lumeo.Docs/Pages/Components/Charts/ScatterChartPage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/Charts/ScatterChartPage.razor
@@ -34,6 +34,20 @@
             <ScatterChart Series="_segmentSeries" Colors="_segmentColors" />
         </Container>
     </ComponentDemo>
+    <ComponentDemo Title="Loading state" Description="Shape-aware skeleton with reserved space for legend and axes — no layout shift when real data arrives.">
+        <Container>
+            <Stack Gap="4">
+                <Stack Direction="Stack.StackDirection.Horizontal" Gap="4" Align="center" Wrap="true">
+                    <Button OnClick="SimulateLoadingAsync" Disabled="@_loading">Simulate loading</Button>
+                    <Stack Direction="Stack.StackDirection.Horizontal" Gap="2" Align="center">
+                        <Switch @bind-Value="_keepLoading" Id="keep-loading" />
+                        <label for="keep-loading" class="text-sm text-muted-foreground cursor-pointer">Hold skeleton open</label>
+                    </Stack>
+                </Stack>
+                <ScatterChart Series="_series" IsLoading="@LoadingComputed" Height="320px" />
+            </Stack>
+        </Container>
+    </ComponentDemo>
 </Stack>
 
 <!-- API Reference -->
@@ -171,4 +185,15 @@
     private string _bubbleCode = @"<ScatterChart Series=""_series"" BubbleSize=""14"" />";
     private string _singleCode = @"<ScatterChart Series=""_singleSeries"" ShowLegend=""false"" />";
     private string _customColorsCode = @"<ScatterChart Series=""_segmentSeries"" Colors=""_segmentColors"" />";
+
+    private bool _loading;
+    private bool _keepLoading;
+    private bool LoadingComputed => _loading || _keepLoading;
+
+    private async Task SimulateLoadingAsync()
+    {
+        _loading = true;
+        await Task.Delay(2000);
+        _loading = false;
+    }
 }

--- a/docs/Lumeo.Docs/Pages/Components/Charts/ScatterChartPage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/Charts/ScatterChartPage.razor
@@ -115,6 +115,12 @@
                             <td class="p-3 font-mono text-xs text-muted-foreground">(chart default)</td>
                             <td class="p-3 text-muted-foreground">Override the skeleton silhouette (Bars, Line, Area, Pie, Scatter, Grid, Generic).</td>
                         </tr>
+                        <tr>
+                            <td class="p-3 font-mono text-xs text-primary">SkeletonStyle</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">ChartSkeletonStyle</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">Phantom</td>
+                            <td class="p-3 text-muted-foreground">Phantom renders the real chart with placeholder data and morphs to real data via ECharts animation. Silhouette falls back to the legacy SVG skeleton overlay.</td>
+                        </tr>
                     </tbody>
                 </table>
             </Stack>

--- a/docs/Lumeo.Docs/Pages/Components/Charts/ScatterChartPage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/Charts/ScatterChartPage.razor
@@ -97,6 +97,24 @@
                             <td class="p-3 font-mono text-xs text-muted-foreground">true</td>
                             <td class="p-3 text-muted-foreground">Enables the hover tooltip.</td>
                         </tr>
+                        <tr>
+                            <td class="p-3 font-mono text-xs text-primary">IsLoading</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">bool</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">false</td>
+                            <td class="p-3 text-muted-foreground">When true, renders a shape-matched loading skeleton in place of the chart. Bind to your async fetch state.</td>
+                        </tr>
+                        <tr>
+                            <td class="p-3 font-mono text-xs text-primary">ShowLoadingSkeleton</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">bool</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">true</td>
+                            <td class="p-3 text-muted-foreground">Set to false to opt out of the skeleton (chart area stays empty while IsLoading is true).</td>
+                        </tr>
+                        <tr>
+                            <td class="p-3 font-mono text-xs text-primary">SkeletonKind</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">ChartSkeletonKind</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">(chart default)</td>
+                            <td class="p-3 text-muted-foreground">Override the skeleton silhouette (Bars, Line, Area, Pie, Scatter, Grid, Generic).</td>
+                        </tr>
                     </tbody>
                 </table>
             </Stack>

--- a/docs/Lumeo.Docs/Pages/Components/Charts/ScatterChartPage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/Charts/ScatterChartPage.razor
@@ -43,8 +43,16 @@
                         <Switch @bind-Value="_keepLoading" Id="keep-loading" />
                         <label for="keep-loading" class="text-sm text-muted-foreground cursor-pointer">Hold skeleton open</label>
                     </Stack>
+                    <Stack Direction="Stack.StackDirection.Horizontal" Gap="2" Align="center">
+                        <label class="text-sm text-muted-foreground">Duration: @(_simulateDurationMs / 1000.0)s</label>
+                        <input type="range" min="500" max="10000" step="500" @bind-value="_simulateDurationMs" @bind-value:event="oninput" class="w-32 accent-primary" />
+                    </Stack>
+                    <Stack Direction="Stack.StackDirection.Horizontal" Gap="2" Align="center">
+                        <label class="text-sm text-muted-foreground">Cycle: @_phantomCycleMs ms</label>
+                        <input type="range" min="300" max="3000" step="100" @bind-value="_phantomCycleMs" @bind-value:event="oninput" class="w-32 accent-primary" />
+                    </Stack>
                 </Stack>
-                <ScatterChart Series="_series" IsLoading="@LoadingComputed" Height="320px" />
+                <ScatterChart Series="_series" PhantomCycleMs="@_phantomCycleMs" IsLoading="@LoadingComputed" Height="320px" />
             </Stack>
         </Container>
     </ComponentDemo>
@@ -213,11 +221,13 @@
     private bool _loading;
     private bool _keepLoading;
     private bool LoadingComputed => _loading || _keepLoading;
+    private int _simulateDurationMs = 2000;
+    private int _phantomCycleMs = 1400;
 
     private async Task SimulateLoadingAsync()
     {
         _loading = true;
-        await Task.Delay(2000);
+        await Task.Delay(_simulateDurationMs);
         _loading = false;
     }
 }

--- a/docs/Lumeo.Docs/Pages/Components/Charts/SunburstChartPage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/Charts/SunburstChartPage.razor
@@ -19,8 +19,16 @@
                         <Switch @bind-Value="_keepLoading" Id="keep-loading" />
                         <label for="keep-loading" class="text-sm text-muted-foreground cursor-pointer">Hold skeleton open</label>
                     </Stack>
+                    <Stack Direction="Stack.StackDirection.Horizontal" Gap="2" Align="center">
+                        <label class="text-sm text-muted-foreground">Duration: @(_simulateDurationMs / 1000.0)s</label>
+                        <input type="range" min="500" max="10000" step="500" @bind-value="_simulateDurationMs" @bind-value:event="oninput" class="w-32 accent-primary" />
+                    </Stack>
+                    <Stack Direction="Stack.StackDirection.Horizontal" Gap="2" Align="center">
+                        <label class="text-sm text-muted-foreground">Cycle: @_phantomCycleMs ms</label>
+                        <input type="range" min="300" max="3000" step="100" @bind-value="_phantomCycleMs" @bind-value:event="oninput" class="w-32 accent-primary" />
+                    </Stack>
                 </Stack>
-                <SunburstChart Data="_data" IsLoading="@LoadingComputed" Height="320px" />
+                <SunburstChart Data="_data" PhantomCycleMs="@_phantomCycleMs" IsLoading="@LoadingComputed" Height="320px" />
             </Stack>
         </Container>
     </ComponentDemo>
@@ -118,11 +126,13 @@
     private bool _loading;
     private bool _keepLoading;
     private bool LoadingComputed => _loading || _keepLoading;
+    private int _simulateDurationMs = 2000;
+    private int _phantomCycleMs = 1400;
 
     private async Task SimulateLoadingAsync()
     {
         _loading = true;
-        await Task.Delay(2000);
+        await Task.Delay(_simulateDurationMs);
         _loading = false;
     }
 }

--- a/docs/Lumeo.Docs/Pages/Components/Charts/SunburstChartPage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/Charts/SunburstChartPage.razor
@@ -10,6 +10,20 @@
             <SunburstChart Data="_data" />
         </Container>
     </ComponentDemo>
+    <ComponentDemo Title="Loading state" Description="Shape-aware skeleton with reserved space for legend and axes — no layout shift when real data arrives.">
+        <Container>
+            <Stack Gap="4">
+                <Stack Direction="Stack.StackDirection.Horizontal" Gap="4" Align="center" Wrap="true">
+                    <Button OnClick="SimulateLoadingAsync" Disabled="@_loading">Simulate loading</Button>
+                    <Stack Direction="Stack.StackDirection.Horizontal" Gap="2" Align="center">
+                        <Switch @bind-Value="_keepLoading" Id="keep-loading" />
+                        <label for="keep-loading" class="text-sm text-muted-foreground cursor-pointer">Hold skeleton open</label>
+                    </Stack>
+                </Stack>
+                <SunburstChart Data="_data" IsLoading="@LoadingComputed" Height="320px" />
+            </Stack>
+        </Container>
+    </ComponentDemo>
 </Stack>
 
 <!-- API Reference -->
@@ -76,4 +90,15 @@
     };
 
     private string _basicCode = @"<SunburstChart Data=""_data"" />";
+
+    private bool _loading;
+    private bool _keepLoading;
+    private bool LoadingComputed => _loading || _keepLoading;
+
+    private async Task SimulateLoadingAsync()
+    {
+        _loading = true;
+        await Task.Delay(2000);
+        _loading = false;
+    }
 }

--- a/docs/Lumeo.Docs/Pages/Components/Charts/SunburstChartPage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/Charts/SunburstChartPage.razor
@@ -61,6 +61,24 @@
                             <td class="p-3 font-mono text-xs text-muted-foreground">null</td>
                             <td class="p-3 text-muted-foreground">Custom color palette.</td>
                         </tr>
+                        <tr>
+                            <td class="p-3 font-mono text-xs text-primary">IsLoading</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">bool</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">false</td>
+                            <td class="p-3 text-muted-foreground">When true, renders a shape-matched loading skeleton in place of the chart. Bind to your async fetch state.</td>
+                        </tr>
+                        <tr>
+                            <td class="p-3 font-mono text-xs text-primary">ShowLoadingSkeleton</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">bool</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">true</td>
+                            <td class="p-3 text-muted-foreground">Set to false to opt out of the skeleton (chart area stays empty while IsLoading is true).</td>
+                        </tr>
+                        <tr>
+                            <td class="p-3 font-mono text-xs text-primary">SkeletonKind</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">ChartSkeletonKind</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">(chart default)</td>
+                            <td class="p-3 text-muted-foreground">Override the skeleton silhouette (Bars, Line, Area, Pie, Scatter, Grid, Generic).</td>
+                        </tr>
                     </tbody>
                 </table>
             </Stack>

--- a/docs/Lumeo.Docs/Pages/Components/Charts/SunburstChartPage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/Charts/SunburstChartPage.razor
@@ -79,6 +79,12 @@
                             <td class="p-3 font-mono text-xs text-muted-foreground">(chart default)</td>
                             <td class="p-3 text-muted-foreground">Override the skeleton silhouette (Bars, Line, Area, Pie, Scatter, Grid, Generic).</td>
                         </tr>
+                        <tr>
+                            <td class="p-3 font-mono text-xs text-primary">SkeletonStyle</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">ChartSkeletonStyle</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">Phantom</td>
+                            <td class="p-3 text-muted-foreground">Phantom renders the real chart with placeholder data and morphs to real data via ECharts animation. Silhouette falls back to the legacy SVG skeleton overlay.</td>
+                        </tr>
                     </tbody>
                 </table>
             </Stack>

--- a/docs/Lumeo.Docs/Pages/Components/Charts/ThemeRiverChartPage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/Charts/ThemeRiverChartPage.razor
@@ -55,6 +55,24 @@
                             <td class="p-3 font-mono text-xs text-muted-foreground">true</td>
                             <td class="p-3 text-muted-foreground">Shows or hides the chart legend.</td>
                         </tr>
+                        <tr>
+                            <td class="p-3 font-mono text-xs text-primary">IsLoading</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">bool</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">false</td>
+                            <td class="p-3 text-muted-foreground">When true, renders a shape-matched loading skeleton in place of the chart. Bind to your async fetch state.</td>
+                        </tr>
+                        <tr>
+                            <td class="p-3 font-mono text-xs text-primary">ShowLoadingSkeleton</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">bool</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">true</td>
+                            <td class="p-3 text-muted-foreground">Set to false to opt out of the skeleton (chart area stays empty while IsLoading is true).</td>
+                        </tr>
+                        <tr>
+                            <td class="p-3 font-mono text-xs text-primary">SkeletonKind</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">ChartSkeletonKind</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">(chart default)</td>
+                            <td class="p-3 text-muted-foreground">Override the skeleton silhouette (Bars, Line, Area, Pie, Scatter, Grid, Generic).</td>
+                        </tr>
                     </tbody>
                 </table>
             </Stack>

--- a/docs/Lumeo.Docs/Pages/Components/Charts/ThemeRiverChartPage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/Charts/ThemeRiverChartPage.razor
@@ -19,8 +19,16 @@
                         <Switch @bind-Value="_keepLoading" Id="keep-loading" />
                         <label for="keep-loading" class="text-sm text-muted-foreground cursor-pointer">Hold skeleton open</label>
                     </Stack>
+                    <Stack Direction="Stack.StackDirection.Horizontal" Gap="2" Align="center">
+                        <label class="text-sm text-muted-foreground">Duration: @(_simulateDurationMs / 1000.0)s</label>
+                        <input type="range" min="500" max="10000" step="500" @bind-value="_simulateDurationMs" @bind-value:event="oninput" class="w-32 accent-primary" />
+                    </Stack>
+                    <Stack Direction="Stack.StackDirection.Horizontal" Gap="2" Align="center">
+                        <label class="text-sm text-muted-foreground">Cycle: @_phantomCycleMs ms</label>
+                        <input type="range" min="300" max="3000" step="100" @bind-value="_phantomCycleMs" @bind-value:event="oninput" class="w-32 accent-primary" />
+                    </Stack>
                 </Stack>
-                <ThemeRiverChart Data="_data" ShowLegend="true" IsLoading="@LoadingComputed" Height="320px" />
+                <ThemeRiverChart Data="_data" ShowLegend="true" PhantomCycleMs="@_phantomCycleMs" IsLoading="@LoadingComputed" Height="320px" />
             </Stack>
         </Container>
     </ComponentDemo>
@@ -105,11 +113,13 @@
     private bool _loading;
     private bool _keepLoading;
     private bool LoadingComputed => _loading || _keepLoading;
+    private int _simulateDurationMs = 2000;
+    private int _phantomCycleMs = 1400;
 
     private async Task SimulateLoadingAsync()
     {
         _loading = true;
-        await Task.Delay(2000);
+        await Task.Delay(_simulateDurationMs);
         _loading = false;
     }
 }

--- a/docs/Lumeo.Docs/Pages/Components/Charts/ThemeRiverChartPage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/Charts/ThemeRiverChartPage.razor
@@ -10,6 +10,20 @@
             <ThemeRiverChart Data="_data" ShowLegend="true" />
         </Container>
     </ComponentDemo>
+    <ComponentDemo Title="Loading state" Description="Shape-aware skeleton with reserved space for legend and axes — no layout shift when real data arrives.">
+        <Container>
+            <Stack Gap="4">
+                <Stack Direction="Stack.StackDirection.Horizontal" Gap="4" Align="center" Wrap="true">
+                    <Button OnClick="SimulateLoadingAsync" Disabled="@_loading">Simulate loading</Button>
+                    <Stack Direction="Stack.StackDirection.Horizontal" Gap="2" Align="center">
+                        <Switch @bind-Value="_keepLoading" Id="keep-loading" />
+                        <label for="keep-loading" class="text-sm text-muted-foreground cursor-pointer">Hold skeleton open</label>
+                    </Stack>
+                </Stack>
+                <ThemeRiverChart Data="_data" ShowLegend="true" IsLoading="@LoadingComputed" Height="320px" />
+            </Stack>
+        </Container>
+    </ComponentDemo>
 </Stack>
 
 <!-- API Reference -->
@@ -63,4 +77,15 @@
     };
 
     private string _basicCode = @"<ThemeRiverChart Data=""_data"" ShowLegend=""true"" />";
+
+    private bool _loading;
+    private bool _keepLoading;
+    private bool LoadingComputed => _loading || _keepLoading;
+
+    private async Task SimulateLoadingAsync()
+    {
+        _loading = true;
+        await Task.Delay(2000);
+        _loading = false;
+    }
 }

--- a/docs/Lumeo.Docs/Pages/Components/Charts/ThemeRiverChartPage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/Charts/ThemeRiverChartPage.razor
@@ -73,6 +73,12 @@
                             <td class="p-3 font-mono text-xs text-muted-foreground">(chart default)</td>
                             <td class="p-3 text-muted-foreground">Override the skeleton silhouette (Bars, Line, Area, Pie, Scatter, Grid, Generic).</td>
                         </tr>
+                        <tr>
+                            <td class="p-3 font-mono text-xs text-primary">SkeletonStyle</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">ChartSkeletonStyle</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">Phantom</td>
+                            <td class="p-3 text-muted-foreground">Phantom renders the real chart with placeholder data and morphs to real data via ECharts animation. Silhouette falls back to the legacy SVG skeleton overlay.</td>
+                        </tr>
                     </tbody>
                 </table>
             </Stack>

--- a/docs/Lumeo.Docs/Pages/Components/Charts/TreeChartPage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/Charts/TreeChartPage.razor
@@ -10,6 +10,20 @@
             <TreeChart Data="_data" Orient="LR" ShowLabels="true" />
         </Container>
     </ComponentDemo>
+    <ComponentDemo Title="Loading state" Description="Shape-aware skeleton with reserved space for legend and axes — no layout shift when real data arrives.">
+        <Container>
+            <Stack Gap="4">
+                <Stack Direction="Stack.StackDirection.Horizontal" Gap="4" Align="center" Wrap="true">
+                    <Button OnClick="SimulateLoadingAsync" Disabled="@_loading">Simulate loading</Button>
+                    <Stack Direction="Stack.StackDirection.Horizontal" Gap="2" Align="center">
+                        <Switch @bind-Value="_keepLoading" Id="keep-loading" />
+                        <label for="keep-loading" class="text-sm text-muted-foreground cursor-pointer">Hold skeleton open</label>
+                    </Stack>
+                </Stack>
+                <TreeChart Data="_data" Orient="LR" ShowLabels="true" IsLoading="@LoadingComputed" Height="320px" />
+            </Stack>
+        </Container>
+    </ComponentDemo>
 </Stack>
 
 <!-- API Reference -->
@@ -79,4 +93,15 @@
     };
 
     private string _basicCode = @"<TreeChart Data=""_root"" Orient=""LR"" ShowLabels=""true"" />";
+
+    private bool _loading;
+    private bool _keepLoading;
+    private bool LoadingComputed => _loading || _keepLoading;
+
+    private async Task SimulateLoadingAsync()
+    {
+        _loading = true;
+        await Task.Delay(2000);
+        _loading = false;
+    }
 }

--- a/docs/Lumeo.Docs/Pages/Components/Charts/TreeChartPage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/Charts/TreeChartPage.razor
@@ -19,8 +19,16 @@
                         <Switch @bind-Value="_keepLoading" Id="keep-loading" />
                         <label for="keep-loading" class="text-sm text-muted-foreground cursor-pointer">Hold skeleton open</label>
                     </Stack>
+                    <Stack Direction="Stack.StackDirection.Horizontal" Gap="2" Align="center">
+                        <label class="text-sm text-muted-foreground">Duration: @(_simulateDurationMs / 1000.0)s</label>
+                        <input type="range" min="500" max="10000" step="500" @bind-value="_simulateDurationMs" @bind-value:event="oninput" class="w-32 accent-primary" />
+                    </Stack>
+                    <Stack Direction="Stack.StackDirection.Horizontal" Gap="2" Align="center">
+                        <label class="text-sm text-muted-foreground">Cycle: @_phantomCycleMs ms</label>
+                        <input type="range" min="300" max="3000" step="100" @bind-value="_phantomCycleMs" @bind-value:event="oninput" class="w-32 accent-primary" />
+                    </Stack>
                 </Stack>
-                <TreeChart Data="_data" Orient="LR" ShowLabels="true" IsLoading="@LoadingComputed" Height="320px" />
+                <TreeChart Data="_data" Orient="LR" ShowLabels="true" PhantomCycleMs="@_phantomCycleMs" IsLoading="@LoadingComputed" Height="320px" />
             </Stack>
         </Container>
     </ComponentDemo>
@@ -121,11 +129,13 @@
     private bool _loading;
     private bool _keepLoading;
     private bool LoadingComputed => _loading || _keepLoading;
+    private int _simulateDurationMs = 2000;
+    private int _phantomCycleMs = 1400;
 
     private async Task SimulateLoadingAsync()
     {
         _loading = true;
-        await Task.Delay(2000);
+        await Task.Delay(_simulateDurationMs);
         _loading = false;
     }
 }

--- a/docs/Lumeo.Docs/Pages/Components/Charts/TreeChartPage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/Charts/TreeChartPage.razor
@@ -61,6 +61,24 @@
                             <td class="p-3 font-mono text-xs text-muted-foreground">true</td>
                             <td class="p-3 text-muted-foreground">Shows node name labels.</td>
                         </tr>
+                        <tr>
+                            <td class="p-3 font-mono text-xs text-primary">IsLoading</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">bool</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">false</td>
+                            <td class="p-3 text-muted-foreground">When true, renders a shape-matched loading skeleton in place of the chart. Bind to your async fetch state.</td>
+                        </tr>
+                        <tr>
+                            <td class="p-3 font-mono text-xs text-primary">ShowLoadingSkeleton</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">bool</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">true</td>
+                            <td class="p-3 text-muted-foreground">Set to false to opt out of the skeleton (chart area stays empty while IsLoading is true).</td>
+                        </tr>
+                        <tr>
+                            <td class="p-3 font-mono text-xs text-primary">SkeletonKind</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">ChartSkeletonKind</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">(chart default)</td>
+                            <td class="p-3 text-muted-foreground">Override the skeleton silhouette (Bars, Line, Area, Pie, Scatter, Grid, Generic).</td>
+                        </tr>
                     </tbody>
                 </table>
             </Stack>

--- a/docs/Lumeo.Docs/Pages/Components/Charts/TreeChartPage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/Charts/TreeChartPage.razor
@@ -79,6 +79,12 @@
                             <td class="p-3 font-mono text-xs text-muted-foreground">(chart default)</td>
                             <td class="p-3 text-muted-foreground">Override the skeleton silhouette (Bars, Line, Area, Pie, Scatter, Grid, Generic).</td>
                         </tr>
+                        <tr>
+                            <td class="p-3 font-mono text-xs text-primary">SkeletonStyle</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">ChartSkeletonStyle</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">Phantom</td>
+                            <td class="p-3 text-muted-foreground">Phantom renders the real chart with placeholder data and morphs to real data via ECharts animation. Silhouette falls back to the legacy SVG skeleton overlay.</td>
+                        </tr>
                     </tbody>
                 </table>
             </Stack>

--- a/docs/Lumeo.Docs/Pages/Components/Charts/TreemapChartPage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/Charts/TreemapChartPage.razor
@@ -28,6 +28,20 @@
             <TreemapChart Data="_headcountData" Toolbox="true" Colors="_violetPalette" />
         </Container>
     </ComponentDemo>
+    <ComponentDemo Title="Loading state" Description="Shape-aware skeleton with reserved space for legend and axes — no layout shift when real data arrives.">
+        <Container>
+            <Stack Gap="4">
+                <Stack Direction="Stack.StackDirection.Horizontal" Gap="4" Align="center" Wrap="true">
+                    <Button OnClick="SimulateLoadingAsync" Disabled="@_loading">Simulate loading</Button>
+                    <Stack Direction="Stack.StackDirection.Horizontal" Gap="2" Align="center">
+                        <Switch @bind-Value="_keepLoading" Id="keep-loading" />
+                        <label for="keep-loading" class="text-sm text-muted-foreground cursor-pointer">Hold skeleton open</label>
+                    </Stack>
+                </Stack>
+                <TreemapChart Data="_data" IsLoading="@LoadingComputed" Height="320px" />
+            </Stack>
+        </Container>
+    </ComponentDemo>
 </Stack>
 
 <!-- API Reference -->
@@ -145,4 +159,15 @@
     private string _diskCode      = @"<TreemapChart Data=""_diskData"" ShowLegend=""false"" />";
     private string _revenueCode   = @"<TreemapChart Data=""_revenueData"" ShowDataLabels=""true"" Toolbox=""true"" />";
     private string _headcountCode = @"<TreemapChart Data=""_headcountData"" Toolbox=""true"" Colors=""_violetPalette"" />";
+
+    private bool _loading;
+    private bool _keepLoading;
+    private bool LoadingComputed => _loading || _keepLoading;
+
+    private async Task SimulateLoadingAsync()
+    {
+        _loading = true;
+        await Task.Delay(2000);
+        _loading = false;
+    }
 }

--- a/docs/Lumeo.Docs/Pages/Components/Charts/TreemapChartPage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/Charts/TreemapChartPage.razor
@@ -97,6 +97,12 @@
                             <td class="p-3 font-mono text-xs text-muted-foreground">(chart default)</td>
                             <td class="p-3 text-muted-foreground">Override the skeleton silhouette (Bars, Line, Area, Pie, Scatter, Grid, Generic).</td>
                         </tr>
+                        <tr>
+                            <td class="p-3 font-mono text-xs text-primary">SkeletonStyle</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">ChartSkeletonStyle</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">Phantom</td>
+                            <td class="p-3 text-muted-foreground">Phantom renders the real chart with placeholder data and morphs to real data via ECharts animation. Silhouette falls back to the legacy SVG skeleton overlay.</td>
+                        </tr>
                     </tbody>
                 </table>
             </Stack>

--- a/docs/Lumeo.Docs/Pages/Components/Charts/TreemapChartPage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/Charts/TreemapChartPage.razor
@@ -79,6 +79,24 @@
                             <td class="p-3 font-mono text-xs text-muted-foreground">null</td>
                             <td class="p-3 text-muted-foreground">Custom color palette.</td>
                         </tr>
+                        <tr>
+                            <td class="p-3 font-mono text-xs text-primary">IsLoading</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">bool</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">false</td>
+                            <td class="p-3 text-muted-foreground">When true, renders a shape-matched loading skeleton in place of the chart. Bind to your async fetch state.</td>
+                        </tr>
+                        <tr>
+                            <td class="p-3 font-mono text-xs text-primary">ShowLoadingSkeleton</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">bool</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">true</td>
+                            <td class="p-3 text-muted-foreground">Set to false to opt out of the skeleton (chart area stays empty while IsLoading is true).</td>
+                        </tr>
+                        <tr>
+                            <td class="p-3 font-mono text-xs text-primary">SkeletonKind</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">ChartSkeletonKind</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">(chart default)</td>
+                            <td class="p-3 text-muted-foreground">Override the skeleton silhouette (Bars, Line, Area, Pie, Scatter, Grid, Generic).</td>
+                        </tr>
                     </tbody>
                 </table>
             </Stack>

--- a/docs/Lumeo.Docs/Pages/Components/Charts/TreemapChartPage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/Charts/TreemapChartPage.razor
@@ -37,8 +37,16 @@
                         <Switch @bind-Value="_keepLoading" Id="keep-loading" />
                         <label for="keep-loading" class="text-sm text-muted-foreground cursor-pointer">Hold skeleton open</label>
                     </Stack>
+                    <Stack Direction="Stack.StackDirection.Horizontal" Gap="2" Align="center">
+                        <label class="text-sm text-muted-foreground">Duration: @(_simulateDurationMs / 1000.0)s</label>
+                        <input type="range" min="500" max="10000" step="500" @bind-value="_simulateDurationMs" @bind-value:event="oninput" class="w-32 accent-primary" />
+                    </Stack>
+                    <Stack Direction="Stack.StackDirection.Horizontal" Gap="2" Align="center">
+                        <label class="text-sm text-muted-foreground">Cycle: @_phantomCycleMs ms</label>
+                        <input type="range" min="300" max="3000" step="100" @bind-value="_phantomCycleMs" @bind-value:event="oninput" class="w-32 accent-primary" />
+                    </Stack>
                 </Stack>
-                <TreemapChart Data="_data" IsLoading="@LoadingComputed" Height="320px" />
+                <TreemapChart Data="_data" PhantomCycleMs="@_phantomCycleMs" IsLoading="@LoadingComputed" Height="320px" />
             </Stack>
         </Container>
     </ComponentDemo>
@@ -187,11 +195,13 @@
     private bool _loading;
     private bool _keepLoading;
     private bool LoadingComputed => _loading || _keepLoading;
+    private int _simulateDurationMs = 2000;
+    private int _phantomCycleMs = 1400;
 
     private async Task SimulateLoadingAsync()
     {
         _loading = true;
-        await Task.Delay(2000);
+        await Task.Delay(_simulateDurationMs);
         _loading = false;
     }
 }

--- a/docs/Lumeo.Docs/Pages/Components/Charts/WaterfallChartPage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/Charts/WaterfallChartPage.razor
@@ -116,6 +116,12 @@
                             <td class="p-3 font-mono text-xs text-muted-foreground">(chart default)</td>
                             <td class="p-3 text-muted-foreground">Override the skeleton silhouette (Bars, Line, Area, Pie, Scatter, Grid, Generic).</td>
                         </tr>
+                        <tr>
+                            <td class="p-3 font-mono text-xs text-primary">SkeletonStyle</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">ChartSkeletonStyle</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">Phantom</td>
+                            <td class="p-3 text-muted-foreground">Phantom renders the real chart with placeholder data and morphs to real data via ECharts animation. Silhouette falls back to the legacy SVG skeleton overlay.</td>
+                        </tr>
                     </tbody>
                 </table>
             </Stack>

--- a/docs/Lumeo.Docs/Pages/Components/Charts/WaterfallChartPage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/Charts/WaterfallChartPage.razor
@@ -98,6 +98,24 @@
                             <td class="p-3 font-mono text-xs text-muted-foreground">null</td>
                             <td class="p-3 text-muted-foreground">Manual rotation override in degrees on top of LabelStrategy.</td>
                         </tr>
+                        <tr>
+                            <td class="p-3 font-mono text-xs text-primary">IsLoading</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">bool</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">false</td>
+                            <td class="p-3 text-muted-foreground">When true, renders a shape-matched loading skeleton in place of the chart. Bind to your async fetch state.</td>
+                        </tr>
+                        <tr>
+                            <td class="p-3 font-mono text-xs text-primary">ShowLoadingSkeleton</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">bool</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">true</td>
+                            <td class="p-3 text-muted-foreground">Set to false to opt out of the skeleton (chart area stays empty while IsLoading is true).</td>
+                        </tr>
+                        <tr>
+                            <td class="p-3 font-mono text-xs text-primary">SkeletonKind</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">ChartSkeletonKind</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">(chart default)</td>
+                            <td class="p-3 text-muted-foreground">Override the skeleton silhouette (Bars, Line, Area, Pie, Scatter, Grid, Generic).</td>
+                        </tr>
                     </tbody>
                 </table>
             </Stack>

--- a/docs/Lumeo.Docs/Pages/Components/Charts/WaterfallChartPage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/Charts/WaterfallChartPage.razor
@@ -38,8 +38,16 @@
                         <Switch @bind-Value="_keepLoading" Id="keep-loading" />
                         <label for="keep-loading" class="text-sm text-muted-foreground cursor-pointer">Hold skeleton open</label>
                     </Stack>
+                    <Stack Direction="Stack.StackDirection.Horizontal" Gap="2" Align="center">
+                        <label class="text-sm text-muted-foreground">Duration: @(_simulateDurationMs / 1000.0)s</label>
+                        <input type="range" min="500" max="10000" step="500" @bind-value="_simulateDurationMs" @bind-value:event="oninput" class="w-32 accent-primary" />
+                    </Stack>
+                    <Stack Direction="Stack.StackDirection.Horizontal" Gap="2" Align="center">
+                        <label class="text-sm text-muted-foreground">Cycle: @_phantomCycleMs ms</label>
+                        <input type="range" min="300" max="3000" step="100" @bind-value="_phantomCycleMs" @bind-value:event="oninput" class="w-32 accent-primary" />
+                    </Stack>
                 </Stack>
-                <WaterfallChart Categories="_categories" Values="_values" IsLoading="@LoadingComputed" Height="320px" />
+                <WaterfallChart Categories="_categories" Values="_values" PhantomCycleMs="@_phantomCycleMs" IsLoading="@LoadingComputed" Height="320px" />
             </Stack>
         </Container>
     </ComponentDemo>
@@ -162,11 +170,13 @@
     private bool _loading;
     private bool _keepLoading;
     private bool LoadingComputed => _loading || _keepLoading;
+    private int _simulateDurationMs = 2000;
+    private int _phantomCycleMs = 1400;
 
     private async Task SimulateLoadingAsync()
     {
         _loading = true;
-        await Task.Delay(2000);
+        await Task.Delay(_simulateDurationMs);
         _loading = false;
     }
 }

--- a/docs/Lumeo.Docs/Pages/Components/Charts/WaterfallChartPage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/Charts/WaterfallChartPage.razor
@@ -29,6 +29,20 @@
             <WaterfallChart Categories="_plCategories" Values="_plValues" DataZoom="true" />
         </Container>
     </ComponentDemo>
+    <ComponentDemo Title="Loading state" Description="Shape-aware skeleton with reserved space for legend and axes — no layout shift when real data arrives.">
+        <Container>
+            <Stack Gap="4">
+                <Stack Direction="Stack.StackDirection.Horizontal" Gap="4" Align="center" Wrap="true">
+                    <Button OnClick="SimulateLoadingAsync" Disabled="@_loading">Simulate loading</Button>
+                    <Stack Direction="Stack.StackDirection.Horizontal" Gap="2" Align="center">
+                        <Switch @bind-Value="_keepLoading" Id="keep-loading" />
+                        <label for="keep-loading" class="text-sm text-muted-foreground cursor-pointer">Hold skeleton open</label>
+                    </Stack>
+                </Stack>
+                <WaterfallChart Categories="_categories" Values="_values" IsLoading="@LoadingComputed" Height="320px" />
+            </Stack>
+        </Container>
+    </ComponentDemo>
 </Stack>
 
 <!-- API Reference -->
@@ -120,4 +134,15 @@
     private string _bridgeCode   = @"<WaterfallChart Categories=""_bridgeCategories"" Values=""_bridgeValues"" ShowDataLabels=""true"" />";
     private string _varianceCode = @"<WaterfallChart Categories=""_varianceCategories"" Values=""_varianceValues"" IncreaseColor=""#10b981"" DecreaseColor=""#f97316"" Toolbox=""true"" />";
     private string _plCode       = @"<WaterfallChart Categories=""_plCategories"" Values=""_plValues"" DataZoom=""true"" />";
+
+    private bool _loading;
+    private bool _keepLoading;
+    private bool LoadingComputed => _loading || _keepLoading;
+
+    private async Task SimulateLoadingAsync()
+    {
+        _loading = true;
+        await Task.Delay(2000);
+        _loading = false;
+    }
 }

--- a/docs/Lumeo.Docs/Pages/Components/Charts/WordCloudChartPage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/Charts/WordCloudChartPage.razor
@@ -19,8 +19,16 @@
                         <Switch @bind-Value="_keepLoading" Id="keep-loading" />
                         <label for="keep-loading" class="text-sm text-muted-foreground cursor-pointer">Hold skeleton open</label>
                     </Stack>
+                    <Stack Direction="Stack.StackDirection.Horizontal" Gap="2" Align="center">
+                        <label class="text-sm text-muted-foreground">Duration: @(_simulateDurationMs / 1000.0)s</label>
+                        <input type="range" min="500" max="10000" step="500" @bind-value="_simulateDurationMs" @bind-value:event="oninput" class="w-32 accent-primary" />
+                    </Stack>
+                    <Stack Direction="Stack.StackDirection.Horizontal" Gap="2" Align="center">
+                        <label class="text-sm text-muted-foreground">Cycle: @_phantomCycleMs ms</label>
+                        <input type="range" min="300" max="3000" step="100" @bind-value="_phantomCycleMs" @bind-value:event="oninput" class="w-32 accent-primary" />
+                    </Stack>
                 </Stack>
-                <WordCloudChart Words="_words" Shape="circle" IsLoading="@LoadingComputed" Height="320px" />
+                <WordCloudChart Words="_words" Shape="circle" PhantomCycleMs="@_phantomCycleMs" IsLoading="@LoadingComputed" Height="320px" />
             </Stack>
         </Container>
     </ComponentDemo>
@@ -123,11 +131,13 @@
     private bool _loading;
     private bool _keepLoading;
     private bool LoadingComputed => _loading || _keepLoading;
+    private int _simulateDurationMs = 2000;
+    private int _phantomCycleMs = 1400;
 
     private async Task SimulateLoadingAsync()
     {
         _loading = true;
-        await Task.Delay(2000);
+        await Task.Delay(_simulateDurationMs);
         _loading = false;
     }
 }

--- a/docs/Lumeo.Docs/Pages/Components/Charts/WordCloudChartPage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/Charts/WordCloudChartPage.razor
@@ -10,6 +10,20 @@
             <WordCloudChart Words="_words" Shape="circle" />
         </Container>
     </ComponentDemo>
+    <ComponentDemo Title="Loading state" Description="Shape-aware skeleton with reserved space for legend and axes — no layout shift when real data arrives.">
+        <Container>
+            <Stack Gap="4">
+                <Stack Direction="Stack.StackDirection.Horizontal" Gap="4" Align="center" Wrap="true">
+                    <Button OnClick="SimulateLoadingAsync" Disabled="@_loading">Simulate loading</Button>
+                    <Stack Direction="Stack.StackDirection.Horizontal" Gap="2" Align="center">
+                        <Switch @bind-Value="_keepLoading" Id="keep-loading" />
+                        <label for="keep-loading" class="text-sm text-muted-foreground cursor-pointer">Hold skeleton open</label>
+                    </Stack>
+                </Stack>
+                <WordCloudChart Words="_words" Shape="circle" IsLoading="@LoadingComputed" Height="320px" />
+            </Stack>
+        </Container>
+    </ComponentDemo>
 </Stack>
 
 <!-- API Reference -->
@@ -81,4 +95,15 @@
     };
 
     private string _basicCode = @"<WordCloudChart Words=""_words"" Shape=""circle"" />";
+
+    private bool _loading;
+    private bool _keepLoading;
+    private bool LoadingComputed => _loading || _keepLoading;
+
+    private async Task SimulateLoadingAsync()
+    {
+        _loading = true;
+        await Task.Delay(2000);
+        _loading = false;
+    }
 }

--- a/docs/Lumeo.Docs/Pages/Components/Charts/WordCloudChartPage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/Charts/WordCloudChartPage.razor
@@ -85,6 +85,12 @@
                             <td class="p-3 font-mono text-xs text-muted-foreground">(chart default)</td>
                             <td class="p-3 text-muted-foreground">Override the skeleton silhouette (Bars, Line, Area, Pie, Scatter, Grid, Generic).</td>
                         </tr>
+                        <tr>
+                            <td class="p-3 font-mono text-xs text-primary">SkeletonStyle</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">ChartSkeletonStyle</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">Phantom</td>
+                            <td class="p-3 text-muted-foreground">Phantom renders the real chart with placeholder data and morphs to real data via ECharts animation. Silhouette falls back to the legacy SVG skeleton overlay.</td>
+                        </tr>
                     </tbody>
                 </table>
             </Stack>

--- a/docs/Lumeo.Docs/Pages/Components/Charts/WordCloudChartPage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/Charts/WordCloudChartPage.razor
@@ -67,6 +67,24 @@
                             <td class="p-3 font-mono text-xs text-muted-foreground">[-90, 90]</td>
                             <td class="p-3 text-muted-foreground">Range of rotation angles for words.</td>
                         </tr>
+                        <tr>
+                            <td class="p-3 font-mono text-xs text-primary">IsLoading</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">bool</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">false</td>
+                            <td class="p-3 text-muted-foreground">When true, renders a shape-matched loading skeleton in place of the chart. Bind to your async fetch state.</td>
+                        </tr>
+                        <tr>
+                            <td class="p-3 font-mono text-xs text-primary">ShowLoadingSkeleton</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">bool</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">true</td>
+                            <td class="p-3 text-muted-foreground">Set to false to opt out of the skeleton (chart area stays empty while IsLoading is true).</td>
+                        </tr>
+                        <tr>
+                            <td class="p-3 font-mono text-xs text-primary">SkeletonKind</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">ChartSkeletonKind</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">(chart default)</td>
+                            <td class="p-3 text-muted-foreground">Override the skeleton silhouette (Bars, Line, Area, Pie, Scatter, Grid, Generic).</td>
+                        </tr>
                     </tbody>
                 </table>
             </Stack>

--- a/docs/Lumeo.Docs/Pages/Components/DataGridPage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/DataGridPage.razor
@@ -487,11 +487,8 @@
         </DataGrid>
     </ComponentDemo>
 
-    <ComponentDemo Title="Composing Toolbar Tools" Description="Mix your own buttons with built-in toolbar tools. Each tool (Export, Fullscreen, Columns, CopySelected, Layouts) is a separate component that picks up the grid's state via a cascading context — no props needed." Code="@_toolbarComposedCode">
-        <DataGrid TItem="Employee" Items="@_employees" PageSize="5" ShowPagination="true" ShowToolbar="true"
-                  Expandable="true"
-                  ShowColumnChooser="false"
-                  ShowExport="false">
+    <ComponentDemo Title="Composing Toolbar Tools" Description="Mix your own buttons with built-in tools. When you provide ToolbarContent, the default tool stack is suppressed — you pick exactly which tools to include and in what order. Each tool picks up the grid's state via a cascading context — no props needed." Code="@_toolbarComposedCode">
+        <DataGrid TItem="Employee" Items="@_employees" PageSize="5" ShowPagination="true" ShowToolbar="true">
             <ChildContent>
                 <ToolbarContent TItem="Employee" Class="gap-2 flex-wrap">
                     <Button Variant="Button.ButtonVariant.Outline" Size="Button.ButtonSize.Sm" Class="gap-1.5">
@@ -758,7 +755,7 @@
                     </tbody>
                 </table>
             </Stack>
-            <Lumeo.Text Size="xs" Color="muted" Class="mt-2">When you omit <code>&lt;ToolbarContent&gt;</code>, all five tools auto-render in the default order (Fullscreen, CopySelected, Columns, Export, Layouts) gated by their <code>Show*</code> flags on the DataGrid.</Lumeo.Text>
+            <Lumeo.Text Size="xs" Color="muted" Class="mt-2">Omit <code>&lt;ToolbarContent&gt;</code> and all five tools auto-render in the default order (Fullscreen, CopySelected, Columns, Export, Layouts) gated by their <code>Show*</code> flags on the DataGrid. Provide <code>&lt;ToolbarContent&gt;</code> and the default stack is suppressed entirely — you pick which tools to include and where, no duplicates.</Lumeo.Text>
         </Stack>
 
         <Stack>
@@ -1372,11 +1369,11 @@
 </DataGrid>";
 
     private string _toolbarComposedCode = @"<DataGrid TItem=""Employee"" Items=""@employees"" PageSize=""5""
-          ShowToolbar=""true""
-          Expandable=""true""
-          ShowColumnChooser=""false""
-          ShowExport=""false"">
+          ShowToolbar=""true"">
     <ChildContent>
+        @* Placing ToolbarContent suppresses the default right-hand tool stack — you
+           pick exactly which tools to include and where. No need for Expandable /
+           ShowExport / ShowColumnChooser flags; tools render wherever you place them. *@
         <ToolbarContent TItem=""Employee"" Class=""gap-2 flex-wrap"">
             <Button Variant=""Button.ButtonVariant.Outline"" Size=""Button.ButtonSize.Sm""
                     Class=""gap-1.5"">

--- a/docs/Lumeo.Docs/Pages/Components/DataGridPage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/DataGridPage.razor
@@ -470,14 +470,37 @@
 &lt;/DataGrid&gt;</code></pre>
     </div>
 
-    <ComponentDemo Title="Custom Toolbar Content" Description="Add custom buttons and controls to the toolbar using the ToolbarContent slot." Code="@_toolbarContentCode">
+    <ComponentDemo Title="Custom Toolbar Content" Description="The ToolbarContent component slots your custom buttons next to the toolbar's filter chips. Use the Class attribute to tweak the wrapper (gap, flex-wrap, etc.)." Code="@_toolbarContentCode">
         <DataGrid TItem="Employee" Items="@_employees" PageSize="5" ShowPagination="true" ShowToolbar="true">
             <ChildContent>
-                <ToolbarContent TItem="Employee">
+                <ToolbarContent TItem="Employee" Class="gap-3">
                     <Button Variant="Button.ButtonVariant.Outline" Size="Button.ButtonSize.Sm" Class="gap-1.5">
                         <DynamicIcon Name="Plus" Class="h-3.5 w-3.5" />
                         Add Employee
                     </Button>
+                </ToolbarContent>
+                <DataGridColumnDef TItem="Employee" Title="Name" Field="Name" Sortable="true" Filterable="true" />
+                <DataGridColumnDef TItem="Employee" Title="Department" Field="Department" Sortable="true" />
+                <DataGridColumnDef TItem="Employee" Title="Salary" Field="Salary" Format="C0" Sortable="true" />
+                <DataGridColumnDef TItem="Employee" Title="Status" Field="Status" />
+            </ChildContent>
+        </DataGrid>
+    </ComponentDemo>
+
+    <ComponentDemo Title="Composing Toolbar Tools" Description="Mix your own buttons with built-in toolbar tools. Each tool (Export, Fullscreen, Columns, CopySelected, Layouts) is a separate component that picks up the grid's state via a cascading context — no props needed." Code="@_toolbarComposedCode">
+        <DataGrid TItem="Employee" Items="@_employees" PageSize="5" ShowPagination="true" ShowToolbar="true"
+                  Expandable="true"
+                  ShowColumnChooser="false"
+                  ShowExport="false">
+            <ChildContent>
+                <ToolbarContent TItem="Employee" Class="gap-2 flex-wrap">
+                    <Button Variant="Button.ButtonVariant.Outline" Size="Button.ButtonSize.Sm" Class="gap-1.5">
+                        <DynamicIcon Name="RefreshCw" Class="h-3.5 w-3.5" />
+                        Refresh
+                    </Button>
+                    <DataGridToolbarColumns TItem="Employee" />
+                    <DataGridToolbarExport TItem="Employee" />
+                    <DataGridToolbarFullscreen TItem="Employee" />
                 </ToolbarContent>
                 <DataGridColumnDef TItem="Employee" Title="Name" Field="Name" Sortable="true" Filterable="true" />
                 <DataGridColumnDef TItem="Employee" Title="Department" Field="Department" Sortable="true" />
@@ -667,7 +690,7 @@
                         <tr><td class="px-4 py-2 font-mono text-xs text-primary">OnDeleteNamedLayout</td><td class="px-4 py-2 font-mono text-xs">EventCallback&lt;string&gt;</td><td class="px-4 py-2 text-xs">--</td><td class="px-4 py-2 text-muted-foreground">Fires when the user deletes a named layout. Receives the layout Id.</td></tr>
                         <tr><td class="px-4 py-2 font-mono text-xs text-primary">DetailTemplate</td><td class="px-4 py-2 font-mono text-xs">RenderFragment&lt;TItem&gt;?</td><td class="px-4 py-2 text-xs">--</td><td class="px-4 py-2 text-muted-foreground">Template for expandable row details.</td></tr>
                         <tr><td class="px-4 py-2 font-mono text-xs text-primary">EmptyContent</td><td class="px-4 py-2 font-mono text-xs">RenderFragment?</td><td class="px-4 py-2 text-xs">--</td><td class="px-4 py-2 text-muted-foreground">Custom content when no data.</td></tr>
-                        <tr><td class="px-4 py-2 font-mono text-xs text-primary">ToolbarContent</td><td class="px-4 py-2 font-mono text-xs">RenderFragment?</td><td class="px-4 py-2 text-xs">--</td><td class="px-4 py-2 text-muted-foreground">Custom toolbar content slot (rendered alongside built-in toolbar items).</td></tr>
+                        <tr><td class="px-4 py-2 font-mono text-xs text-primary">&lt;ToolbarContent&gt;</td><td class="px-4 py-2 font-mono text-xs">component</td><td class="px-4 py-2 text-xs">--</td><td class="px-4 py-2 text-muted-foreground">Nested component placed inside ChildContent. Takes Class for wrapper styling and ChildContent for custom buttons / built-in toolbar tools.</td></tr>
                         <tr><td class="px-4 py-2 font-mono text-xs text-primary">RowContextMenu</td><td class="px-4 py-2 font-mono text-xs">RenderFragment&lt;TItem&gt;?</td><td class="px-4 py-2 text-xs">--</td><td class="px-4 py-2 text-muted-foreground">Right-click context menu template for rows.</td></tr>
                         <tr><td class="px-4 py-2 font-mono text-xs text-primary">OnRowClick</td><td class="px-4 py-2 font-mono text-xs">EventCallback&lt;TItem&gt;</td><td class="px-4 py-2 text-xs">--</td><td class="px-4 py-2 text-muted-foreground">Callback when a row is clicked.</td></tr>
                         <tr><td class="px-4 py-2 font-mono text-xs text-primary">OnRowDoubleClick</td><td class="px-4 py-2 font-mono text-xs">EventCallback&lt;TItem&gt;</td><td class="px-4 py-2 text-xs">--</td><td class="px-4 py-2 text-muted-foreground">Callback when a row is double-clicked.</td></tr>
@@ -691,6 +714,51 @@
                     </tbody>
                 </table>
             </Stack>
+        </Stack>
+
+        <Stack>
+            <Heading Level="3" Class="mb-3">ToolbarContent&lt;TItem&gt;</Heading>
+            <Lumeo.Text Size="sm" Color="muted" Class="mb-3">Place inside <code>&lt;ChildContent&gt;</code> of a DataGrid. Accepts custom buttons or built-in toolbar tool components (see below) that automatically pick up the grid's state via a cascading context.</Lumeo.Text>
+            <Stack Class="overflow-x-auto rounded-lg border border-border/40">
+                <table class="w-full min-w-[600px] text-sm">
+                    <thead>
+                        <tr class="border-b border-border/40 bg-muted/30">
+                            <th class="px-4 py-2 text-left font-medium text-xs uppercase tracking-wider">Property</th>
+                            <th class="px-4 py-2 text-left font-medium text-xs uppercase tracking-wider">Type</th>
+                            <th class="px-4 py-2 text-left font-medium text-xs uppercase tracking-wider">Default</th>
+                            <th class="px-4 py-2 text-left font-medium text-xs uppercase tracking-wider">Description</th>
+                        </tr>
+                    </thead>
+                    <tbody class="divide-y divide-border/40">
+                        <tr><td class="px-4 py-2 font-mono text-xs text-primary">Class</td><td class="px-4 py-2 font-mono text-xs">string?</td><td class="px-4 py-2 text-xs">--</td><td class="px-4 py-2 text-muted-foreground">CSS classes applied to the wrapper around ChildContent + the toolbar's filter chips.</td></tr>
+                        <tr><td class="px-4 py-2 font-mono text-xs text-primary">ChildContent</td><td class="px-4 py-2 font-mono text-xs">RenderFragment?</td><td class="px-4 py-2 text-xs">--</td><td class="px-4 py-2 text-muted-foreground">Your custom buttons and any of the built-in toolbar tool components.</td></tr>
+                    </tbody>
+                </table>
+            </Stack>
+        </Stack>
+
+        <Stack>
+            <Heading Level="3" Class="mb-3">Toolbar Tool Components</Heading>
+            <Lumeo.Text Size="sm" Color="muted" Class="mb-3">Built-in tool components you can drop inside <code>&lt;ToolbarContent&gt;</code>. Each takes only <code>TItem</code> and reads everything else (selection, columns, export formats, layout config, Interop, Localizer) from a cascading <code>DataGridToolbarContext&lt;TItem&gt;</code>.</Lumeo.Text>
+            <Stack Class="overflow-x-auto rounded-lg border border-border/40">
+                <table class="w-full min-w-[600px] text-sm">
+                    <thead>
+                        <tr class="border-b border-border/40 bg-muted/30">
+                            <th class="px-4 py-2 text-left font-medium text-xs uppercase tracking-wider">Component</th>
+                            <th class="px-4 py-2 text-left font-medium text-xs uppercase tracking-wider">Renders</th>
+                            <th class="px-4 py-2 text-left font-medium text-xs uppercase tracking-wider">Visible when</th>
+                        </tr>
+                    </thead>
+                    <tbody class="divide-y divide-border/40">
+                        <tr><td class="px-4 py-2 font-mono text-xs text-primary">&lt;DataGridToolbarFullscreen&gt;</td><td class="px-4 py-2 text-muted-foreground">Fullscreen toggle icon button.</td><td class="px-4 py-2 text-muted-foreground"><code>Expandable="true"</code> on the grid.</td></tr>
+                        <tr><td class="px-4 py-2 font-mono text-xs text-primary">&lt;DataGridToolbarCopySelected&gt;</td><td class="px-4 py-2 text-muted-foreground">Copy-to-clipboard button (tab-separated, selected rows).</td><td class="px-4 py-2 text-muted-foreground">At least one row is selected.</td></tr>
+                        <tr><td class="px-4 py-2 font-mono text-xs text-primary">&lt;DataGridToolbarColumns&gt;</td><td class="px-4 py-2 text-muted-foreground">Column visibility + reorder dropdown.</td><td class="px-4 py-2 text-muted-foreground">Always (gate on the grid via <code>ShowColumnChooser</code>).</td></tr>
+                        <tr><td class="px-4 py-2 font-mono text-xs text-primary">&lt;DataGridToolbarExport&gt;</td><td class="px-4 py-2 text-muted-foreground">Export dropdown (CSV / Excel / PDF per <code>ExportFormats</code>).</td><td class="px-4 py-2 text-muted-foreground"><code>ExportFormats != None</code>.</td></tr>
+                        <tr><td class="px-4 py-2 font-mono text-xs text-primary">&lt;DataGridToolbarLayouts&gt;</td><td class="px-4 py-2 text-muted-foreground">Saved-layouts panel (personal + global).</td><td class="px-4 py-2 text-muted-foreground"><code>EnableLayoutPersistence="true"</code>.</td></tr>
+                    </tbody>
+                </table>
+            </Stack>
+            <Lumeo.Text Size="xs" Color="muted" Class="mt-2">When you omit <code>&lt;ToolbarContent&gt;</code>, all five tools auto-render in the default order (Fullscreen, CopySelected, Columns, Export, Layouts) gated by their <code>Show*</code> flags on the DataGrid.</Lumeo.Text>
         </Stack>
 
         <Stack>
@@ -1288,18 +1356,39 @@
 
     private string _toolbarContentCode = @"<DataGrid TItem=""Employee"" Items=""@employees"" PageSize=""5""
           ShowToolbar=""true"">
-    <ToolbarContent>
-        <Button Variant=""Button.ButtonVariant.Outline"" Size=""Button.ButtonSize.Sm""
-                Class=""gap-1.5"">
-            <DynamicIcon Name=""Plus"" Class=""h-3.5 w-3.5"" />
-            Add Employee
-        </Button>
-    </ToolbarContent>
     <ChildContent>
+        <ToolbarContent TItem=""Employee"" Class=""gap-3"">
+            <Button Variant=""Button.ButtonVariant.Outline"" Size=""Button.ButtonSize.Sm""
+                    Class=""gap-1.5"">
+                <DynamicIcon Name=""Plus"" Class=""h-3.5 w-3.5"" />
+                Add Employee
+            </Button>
+        </ToolbarContent>
         <DataGridColumnDef TItem=""Employee"" Title=""Name"" Field=""Name""
                            Sortable=""true"" Filterable=""true"" />
         <DataGridColumnDef TItem=""Employee"" Title=""Department"" Field=""Department"" />
         <DataGridColumnDef TItem=""Employee"" Title=""Salary"" Field=""Salary"" Format=""C0"" />
+    </ChildContent>
+</DataGrid>";
+
+    private string _toolbarComposedCode = @"<DataGrid TItem=""Employee"" Items=""@employees"" PageSize=""5""
+          ShowToolbar=""true""
+          Expandable=""true""
+          ShowColumnChooser=""false""
+          ShowExport=""false"">
+    <ChildContent>
+        <ToolbarContent TItem=""Employee"" Class=""gap-2 flex-wrap"">
+            <Button Variant=""Button.ButtonVariant.Outline"" Size=""Button.ButtonSize.Sm""
+                    Class=""gap-1.5"">
+                <DynamicIcon Name=""RefreshCw"" Class=""h-3.5 w-3.5"" />
+                Refresh
+            </Button>
+            <DataGridToolbarColumns TItem=""Employee"" />
+            <DataGridToolbarExport TItem=""Employee"" />
+            <DataGridToolbarFullscreen TItem=""Employee"" />
+        </ToolbarContent>
+        <DataGridColumnDef TItem=""Employee"" Title=""Name"" Field=""Name"" Sortable=""true"" />
+        <DataGridColumnDef TItem=""Employee"" Title=""Department"" Field=""Department"" />
     </ChildContent>
 </DataGrid>";
 

--- a/docs/Lumeo.Docs/Pages/Components/DataGridPage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/DataGridPage.razor
@@ -472,13 +472,13 @@
 
     <ComponentDemo Title="Custom Toolbar Content" Description="Add custom buttons and controls to the toolbar using the ToolbarContent slot." Code="@_toolbarContentCode">
         <DataGrid TItem="Employee" Items="@_employees" PageSize="5" ShowPagination="true" ShowToolbar="true">
-            <ToolbarContent>
-                <Button Variant="Button.ButtonVariant.Outline" Size="Button.ButtonSize.Sm" Class="gap-1.5">
-                    <DynamicIcon Name="Plus" Class="h-3.5 w-3.5" />
-                    Add Employee
-                </Button>
-            </ToolbarContent>
             <ChildContent>
+                <ToolbarContent TItem="Employee">
+                    <Button Variant="Button.ButtonVariant.Outline" Size="Button.ButtonSize.Sm" Class="gap-1.5">
+                        <DynamicIcon Name="Plus" Class="h-3.5 w-3.5" />
+                        Add Employee
+                    </Button>
+                </ToolbarContent>
                 <DataGridColumnDef TItem="Employee" Title="Name" Field="Name" Sortable="true" Filterable="true" />
                 <DataGridColumnDef TItem="Employee" Title="Department" Field="Department" Sortable="true" />
                 <DataGridColumnDef TItem="Employee" Title="Salary" Field="Salary" Format="C0" Sortable="true" />

--- a/docs/Lumeo.Docs/wwwroot/index.html
+++ b/docs/Lumeo.Docs/wwwroot/index.html
@@ -88,6 +88,7 @@
     </div>
     <script src="_content/Lumeo/js/theme.js"></script>
     <script src="js/docs.js"></script>
+    <script src="js/nav-scroll.js"></script>
     <script src="_framework/blazor.webassembly#[.{fingerprint}].js"></script>
 </body>
 

--- a/docs/Lumeo.Docs/wwwroot/js/nav-scroll.js
+++ b/docs/Lumeo.Docs/wwwroot/js/nav-scroll.js
@@ -1,0 +1,12 @@
+// Scrolls the active NavLink inside the docs sidebar into view. Called from
+// NavMenu.razor on initial render + every LocationChanged so direct-link loads
+// and in-app navigation both land with the current page's entry visible.
+window.lumeoNavScrollActiveIntoView = function (navEl) {
+    if (!navEl) return;
+    // Blazor's NavLink adds the "active" class on the anchor that matches the current URL.
+    const active = navEl.querySelector('a.active');
+    if (!active) return;
+    // scrollIntoView with block: 'nearest' only scrolls when actually needed (no jumpy
+    // behaviour on already-visible items) and stays inside the scrollable <aside>.
+    active.scrollIntoView({ block: 'nearest', inline: 'nearest' });
+};

--- a/src/Lumeo/Lumeo.csproj
+++ b/src/Lumeo/Lumeo.csproj
@@ -8,7 +8,7 @@
 
     <!-- NuGet Package Metadata -->
     <PackageId>Lumeo</PackageId>
-    <Version>2.0.0-rc.2</Version>
+    <Version>2.0.0-rc.3</Version>
     <Title>Lumeo</Title>
     <Authors>bemi</Authors>
     <Description>Lumeo is a modern, accessible Blazor component library with 135+ production-ready components. Built on Tailwind CSS v4 with 8 color themes, dark mode, and 14 locales. Features AI chat primitives (PromptInput, StreamingText, AgentMessage), motion primitives, Scheduler (FullCalendar), Gantt (Frappe), RichTextEditor (TipTap), 30+ ECharts, enterprise DataGrid with Excel/PDF/CSV export, programmatic overlay service, [LumeoForm] Roslyn source generator, RTL support, and 1,564 unit tests. Inspired by shadcn/ui and Radix.</Description>

--- a/src/Lumeo/Services/ComponentInteropService.cs
+++ b/src/Lumeo/Services/ComponentInteropService.cs
@@ -322,10 +322,10 @@ public sealed class ComponentInteropService : IComponentInteropService
 
     // --- DataGrid Column Resize ---
 
-    public async ValueTask RegisterColumnResize(string handleId, Func<double, Task> resizeHandler, Func<Task> resizeEndHandler)
+    public async ValueTask RegisterColumnResize(string handleId, double minWidth, double? maxWidth, Func<double, Task> commitHandler)
     {
         var module = await GetModuleAsync();
-        await _resize.RegisterColumnResize(module, GetSelfRef(), handleId, resizeHandler, resizeEndHandler);
+        await _resize.RegisterColumnResize(module, GetSelfRef(), handleId, minWidth, maxWidth, commitHandler);
     }
 
     public async ValueTask UnregisterColumnResize(string handleId)
@@ -339,6 +339,9 @@ public sealed class ComponentInteropService : IComponentInteropService
 
     [JSInvokable]
     public async Task OnColumnResizeEnd(string handleId) => await _resize.OnColumnResizeEnd(handleId);
+
+    [JSInvokable]
+    public async Task OnColumnResizeCommit(string handleId, double finalWidth) => await _resize.OnColumnResizeCommit(handleId, finalWidth);
 
     // --- Tour: Element Rect By Selector ---
 

--- a/src/Lumeo/Services/IComponentInteropService.cs
+++ b/src/Lumeo/Services/IComponentInteropService.cs
@@ -69,8 +69,9 @@ public interface IComponentInteropService : IAsyncDisposable, IDisposable
     ValueTask RegisterOtpPaste(string baseId, int length, Func<string, Task> handler);
     ValueTask UnregisterOtpPaste(string baseId, int length);
 
-    // DataGrid Column Resize
-    ValueTask RegisterColumnResize(string handleId, Func<double, Task> resizeHandler, Func<Task> resizeEndHandler);
+    // DataGrid Column Resize — JS previews the drag directly in the DOM and invokes
+    // commitHandler once with the final width on mouseup.
+    ValueTask RegisterColumnResize(string handleId, double minWidth, double? maxWidth, Func<double, Task> commitHandler);
     ValueTask UnregisterColumnResize(string handleId);
 
     // Tour

--- a/src/Lumeo/Services/Interop/ResizeInterop.cs
+++ b/src/Lumeo/Services/Interop/ResizeInterop.cs
@@ -8,6 +8,7 @@ internal sealed class ResizeInterop
     private readonly Dictionary<string, Func<Task>> _resizeEndHandlers = new();
     private readonly Dictionary<string, Func<double, Task>> _columnResizeHandlers = new();
     private readonly Dictionary<string, Func<Task>> _columnResizeEndHandlers = new();
+    private readonly Dictionary<string, Func<double, Task>> _columnResizeCommitHandlers = new();
 
     // --- Panel Resize ---
 
@@ -49,22 +50,26 @@ internal sealed class ResizeInterop
 
     // --- Column Resize ---
 
+    /// <summary>Registers a column resize handle. JS handles the drag entirely in the DOM
+    /// (preview by directly writing styles) and invokes <see cref="OnColumnResizeCommit"/>
+    /// once on mouseup — so we do ONE Blazor re-render per resize instead of one per pixel.</summary>
     public async ValueTask RegisterColumnResize(
         IJSObjectReference module,
         DotNetObjectReference<ComponentInteropService> selfRef,
         string handleId,
-        Func<double, Task> resizeHandler,
-        Func<Task> resizeEndHandler)
+        double minWidth,
+        double? maxWidth,
+        Func<double, Task> commitHandler)
     {
-        _columnResizeHandlers[handleId] = resizeHandler;
-        _columnResizeEndHandlers[handleId] = resizeEndHandler;
-        await module.InvokeVoidAsync("registerColumnResize", handleId, selfRef);
+        _columnResizeCommitHandlers[handleId] = commitHandler;
+        await module.InvokeVoidAsync("registerColumnResize", handleId, selfRef, minWidth, maxWidth ?? 0);
     }
 
     public async ValueTask UnregisterColumnResize(IJSObjectReference module, string handleId)
     {
         _columnResizeHandlers.Remove(handleId);
         _columnResizeEndHandlers.Remove(handleId);
+        _columnResizeCommitHandlers.Remove(handleId);
         await module.InvokeVoidAsync("unregisterColumnResize", handleId);
     }
 
@@ -84,11 +89,20 @@ internal sealed class ResizeInterop
         }
     }
 
+    public async Task OnColumnResizeCommit(string handleId, double finalWidth)
+    {
+        if (_columnResizeCommitHandlers.TryGetValue(handleId, out var handler))
+        {
+            await handler(finalWidth);
+        }
+    }
+
     public void Clear()
     {
         _resizeHandlers.Clear();
         _resizeEndHandlers.Clear();
         _columnResizeHandlers.Clear();
         _columnResizeEndHandlers.Clear();
+        _columnResizeCommitHandlers.Clear();
     }
 }

--- a/src/Lumeo/UI/Chart/Chart.razor
+++ b/src/Lumeo/UI/Chart/Chart.razor
@@ -80,9 +80,11 @@ else
     private string RootCssClass => $"relative {Class}".Trim();
     private string RootStyleStr => $"position: relative; {StyleStr}";
 
-    /// <summary>True when we should be showing *some form* of loading state. This is the
-    /// "is-loading" signal — separate from *how* we present it (Phantom vs Silhouette).</summary>
-    private bool ShouldShowSkeleton => ShowLoadingSkeleton && (IsLoading || !_hasFirstRendered);
+    /// <summary>True when we should be showing a loading state. Keyed strictly on
+    /// <c>IsLoading</c> — we do NOT show phantom/silhouette on initial mount, because
+    /// ECharts initializes synchronously and a ready chart should render its real data
+    /// on first paint. The loading state is reserved for explicit consumer refetches.</summary>
+    private bool ShouldShowSkeleton => ShowLoadingSkeleton && IsLoading;
 
     // Silhouette mode hides the real chart while the SVG overlay takes its place.
     // Phantom mode keeps the chart host fully visible — the "skeleton" IS the chart
@@ -146,6 +148,9 @@ else
             }
 
             _hasFirstRendered = true;
+            // Capture the phantom state that was actually passed to ECharts. Must be
+            // the value at init time (before any subsequent state change), so we can
+            // correctly decide notMerge on the next update.
             _lastWasPhantom = IsPhantomActive;
             UpdatePhantomTimer();
             StateHasChanged();
@@ -159,10 +164,12 @@ else
             if (json != _lastJson)
             {
                 _lastJson = json;
-                // When transitioning OUT of phantom mode, use notMerge=true so the muted
-                // palette and transparent axis labels don't bleed into the real chart.
-                // Phantom→phantom and real→real stay on notMerge=false for smooth tweens.
-                var notMerge = _lastWasPhantom && !isPhantom;
+                // Whenever phantom state flips in either direction, use notMerge=true so
+                // muted palette / transparent axis labels / placeholder category names
+                // don't bleed into the real chart (or vice-versa). Same-mode updates
+                // (phantom→phantom cycling, real→real data refresh) stay on notMerge=false
+                // for smooth value tweens.
+                var notMerge = _lastWasPhantom != isPhantom;
                 await _module!.InvokeVoidAsync("updateChart", _chartId, json, notMerge);
             }
             _lastWasPhantom = isPhantom;

--- a/src/Lumeo/UI/Chart/Chart.razor
+++ b/src/Lumeo/UI/Chart/Chart.razor
@@ -10,14 +10,15 @@
 else
 {
     <div class="@RootCssClass" style="@RootStyleStr" @attributes="AdditionalAttributes">
-        <div id="@_chartId" class="lumeo-chart-host w-full h-full @(ShouldShowSkeleton ? "invisible" : "")"></div>
-        @if (ShouldShowSkeleton)
+        <div id="@_chartId" class="lumeo-chart-host w-full h-full"
+             style="transition: opacity 350ms ease-out; opacity: @ChartHostOpacity;"></div>
+        @if (ShowLoadingSkeleton)
         {
-            @* Wrap the skeleton in a plain div with inline positioning so we
-               guarantee the overlay pins to this chart box regardless of whether
-               tailwind's `absolute inset-0` utilities are in the compiled bundle.
-               (Without this, rc.3 consumers saw skeletons offset by one card.) *@
-            <div style="position: absolute; inset: 0; pointer-events: none;">
+            @* Skeleton stays mounted while ShowLoadingSkeleton is on — we cross-fade
+               via opacity so the handoff to the real chart feels continuous instead
+               of snapping. Inline positioning guarantees the overlay pins to THIS
+               chart box regardless of the compiled Tailwind bundle. *@
+            <div style="position: absolute; inset: 0; pointer-events: none; transition: opacity 350ms ease-out; opacity: @SkeletonOpacity;">
                 <ChartSkeleton Kind="@SkeletonKind" Width="100%" Height="100%" Class="!rounded-none" />
             </div>
         }
@@ -86,6 +87,13 @@ else
     /// mount — prevents an empty-whitespace flash on initial paint. ShowLoadingSkeleton=false
     /// opts out entirely.</summary>
     private bool ShouldShowSkeleton => ShowLoadingSkeleton && (IsLoading || !_hasFirstRendered);
+
+    // Cross-fade handoff: the chart host starts at opacity 0 and fades to 1 once the real
+    // ECharts canvas has mounted; the skeleton stays in the DOM (so its opacity can
+    // transition) and fades out in the same 350ms window. Pointer-events:none on the
+    // skeleton layer means the faded-out overlay doesn't swallow hover/click events.
+    private string ChartHostOpacity => ShouldShowSkeleton ? "0" : "1";
+    private string SkeletonOpacity => ShouldShowSkeleton ? "1" : "0";
 
     // Chart repaint on theme change is handled entirely in JS:
     // theme.js dispatches a `lumeo:theme-changed` event after every setter,

--- a/src/Lumeo/UI/Chart/Chart.razor
+++ b/src/Lumeo/UI/Chart/Chart.razor
@@ -106,6 +106,12 @@ else
     private int _activePhantomCycleMs;
     private int EffectivePhantomCycleMs => Math.Max(200, PhantomCycleMs);
 
+    // Components whose phantom styling (muted palette, transparent text, skeleton-box
+    // labels) must be wiped during the phantom↔real transition — otherwise they'd
+    // persist under setOption merge semantics and bleed into the real chart.
+    private const string PhantomTransitionReplaceMergeJson =
+        "[\"xAxis\",\"yAxis\",\"legend\",\"polar\",\"angleAxis\",\"radiusAxis\",\"radar\",\"parallel\",\"parallelAxis\",\"visualMap\",\"grid\"]";
+
     private bool IsPhantomActive =>
         ShouldShowSkeleton && SkeletonStyle == ChartSkeletonStyle.Phantom && ShowLoadingSkeleton;
 
@@ -174,13 +180,14 @@ else
             if (json != _lastJson)
             {
                 _lastJson = json;
-                // Whenever phantom state flips in either direction, use notMerge=true so
-                // muted palette / transparent axis labels / placeholder category names
-                // don't bleed into the real chart (or vice-versa). Same-mode updates
-                // (phantom→phantom cycling, real→real data refresh) stay on notMerge=false
-                // for smooth value tweens.
-                var notMerge = _lastWasPhantom != isPhantom;
-                await _module!.InvokeVoidAsync("updateChart", _chartId, json, notMerge);
+                // Phantom↔real transition: keep notMerge=false so SERIES values tween
+                // (bars move from phantom heights to real heights — feels like data
+                // loading, not a snap). Use replaceMerge to fully replace layout
+                // components (axes, legend, radar, polar, parallel, visualMap) so the
+                // muted skeleton-box styling doesn't bleed into the real chart.
+                var phantomFlipped = _lastWasPhantom != isPhantom;
+                string? replaceMergeJson = phantomFlipped ? PhantomTransitionReplaceMergeJson : null;
+                await _module!.InvokeVoidAsync("updateChart", _chartId, json, false, replaceMergeJson);
             }
             _lastWasPhantom = isPhantom;
 

--- a/src/Lumeo/UI/Chart/Chart.razor
+++ b/src/Lumeo/UI/Chart/Chart.razor
@@ -60,6 +60,10 @@ else
     /// data in a muted palette; ECharts animates the option swap to real data.
     /// Silhouette falls back to the legacy SVG overlay skeleton.</summary>
     [Parameter] public ChartSkeletonStyle SkeletonStyle { get; set; } = ChartSkeletonStyle.Phantom;
+    /// <summary>Phantom-mode refresh interval in milliseconds — each tick regenerates
+    /// the placeholder dataset with a new random seed so bars/lines/slices visibly
+    /// redistribute while loading. Defaults to 1400ms; clamped to ≥200ms.</summary>
+    [Parameter] public int PhantomCycleMs { get; set; } = 1400;
 
     private readonly string _chartId = $"lumeo-chart-{Guid.NewGuid():N}";
     private IJSObjectReference? _module;
@@ -96,7 +100,8 @@ else
     private System.Threading.Timer? _phantomTimer;
     private int _phantomTick;
     private bool _lastWasPhantom;
-    private const int PhantomCycleMs = 1400;
+    private int _activePhantomCycleMs;
+    private int EffectivePhantomCycleMs => Math.Max(200, PhantomCycleMs);
 
     private bool IsPhantomActive =>
         ShouldShowSkeleton && SkeletonStyle == ChartSkeletonStyle.Phantom && ShowLoadingSkeleton;
@@ -203,29 +208,36 @@ else
 
     private void UpdatePhantomTimer()
     {
-        if (IsPhantomActive && _phantomTimer is null)
+        var cycle = EffectivePhantomCycleMs;
+        if (IsPhantomActive)
         {
-            _phantomTimer = new System.Threading.Timer(_ =>
+            if (_phantomTimer is null || _activePhantomCycleMs != cycle)
             {
-                _phantomTick++;
-                _ = InvokeAsync(async () =>
+                _phantomTimer?.Dispose();
+                _activePhantomCycleMs = cycle;
+                _phantomTimer = new System.Threading.Timer(_ =>
                 {
-                    if (!_initialized || _module is null || !IsPhantomActive) return;
-                    var json = ChartPlaceholderFactory.CreateJson(SkeletonKind, _phantomTick);
-                    _lastJson = json;
-                    try
+                    _phantomTick++;
+                    _ = InvokeAsync(async () =>
                     {
-                        await _module.InvokeVoidAsync("updateChart", _chartId, json, false);
-                    }
-                    catch (JSDisconnectedException) { }
-                    catch (ObjectDisposedException) { }
-                });
-            }, null, PhantomCycleMs, PhantomCycleMs);
+                        if (!_initialized || _module is null || !IsPhantomActive) return;
+                        var json = ChartPlaceholderFactory.CreateJson(SkeletonKind, _phantomTick);
+                        _lastJson = json;
+                        try
+                        {
+                            await _module.InvokeVoidAsync("updateChart", _chartId, json, false);
+                        }
+                        catch (JSDisconnectedException) { }
+                        catch (ObjectDisposedException) { }
+                    });
+                }, null, cycle, cycle);
+            }
         }
-        else if (!IsPhantomActive && _phantomTimer is not null)
+        else if (_phantomTimer is not null)
         {
             _phantomTimer.Dispose();
             _phantomTimer = null;
+            _activePhantomCycleMs = 0;
         }
     }
 

--- a/src/Lumeo/UI/Chart/Chart.razor
+++ b/src/Lumeo/UI/Chart/Chart.razor
@@ -11,7 +11,7 @@ else
 {
     <div class="@RootCssClass" style="@RootStyleStr" @attributes="AdditionalAttributes">
         <div id="@_chartId" class="lumeo-chart-host w-full h-full"
-             style="transition: opacity 350ms ease-out; opacity: @ChartHostOpacity;"></div>
+             style="@HostStyle"></div>
         @if (ShouldShowSkeleton && SkeletonStyle == ChartSkeletonStyle.Silhouette)
         {
             @* Silhouette mode (legacy SVG skeleton overlay). Phantom mode renders the real
@@ -95,8 +95,18 @@ else
 
     // Silhouette mode hides the real chart while the SVG overlay takes its place.
     // Phantom mode keeps the chart host fully visible — the "skeleton" IS the chart
-    // (with fake data), and the option-swap tween handles the handoff to real data.
+    // with placeholder data. To give phantom a "loading" look without polluting the
+    // option.color palette (which would bleed through the merge into the real chart),
+    // we apply a CSS grayscale+dim filter while phantom is active. The filter cleanly
+    // transitions off when real data arrives — bars keep their real hue throughout.
     private string ChartHostOpacity => (ShouldShowSkeleton && SkeletonStyle == ChartSkeletonStyle.Silhouette) ? "0" : "1";
+
+    private bool IsPhantomStyled =>
+        ShouldShowSkeleton && SkeletonStyle == ChartSkeletonStyle.Phantom && ShowLoadingSkeleton;
+
+    private string HostStyle => IsPhantomStyled
+        ? $"transition: opacity 350ms ease-out, filter 500ms ease-out; opacity: {ChartHostOpacity}; filter: grayscale(0.85) saturate(0.15) opacity(0.78);"
+        : $"transition: opacity 350ms ease-out, filter 500ms ease-out; opacity: {ChartHostOpacity}; filter: none;";
 
     // Phantom-mode state: cycling random placeholder data while loading, then one
     // clean "notMerge=true" swap to real data so the muted palette doesn't bleed.

--- a/src/Lumeo/UI/Chart/Chart.razor
+++ b/src/Lumeo/UI/Chart/Chart.razor
@@ -89,14 +89,23 @@ else
     // (with fake data), and the option-swap tween handles the handoff to real data.
     private string ChartHostOpacity => (ShouldShowSkeleton && SkeletonStyle == ChartSkeletonStyle.Silhouette) ? "0" : "1";
 
-    /// <summary>Returns the JSON that actually goes to ECharts. In Phantom mode, when we're
-    /// in loading state, this is the placeholder option — swapping to the real option later
-    /// triggers an ECharts option-change animation from phantom → real.</summary>
+    // Phantom-mode state: cycling random placeholder data while loading, then one
+    // clean "notMerge=true" swap to real data so the muted palette doesn't bleed.
+    private System.Threading.Timer? _phantomTimer;
+    private int _phantomTick;
+    private bool _lastWasPhantom;
+    private const int PhantomCycleMs = 1400;
+
+    private bool IsPhantomActive =>
+        ShouldShowSkeleton && SkeletonStyle == ChartSkeletonStyle.Phantom && ShowLoadingSkeleton;
+
+    /// <summary>Returns the JSON that actually goes to ECharts. Phantom mode uses
+    /// the current cycling tick so each frame redistributes the random data.</summary>
     private string GetEffectiveJson()
     {
-        if (ShouldShowSkeleton && SkeletonStyle == ChartSkeletonStyle.Phantom && ShowLoadingSkeleton)
+        if (IsPhantomActive)
         {
-            return ChartPlaceholderFactory.CreateJson(SkeletonKind);
+            return ChartPlaceholderFactory.CreateJson(SkeletonKind, _phantomTick);
         }
         return GetOptionsJson();
     }
@@ -137,19 +146,26 @@ else
             }
 
             _hasFirstRendered = true;
+            _lastWasPhantom = IsPhantomActive;
+            UpdatePhantomTimer();
             StateHasChanged();
         }
         else if (_initialized)
         {
+            UpdatePhantomTimer();
+
             var json = GetEffectiveJson();
+            var isPhantom = IsPhantomActive;
             if (json != _lastJson)
             {
                 _lastJson = json;
-                // notMerge=false so ECharts diffs the new option against the old and
-                // tweens series values — this is what turns the phantom → real swap
-                // into a morph animation rather than a snap.
-                await _module!.InvokeVoidAsync("updateChart", _chartId, json, false);
+                // When transitioning OUT of phantom mode, use notMerge=true so the muted
+                // palette and transparent axis labels don't bleed into the real chart.
+                // Phantom→phantom and real→real stay on notMerge=false for smooth tweens.
+                var notMerge = _lastWasPhantom && !isPhantom;
+                await _module!.InvokeVoidAsync("updateChart", _chartId, json, notMerge);
             }
+            _lastWasPhantom = isPhantom;
 
             if (ShowLoading != _lastShowLoading)
             {
@@ -175,6 +191,34 @@ else
                 if (!string.IsNullOrEmpty(Group))
                     await _module!.InvokeVoidAsync("connectCharts", Group, new[] { _chartId });
             }
+        }
+    }
+
+    private void UpdatePhantomTimer()
+    {
+        if (IsPhantomActive && _phantomTimer is null)
+        {
+            _phantomTimer = new System.Threading.Timer(_ =>
+            {
+                _phantomTick++;
+                _ = InvokeAsync(async () =>
+                {
+                    if (!_initialized || _module is null || !IsPhantomActive) return;
+                    var json = ChartPlaceholderFactory.CreateJson(SkeletonKind, _phantomTick);
+                    _lastJson = json;
+                    try
+                    {
+                        await _module.InvokeVoidAsync("updateChart", _chartId, json, false);
+                    }
+                    catch (JSDisconnectedException) { }
+                    catch (ObjectDisposedException) { }
+                });
+            }, null, PhantomCycleMs, PhantomCycleMs);
+        }
+        else if (!IsPhantomActive && _phantomTimer is not null)
+        {
+            _phantomTimer.Dispose();
+            _phantomTimer = null;
         }
     }
 
@@ -253,6 +297,8 @@ else
 
     public async ValueTask DisposeAsync()
     {
+        _phantomTimer?.Dispose();
+        _phantomTimer = null;
         if (_module is not null && _initialized)
         {
             try

--- a/src/Lumeo/UI/Chart/Chart.razor
+++ b/src/Lumeo/UI/Chart/Chart.razor
@@ -10,10 +10,10 @@
 else
 {
     <div class="@RootCssClass" style="@StyleStr" @attributes="AdditionalAttributes">
-        <div id="@_chartId" class="lumeo-chart-host w-full h-full"></div>
+        <div id="@_chartId" class="lumeo-chart-host w-full h-full @(ShouldShowSkeleton ? "invisible" : "")"></div>
         @if (ShouldShowSkeleton)
         {
-            <ChartSkeleton Kind="@SkeletonKind" Width="100%" Height="100%" Class="absolute inset-0 !rounded-none !bg-transparent animate-in fade-in duration-200 pointer-events-none" />
+            <ChartSkeleton Kind="@SkeletonKind" Width="100%" Height="100%" Class="absolute inset-0 !rounded-none !bg-transparent pointer-events-none" />
         }
     </div>
 }

--- a/src/Lumeo/UI/Chart/Chart.razor
+++ b/src/Lumeo/UI/Chart/Chart.razor
@@ -13,7 +13,11 @@ else
         <div id="@_chartId" class="lumeo-chart-host w-full h-full @(ShouldShowSkeleton ? "invisible" : "")"></div>
         @if (ShouldShowSkeleton)
         {
-            <ChartSkeleton Kind="@SkeletonKind" Width="100%" Height="100%" Class="absolute inset-0 !rounded-none !bg-transparent pointer-events-none" />
+            @* Skeleton keeps its muted background so it visually fills the card
+               instead of looking like floating SVG on transparent. `inset-0` pins
+               it to the chart box; `!rounded-none` flattens its corners (the
+               parent card already provides the rounding). *@
+            <ChartSkeleton Kind="@SkeletonKind" Width="100%" Height="100%" Class="absolute inset-0 !rounded-none pointer-events-none" />
         }
     </div>
 }

--- a/src/Lumeo/UI/Chart/Chart.razor
+++ b/src/Lumeo/UI/Chart/Chart.razor
@@ -9,15 +9,17 @@
 }
 else
 {
-    <div class="@RootCssClass" style="@StyleStr" @attributes="AdditionalAttributes">
+    <div class="@RootCssClass" style="@RootStyleStr" @attributes="AdditionalAttributes">
         <div id="@_chartId" class="lumeo-chart-host w-full h-full @(ShouldShowSkeleton ? "invisible" : "")"></div>
         @if (ShouldShowSkeleton)
         {
-            @* Skeleton keeps its muted background so it visually fills the card
-               instead of looking like floating SVG on transparent. `inset-0` pins
-               it to the chart box; `!rounded-none` flattens its corners (the
-               parent card already provides the rounding). *@
-            <ChartSkeleton Kind="@SkeletonKind" Width="100%" Height="100%" Class="absolute inset-0 !rounded-none pointer-events-none" />
+            @* Wrap the skeleton in a plain div with inline positioning so we
+               guarantee the overlay pins to this chart box regardless of whether
+               tailwind's `absolute inset-0` utilities are in the compiled bundle.
+               (Without this, rc.3 consumers saw skeletons offset by one card.) *@
+            <div style="position: absolute; inset: 0; pointer-events: none;">
+                <ChartSkeleton Kind="@SkeletonKind" Width="100%" Height="100%" Class="!rounded-none" />
+            </div>
         }
     </div>
 }
@@ -73,9 +75,12 @@ else
         : $"width: {Width}; height: {Height};";
 
     // Root now hosts both the ECharts canvas (rendered via JS into this div) and the
-    // skeleton overlay (absolute-positioned child). `relative` is required so the
-    // overlay pins to the chart box; ECharts is fine rendering children inside it.
+    // skeleton overlay (absolute-positioned child). position: relative is required
+    // so the overlay pins to THIS chart's box (not an outer ancestor); we use inline
+    // style because the Tailwind `relative` utility can be purged from pre-compiled
+    // bundles — which caused a skeleton-offset-by-one-card regression during rc.3.
     private string RootCssClass => $"relative {Class}".Trim();
+    private string RootStyleStr => $"position: relative; {StyleStr}";
 
     /// <summary>Skeleton shows when explicitly loading OR before the first successful ECharts
     /// mount — prevents an empty-whitespace flash on initial paint. ShowLoadingSkeleton=false

--- a/src/Lumeo/UI/Chart/Chart.razor
+++ b/src/Lumeo/UI/Chart/Chart.razor
@@ -12,13 +12,11 @@ else
     <div class="@RootCssClass" style="@RootStyleStr" @attributes="AdditionalAttributes">
         <div id="@_chartId" class="lumeo-chart-host w-full h-full"
              style="transition: opacity 350ms ease-out; opacity: @ChartHostOpacity;"></div>
-        @if (ShowLoadingSkeleton)
+        @if (ShouldShowSkeleton && SkeletonStyle == ChartSkeletonStyle.Silhouette)
         {
-            @* Skeleton stays mounted while ShowLoadingSkeleton is on — we cross-fade
-               via opacity so the handoff to the real chart feels continuous instead
-               of snapping. Inline positioning guarantees the overlay pins to THIS
-               chart box regardless of the compiled Tailwind bundle. *@
-            <div style="position: absolute; inset: 0; pointer-events: none; transition: opacity 350ms ease-out; opacity: @SkeletonOpacity;">
+            @* Silhouette mode (legacy SVG skeleton overlay). Phantom mode renders the real
+               ECharts with placeholder data instead — no DOM element needed here. *@
+            <div style="position: absolute; inset: 0; pointer-events: none;">
                 <ChartSkeleton Kind="@SkeletonKind" Width="100%" Height="100%" Class="!rounded-none" />
             </div>
         }
@@ -46,11 +44,11 @@ else
     [Parameter] public string? Class { get; set; }
     [Parameter(CaptureUnmatchedValues = true)] public Dictionary<string, object>? AdditionalAttributes { get; set; }
 
-    /// <summary>When true, forces the loading skeleton to render on top of the chart
+    /// <summary>When true, forces the loading state on top of the chart
     /// (consumer is refetching data). Independent of the JS-driven ECharts loading
     /// indicator controlled by <see cref="ShowLoading"/>.</summary>
     [Parameter] public bool IsLoading { get; set; }
-    /// <summary>When true (default), renders a shape-aware skeleton while the chart
+    /// <summary>When true (default), renders the loading state while the chart
     /// has not yet rendered for the first time, and whenever <see cref="IsLoading"/>
     /// is true. Set to <c>false</c> to opt out entirely.</summary>
     [Parameter] public bool ShowLoadingSkeleton { get; set; } = true;
@@ -58,6 +56,10 @@ else
     /// default (bars for Bar, pie ring for Pie, etc.) — consumers only override when
     /// they want a different silhouette.</summary>
     [Parameter] public ChartSkeletonKind SkeletonKind { get; set; } = ChartSkeletonKind.Generic;
+    /// <summary>Phantom (default) renders the real chart with synthesized placeholder
+    /// data in a muted palette; ECharts animates the option swap to real data.
+    /// Silhouette falls back to the legacy SVG overlay skeleton.</summary>
+    [Parameter] public ChartSkeletonStyle SkeletonStyle { get; set; } = ChartSkeletonStyle.Phantom;
 
     private readonly string _chartId = $"lumeo-chart-{Guid.NewGuid():N}";
     private IJSObjectReference? _module;
@@ -75,31 +77,29 @@ else
         ? $"width: {Width}; aspect-ratio: {AspectRatio};"
         : $"width: {Width}; height: {Height};";
 
-    // Root now hosts both the ECharts canvas (rendered via JS into this div) and the
-    // skeleton overlay (absolute-positioned child). position: relative is required
-    // so the overlay pins to THIS chart's box (not an outer ancestor); we use inline
-    // style because the Tailwind `relative` utility can be purged from pre-compiled
-    // bundles — which caused a skeleton-offset-by-one-card regression during rc.3.
     private string RootCssClass => $"relative {Class}".Trim();
     private string RootStyleStr => $"position: relative; {StyleStr}";
 
-    /// <summary>Skeleton shows when explicitly loading OR before the first successful ECharts
-    /// mount — prevents an empty-whitespace flash on initial paint. ShowLoadingSkeleton=false
-    /// opts out entirely.</summary>
+    /// <summary>True when we should be showing *some form* of loading state. This is the
+    /// "is-loading" signal — separate from *how* we present it (Phantom vs Silhouette).</summary>
     private bool ShouldShowSkeleton => ShowLoadingSkeleton && (IsLoading || !_hasFirstRendered);
 
-    // Cross-fade handoff: the chart host starts at opacity 0 and fades to 1 once the real
-    // ECharts canvas has mounted; the skeleton stays in the DOM (so its opacity can
-    // transition) and fades out in the same 350ms window. Pointer-events:none on the
-    // skeleton layer means the faded-out overlay doesn't swallow hover/click events.
-    private string ChartHostOpacity => ShouldShowSkeleton ? "0" : "1";
-    private string SkeletonOpacity => ShouldShowSkeleton ? "1" : "0";
+    // Silhouette mode hides the real chart while the SVG overlay takes its place.
+    // Phantom mode keeps the chart host fully visible — the "skeleton" IS the chart
+    // (with fake data), and the option-swap tween handles the handoff to real data.
+    private string ChartHostOpacity => (ShouldShowSkeleton && SkeletonStyle == ChartSkeletonStyle.Silhouette) ? "0" : "1";
 
-    // Chart repaint on theme change is handled entirely in JS:
-    // theme.js dispatches a `lumeo:theme-changed` event after every setter,
-    // and echarts-interop.js listens for it and calls refreshAllCharts().
-    // That covers every code path (ThemeService, CustomizerSidebar's direct
-    // themeManager.* calls, manual JS) uniformly.
+    /// <summary>Returns the JSON that actually goes to ECharts. In Phantom mode, when we're
+    /// in loading state, this is the placeholder option — swapping to the real option later
+    /// triggers an ECharts option-change animation from phantom → real.</summary>
+    private string GetEffectiveJson()
+    {
+        if (ShouldShowSkeleton && SkeletonStyle == ChartSkeletonStyle.Phantom && ShowLoadingSkeleton)
+        {
+            return ChartPlaceholderFactory.CreateJson(SkeletonKind);
+        }
+        return GetOptionsJson();
+    }
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
@@ -108,7 +108,7 @@ else
             _module = await JSRuntime.InvokeAsync<IJSObjectReference>(
                 "import", "./_content/Lumeo/js/echarts-interop.js");
 
-            var json = GetOptionsJson();
+            var json = GetEffectiveJson();
             _lastJson = json;
             _lastTheme = Theme;
             _lastGroup = Group;
@@ -136,18 +136,18 @@ else
                 await _module.InvokeVoidAsync("showLoading", _chartId, null);
             }
 
-            // Flip the flag and re-render so the shape-aware skeleton overlay fades out
-            // now that the real ECharts canvas is mounted. Only triggers when the consumer
-            // isn't still forcing IsLoading=true for a refetch cycle.
             _hasFirstRendered = true;
             StateHasChanged();
         }
         else if (_initialized)
         {
-            var json = GetOptionsJson();
+            var json = GetEffectiveJson();
             if (json != _lastJson)
             {
                 _lastJson = json;
+                // notMerge=false so ECharts diffs the new option against the old and
+                // tweens series values — this is what turns the phantom → real swap
+                // into a morph animation rather than a snap.
                 await _module!.InvokeVoidAsync("updateChart", _chartId, json, false);
             }
 
@@ -163,11 +163,9 @@ else
             if (Theme != _lastTheme)
             {
                 _lastTheme = Theme;
-                // Re-initialize chart with new theme — echarts requires dispose+init for theme changes
                 await _module!.InvokeVoidAsync("disposeChart", _chartId);
-                var currentJson = _lastJson ?? GetOptionsJson();
+                var currentJson = _lastJson ?? GetEffectiveJson();
                 await _module!.InvokeVoidAsync("initChart", _chartId, currentJson, Theme, EChartsSource);
-                // Re-register events and groups lost during dispose+init
                 await RegisterChartEventsAsync();
             }
 

--- a/src/Lumeo/UI/Chart/Chart.razor
+++ b/src/Lumeo/UI/Chart/Chart.razor
@@ -9,7 +9,13 @@
 }
 else
 {
-    <div id="@_chartId" class="@CssClass" style="@StyleStr" @attributes="AdditionalAttributes"></div>
+    <div class="@RootCssClass" style="@StyleStr" @attributes="AdditionalAttributes">
+        <div id="@_chartId" class="lumeo-chart-host w-full h-full"></div>
+        @if (ShouldShowSkeleton)
+        {
+            <ChartSkeleton Kind="@SkeletonKind" Width="100%" Height="100%" Class="absolute inset-0 !rounded-none !bg-transparent animate-in fade-in duration-200 pointer-events-none" />
+        }
+    </div>
 }
 
 @inject IJSRuntime JSRuntime
@@ -33,10 +39,24 @@ else
     [Parameter] public string? Class { get; set; }
     [Parameter(CaptureUnmatchedValues = true)] public Dictionary<string, object>? AdditionalAttributes { get; set; }
 
+    /// <summary>When true, forces the loading skeleton to render on top of the chart
+    /// (consumer is refetching data). Independent of the JS-driven ECharts loading
+    /// indicator controlled by <see cref="ShowLoading"/>.</summary>
+    [Parameter] public bool IsLoading { get; set; }
+    /// <summary>When true (default), renders a shape-aware skeleton while the chart
+    /// has not yet rendered for the first time, and whenever <see cref="IsLoading"/>
+    /// is true. Set to <c>false</c> to opt out entirely.</summary>
+    [Parameter] public bool ShowLoadingSkeleton { get; set; } = true;
+    /// <summary>Shape family for the skeleton. Each chart wrapper presets a sensible
+    /// default (bars for Bar, pie ring for Pie, etc.) — consumers only override when
+    /// they want a different silhouette.</summary>
+    [Parameter] public ChartSkeletonKind SkeletonKind { get; set; } = ChartSkeletonKind.Generic;
+
     private readonly string _chartId = $"lumeo-chart-{Guid.NewGuid():N}";
     private IJSObjectReference? _module;
     private DotNetObjectReference<Chart>? _selfRef;
     private bool _initialized;
+    private bool _hasFirstRendered;
     private string? _lastJson;
     private bool _lastShowLoading;
     private string? _lastTheme;
@@ -47,6 +67,16 @@ else
     private string StyleStr => AspectRatio is not null
         ? $"width: {Width}; aspect-ratio: {AspectRatio};"
         : $"width: {Width}; height: {Height};";
+
+    // Root now hosts both the ECharts canvas (rendered via JS into this div) and the
+    // skeleton overlay (absolute-positioned child). `relative` is required so the
+    // overlay pins to the chart box; ECharts is fine rendering children inside it.
+    private string RootCssClass => $"relative {Class}".Trim();
+
+    /// <summary>Skeleton shows when explicitly loading OR before the first successful ECharts
+    /// mount — prevents an empty-whitespace flash on initial paint. ShowLoadingSkeleton=false
+    /// opts out entirely.</summary>
+    private bool ShouldShowSkeleton => ShowLoadingSkeleton && (IsLoading || !_hasFirstRendered);
 
     // Chart repaint on theme change is handled entirely in JS:
     // theme.js dispatches a `lumeo:theme-changed` event after every setter,
@@ -88,6 +118,12 @@ else
                 _lastShowLoading = true;
                 await _module.InvokeVoidAsync("showLoading", _chartId, null);
             }
+
+            // Flip the flag and re-render so the shape-aware skeleton overlay fades out
+            // now that the real ECharts canvas is mounted. Only triggers when the consumer
+            // isn't still forcing IsLoading=true for a refetch cycle.
+            _hasFirstRendered = true;
+            StateHasChanged();
         }
         else if (_initialized)
         {

--- a/src/Lumeo/UI/Chart/Chart.razor
+++ b/src/Lumeo/UI/Chart/Chart.razor
@@ -64,12 +64,15 @@ else
     /// the placeholder dataset with a new random seed so bars/lines/slices visibly
     /// redistribute while loading. Defaults to 1400ms; clamped to ≥200ms.</summary>
     [Parameter] public int PhantomCycleMs { get; set; } = 1400;
+    /// <summary>Explicit override for the phantom layout (category count, series count,
+    /// stacking, area fill). When null (default), the shape is inferred from the real
+    /// <see cref="Option"/> so the phantom mirrors the actual chart structure.</summary>
+    [Parameter] public PhantomShape? PhantomShapeOverride { get; set; }
 
     private readonly string _chartId = $"lumeo-chart-{Guid.NewGuid():N}";
     private IJSObjectReference? _module;
     private DotNetObjectReference<Chart>? _selfRef;
     private bool _initialized;
-    private bool _hasFirstRendered;
     private string? _lastJson;
     private bool _lastShowLoading;
     private string? _lastTheme;
@@ -107,12 +110,15 @@ else
         ShouldShowSkeleton && SkeletonStyle == ChartSkeletonStyle.Phantom && ShowLoadingSkeleton;
 
     /// <summary>Returns the JSON that actually goes to ECharts. Phantom mode uses
-    /// the current cycling tick so each frame redistributes the random data.</summary>
+    /// the current cycling tick so each frame redistributes the random data, and
+    /// mirrors the real chart's structure (category count, series count, stacking)
+    /// via <see cref="ChartPlaceholderFactory.InferShape"/>.</summary>
     private string GetEffectiveJson()
     {
         if (IsPhantomActive)
         {
-            return ChartPlaceholderFactory.CreateJson(SkeletonKind, _phantomTick);
+            var shape = PhantomShapeOverride ?? ChartPlaceholderFactory.InferShape(Option);
+            return ChartPlaceholderFactory.CreateJson(SkeletonKind, _phantomTick, shape);
         }
         return GetOptionsJson();
     }
@@ -152,7 +158,6 @@ else
                 await _module.InvokeVoidAsync("showLoading", _chartId, null);
             }
 
-            _hasFirstRendered = true;
             // Capture the phantom state that was actually passed to ECharts. Must be
             // the value at init time (before any subsequent state change), so we can
             // correctly decide notMerge on the next update.
@@ -221,7 +226,8 @@ else
                     _ = InvokeAsync(async () =>
                     {
                         if (!_initialized || _module is null || !IsPhantomActive) return;
-                        var json = ChartPlaceholderFactory.CreateJson(SkeletonKind, _phantomTick);
+                        var shape = PhantomShapeOverride ?? ChartPlaceholderFactory.InferShape(Option);
+                        var json = ChartPlaceholderFactory.CreateJson(SkeletonKind, _phantomTick, shape);
                         _lastJson = json;
                         try
                         {

--- a/src/Lumeo/UI/Chart/ChartPlaceholderFactory.cs
+++ b/src/Lumeo/UI/Chart/ChartPlaceholderFactory.cs
@@ -1,0 +1,203 @@
+using System.Text.Json;
+
+namespace Lumeo;
+
+/// <summary>
+/// Builds "phantom" ECharts options — a real chart rendered with synthesized placeholder data
+/// in a muted palette. When the consumer flips <c>IsLoading</c> off, ECharts animates the option
+/// swap from phantom → real, giving a continuous morph instead of a skeleton → chart snap.
+///
+/// The placeholder palette is intentionally flat grayscale so the handoff reads as
+/// "data just arrived" rather than "new chart type appeared". All geometry (axes, legend slots,
+/// grid padding) matches the real chart's layout so the swap doesn't shift pixels.
+/// </summary>
+internal static class ChartPlaceholderFactory
+{
+    // Muted palette — flat slate with decreasing opacity per series. Picked to look
+    // intentionally "loading" on light AND dark themes without theme-token gymnastics.
+    private static readonly List<string> MutedPalette = new()
+    {
+        "rgba(148, 163, 184, 0.55)",
+        "rgba(148, 163, 184, 0.40)",
+        "rgba(148, 163, 184, 0.28)",
+        "rgba(148, 163, 184, 0.20)",
+        "rgba(148, 163, 184, 0.14)",
+    };
+
+    private static readonly List<string> BarsCategories =
+        new() { "A", "B", "C", "D", "E", "F", "G", "H" };
+
+    private static readonly List<string> LineCategories =
+        new() { "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12" };
+
+    private static readonly List<string> PieSliceNames =
+        new() { "·", "·", "·", "·" };
+
+    public static EChartOption Create(ChartSkeletonKind kind) => kind switch
+    {
+        ChartSkeletonKind.Bars => BuildBars(),
+        ChartSkeletonKind.Line => BuildLine(false),
+        ChartSkeletonKind.Area => BuildLine(true),
+        ChartSkeletonKind.Pie => BuildPie(),
+        ChartSkeletonKind.Scatter => BuildScatter(),
+        ChartSkeletonKind.Grid => BuildHeatmap(),
+        _ => BuildBars()
+    };
+
+    private static EChartOption BuildBars()
+    {
+        // 8 staggered heights — same silhouette as the SVG skeleton so the morph from
+        // phantom to real feels like the bars just "settled" onto actual values.
+        var values = new List<double> { 38, 62, 28, 75, 45, 88, 52, 68 };
+
+        return new EChartOption
+        {
+            Color = MutedPalette,
+            Grid = new EChartGrid { Left = "3%", Right = "4%", Bottom = "8%", Top = "14%", ContainLabel = true },
+            Legend = BuildLegendHint(new() { "·", "·", "·" }),
+            XAxis = new() { new EChartAxis { Type = "category", Data = BarsCategories, AxisLabel = new() { Color = "transparent" } } },
+            YAxis = new() { new EChartAxis { Type = "value", AxisLabel = new() { Color = "transparent" } } },
+            Series = new()
+            {
+                new EChartSeries
+                {
+                    Name = "·",
+                    Type = "bar",
+                    Data = values,
+                    BarWidth = 18,
+                    ItemStyle = new() { BorderRadius = 4 }
+                }
+            }
+        };
+    }
+
+    private static EChartOption BuildLine(bool filled)
+    {
+        // 3 gently curved series — matches the "multi-line skeleton" silhouette.
+        var s1 = new List<double> { 30, 38, 34, 48, 55, 62, 58, 72, 78, 85, 80, 92 };
+        var s2 = new List<double> { 22, 28, 32, 38, 42, 48, 52, 58, 62, 68, 72, 78 };
+        var s3 = new List<double> { 15, 18, 22, 28, 32, 36, 40, 44, 48, 52, 56, 60 };
+
+        EChartSeries Line(string name, List<double> data) => new()
+        {
+            Name = name,
+            Type = "line",
+            Data = data,
+            Smooth = true,
+            ShowSymbol = false,
+            LineStyle = new() { Width = 2 },
+            AreaStyle = filled ? new EChartAreaStyle { Opacity = 0.18 } : null
+        };
+
+        return new EChartOption
+        {
+            Color = MutedPalette,
+            Grid = new EChartGrid { Left = "3%", Right = "4%", Bottom = "8%", Top = "14%", ContainLabel = true },
+            Legend = BuildLegendHint(new() { "·", "·", "·" }),
+            XAxis = new() { new EChartAxis { Type = "category", Data = LineCategories, BoundaryGap = false, AxisLabel = new() { Color = "transparent" } } },
+            YAxis = new() { new EChartAxis { Type = "value", AxisLabel = new() { Color = "transparent" } } },
+            Series = new() { Line("·1", s1), Line("·2", s2), Line("·3", s3) }
+        };
+    }
+
+    private static EChartOption BuildPie()
+    {
+        var data = new List<EChartPieData>
+        {
+            new() { Name = PieSliceNames[0], Value = 38 },
+            new() { Name = PieSliceNames[1], Value = 28 },
+            new() { Name = PieSliceNames[2], Value = 20 },
+            new() { Name = PieSliceNames[3], Value = 14 },
+        };
+
+        return new EChartOption
+        {
+            Color = MutedPalette,
+            Legend = BuildLegendHint(PieSliceNames),
+            Series = new()
+            {
+                new EChartSeries
+                {
+                    Name = "·",
+                    Type = "pie",
+                    Radius = "58%",
+                    Center = "50%,58%",
+                    Data = data,
+                    Label = new() { Show = false },
+                    ItemStyle = new() { BorderColor = "rgba(0,0,0,0)", BorderWidth = 2 }
+                }
+            }
+        };
+    }
+
+    private static EChartOption BuildScatter()
+    {
+        // 20 seeded positions — stable across renders so the morph to real data is smooth.
+        var pts = new List<double[]>
+        {
+            new[] { 12.0, 44 }, new[] { 18.0, 38 }, new[] { 22.0, 52 }, new[] { 28.0, 48 },
+            new[] { 33.0, 60 }, new[] { 38.0, 55 }, new[] { 44.0, 68 }, new[] { 50.0, 62 },
+            new[] { 55.0, 74 }, new[] { 60.0, 70 }, new[] { 66.0, 82 }, new[] { 72.0, 78 },
+            new[] { 77.0, 85 }, new[] { 82.0, 80 }, new[] { 88.0, 92 }, new[] { 15.0, 62 },
+            new[] { 30.0, 40 }, new[] { 48.0, 50 }, new[] { 65.0, 58 }, new[] { 80.0, 68 },
+        };
+
+        return new EChartOption
+        {
+            Color = MutedPalette,
+            Grid = new EChartGrid { Left = "3%", Right = "4%", Bottom = "8%", Top = "14%", ContainLabel = true },
+            Legend = BuildLegendHint(new() { "·" }),
+            XAxis = new() { new EChartAxis { Type = "value", AxisLabel = new() { Color = "transparent" } } },
+            YAxis = new() { new EChartAxis { Type = "value", AxisLabel = new() { Color = "transparent" } } },
+            Series = new()
+            {
+                new EChartSeries { Name = "·", Type = "scatter", Data = pts, SymbolSize = 12 }
+            }
+        };
+    }
+
+    private static EChartOption BuildHeatmap()
+    {
+        // 8×5 grid of values — heatmap placeholder works for CalendarHeatmap + Heatmap kinds.
+        var points = new List<int[]>();
+        int seed = 0;
+        for (int x = 0; x < 8; x++)
+        {
+            for (int y = 0; y < 5; y++)
+            {
+                seed = (seed * 1103515245 + 12345) & 0x7fffffff;
+                points.Add(new[] { x, y, 20 + seed % 60 });
+            }
+        }
+
+        return new EChartOption
+        {
+            Color = MutedPalette,
+            Grid = new EChartGrid { Left = "3%", Right = "4%", Bottom = "8%", Top = "14%", ContainLabel = true },
+            XAxis = new() { new EChartAxis { Type = "category", Data = new() { "1", "2", "3", "4", "5", "6", "7", "8" }, AxisLabel = new() { Color = "transparent" } } },
+            YAxis = new() { new EChartAxis { Type = "category", Data = new() { "a", "b", "c", "d", "e" }, AxisLabel = new() { Color = "transparent" } } },
+            VisualMap = new EChartVisualMap
+            {
+                Min = 0,
+                Max = 100,
+                Show = false,
+                InRange = new EChartVisualMapInRange { Color = new() { "rgba(148,163,184,0.15)", "rgba(148,163,184,0.55)" } }
+            },
+            Series = new()
+            {
+                new EChartSeries { Name = "·", Type = "heatmap", Data = points, Label = new() { Show = false } }
+            }
+        };
+    }
+
+    private static EChartLegend BuildLegendHint(List<string> data) => new()
+    {
+        Data = data,
+        Top = "3%",
+        TextStyle = new() { Color = "transparent" }
+    };
+
+    /// <summary>Serializes a placeholder option to JSON — callers pass this directly to
+    /// ECharts via <c>updateChart</c> so the option-swap animation fires.</summary>
+    public static string CreateJson(ChartSkeletonKind kind) => Create(kind).ToJson();
+}

--- a/src/Lumeo/UI/Chart/ChartPlaceholderFactory.cs
+++ b/src/Lumeo/UI/Chart/ChartPlaceholderFactory.cs
@@ -76,6 +76,15 @@ internal static class ChartPlaceholderFactory
             ChartSkeletonKind.Pie => BuildPie(rng, shape),
             ChartSkeletonKind.Scatter => BuildScatter(rng, shape),
             ChartSkeletonKind.Grid => BuildHeatmap(rng, shape),
+            ChartSkeletonKind.Radar => BuildRadar(rng, shape),
+            ChartSkeletonKind.Sankey => BuildSankey(rng),
+            ChartSkeletonKind.Graph => BuildGraph(rng),
+            ChartSkeletonKind.Tree => BuildTree(rng),
+            ChartSkeletonKind.Parallel => BuildParallel(rng, shape),
+            ChartSkeletonKind.Funnel => BuildFunnel(rng, shape),
+            ChartSkeletonKind.Gauge => BuildGauge(rng),
+            ChartSkeletonKind.Polar => BuildPolar(rng, shape),
+            ChartSkeletonKind.Candlestick => BuildCandlestick(rng, shape),
             _ => BuildBars(rng, shape)
         };
     }
@@ -118,8 +127,8 @@ internal static class ChartPlaceholderFactory
             Color = MutedPalette,
             Grid = new EChartGrid { Left = "3%", Right = "4%", Bottom = "8%", Top = "14%", ContainLabel = true },
             Legend = BuildLegendHint(seriesCount),
-            XAxis = new() { new EChartAxis { Type = "category", Data = CategoryLabels(categories), AxisLabel = new() { Color = "transparent" } } },
-            YAxis = new() { new EChartAxis { Type = "value", AxisLabel = new() { Color = "transparent" } } },
+            XAxis = new() { new EChartAxis { Type = "category", Data = CategoryLabels(categories), AxisLabel = SkeletonBoxAxisLabel() } },
+            YAxis = new() { new EChartAxis { Type = "value", AxisLabel = SkeletonBoxAxisLabel() } },
             Series = series
         };
     }
@@ -163,8 +172,8 @@ internal static class ChartPlaceholderFactory
             Color = MutedPalette,
             Grid = new EChartGrid { Left = "3%", Right = "4%", Bottom = "8%", Top = "14%", ContainLabel = true },
             Legend = BuildLegendHint(seriesCount),
-            XAxis = new() { new EChartAxis { Type = "category", Data = CategoryLabels(categories), BoundaryGap = false, AxisLabel = new() { Color = "transparent" } } },
-            YAxis = new() { new EChartAxis { Type = "value", AxisLabel = new() { Color = "transparent" } } },
+            XAxis = new() { new EChartAxis { Type = "category", Data = CategoryLabels(categories), BoundaryGap = false, AxisLabel = SkeletonBoxAxisLabel() } },
+            YAxis = new() { new EChartAxis { Type = "value", AxisLabel = SkeletonBoxAxisLabel() } },
             Series = series
         };
     }
@@ -216,8 +225,8 @@ internal static class ChartPlaceholderFactory
             Color = MutedPalette,
             Grid = new EChartGrid { Left = "3%", Right = "4%", Bottom = "8%", Top = "14%", ContainLabel = true },
             Legend = BuildLegendHint(1),
-            XAxis = new() { new EChartAxis { Type = "value", AxisLabel = new() { Color = "transparent" } } },
-            YAxis = new() { new EChartAxis { Type = "value", AxisLabel = new() { Color = "transparent" } } },
+            XAxis = new() { new EChartAxis { Type = "value", AxisLabel = SkeletonBoxAxisLabel() } },
+            YAxis = new() { new EChartAxis { Type = "value", AxisLabel = SkeletonBoxAxisLabel() } },
             Series = new()
             {
                 new EChartSeries { Name = "·", Type = "scatter", Data = pts, SymbolSize = 12 }
@@ -243,8 +252,8 @@ internal static class ChartPlaceholderFactory
         {
             Color = MutedPalette,
             Grid = new EChartGrid { Left = "3%", Right = "4%", Bottom = "8%", Top = "14%", ContainLabel = true },
-            XAxis = new() { new EChartAxis { Type = "category", Data = CategoryLabels(cols), AxisLabel = new() { Color = "transparent" } } },
-            YAxis = new() { new EChartAxis { Type = "category", Data = CategoryLabels(rows), AxisLabel = new() { Color = "transparent" } } },
+            XAxis = new() { new EChartAxis { Type = "category", Data = CategoryLabels(cols), AxisLabel = SkeletonBoxAxisLabel() } },
+            YAxis = new() { new EChartAxis { Type = "category", Data = CategoryLabels(rows), AxisLabel = SkeletonBoxAxisLabel() } },
             VisualMap = new EChartVisualMap
             {
                 Min = 0,
@@ -259,6 +268,23 @@ internal static class ChartPlaceholderFactory
         };
     }
 
+    // Muted box color for axis/legend skeleton rectangles — a shade lighter than series bars
+    // so the "text boxes" don't compete with the data but still read as placeholders.
+    private const string SkeletonBoxColor = "rgba(148, 163, 184, 0.35)";
+
+    /// <summary>Axis label styled as a skeleton box — label text is transparent but the
+    /// label's backgroundColor / padding / borderRadius draw a muted rectangle. Width
+    /// tuned for typical tick labels; consumers can override if needed.</summary>
+    private static EChartAxisLabel SkeletonBoxAxisLabel(int width = 22, int height = 8) => new()
+    {
+        Color = "transparent",
+        BackgroundColor = SkeletonBoxColor,
+        Padding = new[] { 0, 0, 0, 0 },
+        BorderRadius = 2,
+        Width = width,
+        Height = height
+    };
+
     private static EChartLegend BuildLegendHint(int entries)
     {
         var data = new List<string>(entries);
@@ -267,7 +293,341 @@ internal static class ChartPlaceholderFactory
         {
             Data = data,
             Top = "3%",
-            TextStyle = new() { Color = "transparent" }
+            // Transparent text + muted pill per legend item reads as "loading legend entries".
+            TextStyle = new()
+            {
+                Color = "transparent",
+                BackgroundColor = SkeletonBoxColor,
+                BorderRadius = 3,
+                Width = 28,
+                Height = 8
+            }
+        };
+    }
+
+    // ---- dedicated phantom builders for complex chart types ----
+
+    private static EChartOption BuildRadar(Random rng, PhantomShape shape)
+    {
+        int dims = 5;
+        var indicators = new List<EChartRadarIndicator>(dims);
+        for (int i = 0; i < dims; i++) indicators.Add(new EChartRadarIndicator { Name = " ", Max = 100 });
+
+        int seriesCount = Math.Max(1, Math.Min(3, shape.SeriesCount));
+        var radarData = new List<EChartRadarData>(seriesCount);
+        for (int s = 0; s < seriesCount; s++)
+        {
+            var values = new List<double>(dims);
+            for (int i = 0; i < dims; i++) values.Add(Math.Round(30 + rng.NextDouble() * 60, 1));
+            radarData.Add(new EChartRadarData { Name = " ", Value = values, AreaStyle = new() { Opacity = 0.18 } });
+        }
+
+        return new EChartOption
+        {
+            Color = MutedPalette,
+            Legend = BuildLegendHint(seriesCount),
+            Radar = new EChartRadar { Indicator = indicators, Shape = "polygon" },
+            Series = new()
+            {
+                new EChartSeries
+                {
+                    Name = "·",
+                    Type = "radar",
+                    Data = radarData
+                }
+            }
+        };
+    }
+
+    private static EChartOption BuildSankey(Random rng)
+    {
+        var nodes = new List<EChartSankeyNode>();
+        for (int i = 0; i < 7; i++) nodes.Add(new EChartSankeyNode { Name = $"n{i}" });
+
+        var links = new List<EChartSankeyLink>
+        {
+            new() { Source = "n0", Target = "n3", Value = Math.Round(20 + rng.NextDouble() * 30, 1) },
+            new() { Source = "n0", Target = "n4", Value = Math.Round(15 + rng.NextDouble() * 25, 1) },
+            new() { Source = "n1", Target = "n3", Value = Math.Round(10 + rng.NextDouble() * 20, 1) },
+            new() { Source = "n1", Target = "n5", Value = Math.Round(15 + rng.NextDouble() * 25, 1) },
+            new() { Source = "n2", Target = "n4", Value = Math.Round(20 + rng.NextDouble() * 30, 1) },
+            new() { Source = "n3", Target = "n6", Value = Math.Round(18 + rng.NextDouble() * 22, 1) },
+            new() { Source = "n4", Target = "n6", Value = Math.Round(15 + rng.NextDouble() * 25, 1) },
+            new() { Source = "n5", Target = "n6", Value = Math.Round(12 + rng.NextDouble() * 18, 1) },
+        };
+
+        return new EChartOption
+        {
+            Color = MutedPalette,
+            Series = new()
+            {
+                new EChartSeries
+                {
+                    Name = "·",
+                    Type = "sankey",
+                    Left = "5%",
+                    Right = "10%",
+                    Top = "5%",
+                    Bottom = "5%",
+                    Nodes = nodes,
+                    Links = links,
+                    Label = new() { Show = false },
+                    ItemStyle = new() { BorderColor = "rgba(0,0,0,0)" }
+                }
+            }
+        };
+    }
+
+    private static EChartOption BuildGraph(Random rng)
+    {
+        int nodeCount = 10;
+        var nodes = new List<EChartGraphNode>();
+        for (int i = 0; i < nodeCount; i++)
+        {
+            nodes.Add(new EChartGraphNode
+            {
+                Name = $"g{i}",
+                X = Math.Round(rng.NextDouble() * 100, 1),
+                Y = Math.Round(rng.NextDouble() * 100, 1),
+                SymbolSize = 10 + rng.Next(18)
+            });
+        }
+
+        var links = new List<EChartGraphLink>();
+        for (int i = 0; i < nodeCount - 1; i++)
+        {
+            links.Add(new EChartGraphLink { Source = $"g{i}", Target = $"g{i + 1}" });
+        }
+        for (int extra = 0; extra < 4; extra++)
+        {
+            int a = rng.Next(nodeCount), b = rng.Next(nodeCount);
+            if (a != b) links.Add(new EChartGraphLink { Source = $"g{a}", Target = $"g{b}" });
+        }
+
+        return new EChartOption
+        {
+            Color = MutedPalette,
+            Series = new()
+            {
+                new EChartSeries
+                {
+                    Name = "·",
+                    Type = "graph",
+                    Layout = "none",
+                    Nodes = nodes,
+                    Links = links,
+                    Roam = false,
+                    Label = new() { Show = false },
+                    LineStyle = new() { Width = 1, Color = "rgba(148,163,184,0.35)" }
+                }
+            }
+        };
+    }
+
+    private static EChartOption BuildTree(Random rng)
+    {
+        // 3-level tree with random branching factor.
+        var root = new EChartTreeData
+        {
+            Name = " ",
+            Children = new()
+            {
+                new() { Name = " ", Children = new()
+                {
+                    new() { Name = " " },
+                    new() { Name = " " },
+                    new() { Name = " " }
+                }},
+                new() { Name = " ", Children = new()
+                {
+                    new() { Name = " " },
+                    new() { Name = " " }
+                }},
+                new() { Name = " ", Children = new()
+                {
+                    new() { Name = " " },
+                    new() { Name = " " },
+                    new() { Name = " " }
+                }}
+            }
+        };
+
+        return new EChartOption
+        {
+            Color = MutedPalette,
+            Series = new()
+            {
+                new EChartSeries
+                {
+                    Name = "·",
+                    Type = "tree",
+                    Data = new List<EChartTreeData> { root },
+                    Orient = "LR",
+                    Left = "8%",
+                    Right = "18%",
+                    Top = "5%",
+                    Bottom = "5%",
+                    Label = new() { Show = false },
+                    LineStyle = new() { Width = 1, Color = "rgba(148,163,184,0.35)" },
+                    ItemStyle = new() { Color = "rgba(148,163,184,0.55)", BorderColor = "rgba(0,0,0,0)" }
+                }
+            }
+        };
+    }
+
+    private static EChartOption BuildParallel(Random rng, PhantomShape shape)
+    {
+        int axes = Math.Max(3, Math.Min(8, shape.Categories > 3 ? shape.Categories : 5));
+        var parallelAxis = new List<EChartParallelAxis>(axes);
+        for (int i = 0; i < axes; i++) parallelAxis.Add(new EChartParallelAxis { Dim = i, Name = " ", Min = 0, Max = 100 });
+
+        int lines = 8;
+        var data = new List<double[]>(lines);
+        for (int i = 0; i < lines; i++)
+        {
+            var row = new double[axes];
+            for (int j = 0; j < axes; j++) row[j] = Math.Round(10 + rng.NextDouble() * 80, 1);
+            data.Add(row);
+        }
+
+        return new EChartOption
+        {
+            Color = MutedPalette,
+            Parallel = new EChartParallel { Left = "6%", Right = "14%", Top = "10%", Bottom = "10%" },
+            ParallelAxis = parallelAxis,
+            Series = new()
+            {
+                new EChartSeries
+                {
+                    Name = "·",
+                    Type = "parallel",
+                    Data = data,
+                    LineStyle = new() { Width = 1, Color = "rgba(148,163,184,0.45)" }
+                }
+            }
+        };
+    }
+
+    private static EChartOption BuildFunnel(Random rng, PhantomShape shape)
+    {
+        int steps = Math.Max(3, Math.Min(6, shape.SliceCount ?? 5));
+        var data = new List<EChartPieData>(steps);
+        double value = 100;
+        for (int i = 0; i < steps; i++)
+        {
+            value = Math.Max(8, value - (10 + rng.NextDouble() * 18));
+            data.Add(new EChartPieData { Name = " ", Value = Math.Round(value, 1) });
+        }
+
+        return new EChartOption
+        {
+            Color = MutedPalette,
+            Series = new()
+            {
+                new EChartSeries
+                {
+                    Name = "·",
+                    Type = "funnel",
+                    Left = "10%",
+                    Right = "10%",
+                    Top = "8%",
+                    Bottom = "8%",
+                    Data = data,
+                    Label = new() { Show = false },
+                    ItemStyle = new() { BorderColor = "rgba(0,0,0,0)", BorderWidth = 2 }
+                }
+            }
+        };
+    }
+
+    private static EChartOption BuildGauge(Random rng)
+    {
+        double value = Math.Round(10 + rng.NextDouble() * 80, 0);
+
+        return new EChartOption
+        {
+            Color = MutedPalette,
+            Series = new()
+            {
+                new EChartSeries
+                {
+                    Name = "·",
+                    Type = "gauge",
+                    StartAngle = 210,
+                    EndAngle = -30,
+                    Min = 0,
+                    Max = 100,
+                    Progress = new EChartSeriesProgress { Show = true, Width = 10 },
+                    Pointer = new EChartPointer { Show = true },
+                    Detail = new EChartSeriesDetail { FontSize = 0, Formatter = " " },
+                    Data = new List<EChartPieData> { new() { Name = " ", Value = value } },
+                    ItemStyle = new() { Color = "rgba(148,163,184,0.55)" }
+                }
+            }
+        };
+    }
+
+    private static EChartOption BuildPolar(Random rng, PhantomShape shape)
+    {
+        int bars = Math.Max(6, Math.Min(12, shape.Categories > 0 ? shape.Categories : 8));
+        var values = new List<double>(bars);
+        for (int i = 0; i < bars; i++) values.Add(20 + rng.Next(70));
+
+        return new EChartOption
+        {
+            Color = MutedPalette,
+            Polar = new { radius = new[] { "20%", "75%" } },
+            AngleAxis = new() { new { type = "category", data = CategoryLabels(bars), axisLabel = new { color = "transparent", backgroundColor = SkeletonBoxColor, width = 18, height = 8, borderRadius = 2 } } },
+            RadiusAxis = new() { new { axisLabel = new { color = "transparent", backgroundColor = SkeletonBoxColor, width = 18, height = 8, borderRadius = 2 } } },
+            Series = new()
+            {
+                new EChartSeries
+                {
+                    Name = "·",
+                    Type = "bar",
+                    CoordinateSystem = "polar",
+                    Data = values,
+                    ItemStyle = new() { BorderRadius = 4 }
+                }
+            }
+        };
+    }
+
+    private static EChartOption BuildCandlestick(Random rng, PhantomShape shape)
+    {
+        int candles = Math.Max(8, Math.Min(40, shape.Categories > 0 ? shape.Categories : 16));
+        var data = new List<double[]>(candles);
+        double prev = 50;
+        for (int i = 0; i < candles; i++)
+        {
+            double open = prev;
+            double close = Math.Round(Math.Clamp(prev + (rng.NextDouble() - 0.5) * 18, 10, 90), 1);
+            double low = Math.Round(Math.Min(open, close) - rng.NextDouble() * 6, 1);
+            double high = Math.Round(Math.Max(open, close) + rng.NextDouble() * 6, 1);
+            data.Add(new[] { open, close, low, high });
+            prev = close;
+        }
+
+        return new EChartOption
+        {
+            Color = MutedPalette,
+            Grid = new EChartGrid { Left = "3%", Right = "4%", Bottom = "8%", Top = "10%", ContainLabel = true },
+            XAxis = new() { new EChartAxis { Type = "category", Data = CategoryLabels(candles), AxisLabel = SkeletonBoxAxisLabel() } },
+            YAxis = new() { new EChartAxis { Type = "value", AxisLabel = SkeletonBoxAxisLabel() } },
+            Series = new()
+            {
+                new EChartSeries
+                {
+                    Name = "·",
+                    Type = "candlestick",
+                    Data = data,
+                    ItemStyle = new()
+                    {
+                        Color = "rgba(148,163,184,0.55)",
+                        BorderColor = "rgba(148,163,184,0.70)"
+                    }
+                }
+            }
         };
     }
 }

--- a/src/Lumeo/UI/Chart/ChartPlaceholderFactory.cs
+++ b/src/Lumeo/UI/Chart/ChartPlaceholderFactory.cs
@@ -1,15 +1,12 @@
-using System.Text.Json;
-
 namespace Lumeo;
 
 /// <summary>
 /// Builds "phantom" ECharts options — a real chart rendered with synthesized placeholder data
-/// in a muted palette. When the consumer flips <c>IsLoading</c> off, ECharts animates the option
-/// swap from phantom → real, giving a continuous morph instead of a skeleton → chart snap.
-///
-/// The placeholder palette is intentionally flat grayscale so the handoff reads as
-/// "data just arrived" rather than "new chart type appeared". All geometry (axes, legend slots,
-/// grid padding) matches the real chart's layout so the swap doesn't shift pixels.
+/// in a muted palette. Each <c>Create(kind, tick)</c> call produces a fresh random variation
+/// seeded on <c>tick</c>, so Chart.razor can cycle through phantom frames every ~1.5s while
+/// loading — the effect reads as "incoming data" rather than a static placeholder.
+/// When <c>IsLoading</c> flips off, Chart.razor swaps to the real option with
+/// <c>notMerge=true</c> so the muted palette doesn't bleed into real colors.
 /// </summary>
 internal static class ChartPlaceholderFactory
 {
@@ -33,22 +30,25 @@ internal static class ChartPlaceholderFactory
     private static readonly List<string> PieSliceNames =
         new() { "·", "·", "·", "·" };
 
-    public static EChartOption Create(ChartSkeletonKind kind) => kind switch
+    public static EChartOption Create(ChartSkeletonKind kind, int tick = 0)
     {
-        ChartSkeletonKind.Bars => BuildBars(),
-        ChartSkeletonKind.Line => BuildLine(false),
-        ChartSkeletonKind.Area => BuildLine(true),
-        ChartSkeletonKind.Pie => BuildPie(),
-        ChartSkeletonKind.Scatter => BuildScatter(),
-        ChartSkeletonKind.Grid => BuildHeatmap(),
-        _ => BuildBars()
-    };
+        var rng = new Random(unchecked(kind.GetHashCode() * 397 ^ tick));
+        return kind switch
+        {
+            ChartSkeletonKind.Bars => BuildBars(rng),
+            ChartSkeletonKind.Line => BuildLine(rng, filled: false),
+            ChartSkeletonKind.Area => BuildLine(rng, filled: true),
+            ChartSkeletonKind.Pie => BuildPie(rng),
+            ChartSkeletonKind.Scatter => BuildScatter(rng),
+            ChartSkeletonKind.Grid => BuildHeatmap(rng),
+            _ => BuildBars(rng)
+        };
+    }
 
-    private static EChartOption BuildBars()
+    private static EChartOption BuildBars(Random rng)
     {
-        // 8 staggered heights — same silhouette as the SVG skeleton so the morph from
-        // phantom to real feels like the bars just "settled" onto actual values.
-        var values = new List<double> { 38, 62, 28, 75, 45, 88, 52, 68 };
+        var values = new List<double>(8);
+        for (int i = 0; i < 8; i++) values.Add(20 + rng.Next(80));
 
         return new EChartOption
         {
@@ -71,12 +71,24 @@ internal static class ChartPlaceholderFactory
         };
     }
 
-    private static EChartOption BuildLine(bool filled)
+    private static EChartOption BuildLine(Random rng, bool filled)
     {
-        // 3 gently curved series — matches the "multi-line skeleton" silhouette.
-        var s1 = new List<double> { 30, 38, 34, 48, 55, 62, 58, 72, 78, 85, 80, 92 };
-        var s2 = new List<double> { 22, 28, 32, 38, 42, 48, 52, 58, 62, 68, 72, 78 };
-        var s3 = new List<double> { 15, 18, 22, 28, 32, 36, 40, 44, 48, 52, 56, 60 };
+        // Each series is a gentle random-walk so consecutive phantom frames morph smoothly.
+        List<double> Walk(double start, double drift, double noise)
+        {
+            var result = new List<double>(12);
+            double value = start;
+            for (int i = 0; i < 12; i++)
+            {
+                value += drift + (rng.NextDouble() - 0.5) * noise;
+                result.Add(Math.Round(Math.Clamp(value, 5, 95), 1));
+            }
+            return result;
+        }
+
+        var s1 = Walk(30, 5, 12);
+        var s2 = Walk(22, 4, 10);
+        var s3 = Walk(15, 3, 8);
 
         EChartSeries Line(string name, List<double> data) => new()
         {
@@ -100,15 +112,18 @@ internal static class ChartPlaceholderFactory
         };
     }
 
-    private static EChartOption BuildPie()
+    private static EChartOption BuildPie(Random rng)
     {
-        var data = new List<EChartPieData>
+        // Fresh random weights each tick — slices visibly redistribute between frames.
+        var weights = new double[4];
+        double total = 0;
+        for (int i = 0; i < 4; i++) { weights[i] = 10 + rng.NextDouble() * 40; total += weights[i]; }
+
+        var data = new List<EChartPieData>();
+        for (int i = 0; i < 4; i++)
         {
-            new() { Name = PieSliceNames[0], Value = 38 },
-            new() { Name = PieSliceNames[1], Value = 28 },
-            new() { Name = PieSliceNames[2], Value = 20 },
-            new() { Name = PieSliceNames[3], Value = 14 },
-        };
+            data.Add(new EChartPieData { Name = PieSliceNames[i], Value = Math.Round(weights[i] / total * 100, 1) });
+        }
 
         return new EChartOption
         {
@@ -130,17 +145,13 @@ internal static class ChartPlaceholderFactory
         };
     }
 
-    private static EChartOption BuildScatter()
+    private static EChartOption BuildScatter(Random rng)
     {
-        // 20 seeded positions — stable across renders so the morph to real data is smooth.
-        var pts = new List<double[]>
+        var pts = new List<double[]>(20);
+        for (int i = 0; i < 20; i++)
         {
-            new[] { 12.0, 44 }, new[] { 18.0, 38 }, new[] { 22.0, 52 }, new[] { 28.0, 48 },
-            new[] { 33.0, 60 }, new[] { 38.0, 55 }, new[] { 44.0, 68 }, new[] { 50.0, 62 },
-            new[] { 55.0, 74 }, new[] { 60.0, 70 }, new[] { 66.0, 82 }, new[] { 72.0, 78 },
-            new[] { 77.0, 85 }, new[] { 82.0, 80 }, new[] { 88.0, 92 }, new[] { 15.0, 62 },
-            new[] { 30.0, 40 }, new[] { 48.0, 50 }, new[] { 65.0, 58 }, new[] { 80.0, 68 },
-        };
+            pts.Add(new[] { Math.Round(5 + rng.NextDouble() * 90, 1), Math.Round(10 + rng.NextDouble() * 85, 1) });
+        }
 
         return new EChartOption
         {
@@ -156,17 +167,14 @@ internal static class ChartPlaceholderFactory
         };
     }
 
-    private static EChartOption BuildHeatmap()
+    private static EChartOption BuildHeatmap(Random rng)
     {
-        // 8×5 grid of values — heatmap placeholder works for CalendarHeatmap + Heatmap kinds.
         var points = new List<int[]>();
-        int seed = 0;
         for (int x = 0; x < 8; x++)
         {
             for (int y = 0; y < 5; y++)
             {
-                seed = (seed * 1103515245 + 12345) & 0x7fffffff;
-                points.Add(new[] { x, y, 20 + seed % 60 });
+                points.Add(new[] { x, y, 15 + rng.Next(75) });
             }
         }
 
@@ -197,7 +205,5 @@ internal static class ChartPlaceholderFactory
         TextStyle = new() { Color = "transparent" }
     };
 
-    /// <summary>Serializes a placeholder option to JSON — callers pass this directly to
-    /// ECharts via <c>updateChart</c> so the option-swap animation fires.</summary>
-    public static string CreateJson(ChartSkeletonKind kind) => Create(kind).ToJson();
+    public static string CreateJson(ChartSkeletonKind kind, int tick = 0) => Create(kind, tick).ToJson();
 }

--- a/src/Lumeo/UI/Chart/ChartPlaceholderFactory.cs
+++ b/src/Lumeo/UI/Chart/ChartPlaceholderFactory.cs
@@ -1,17 +1,27 @@
 namespace Lumeo;
 
+/// <summary>Describes the layout the phantom should mimic — the real chart's category count,
+/// number of series, stacking, etc. When absent, defaults per chart kind are used.</summary>
+public sealed record PhantomShape
+{
+    public int Categories { get; init; } = 8;
+    public int SeriesCount { get; init; } = 1;
+    public bool Stacked { get; init; }
+    public bool FilledArea { get; init; }
+    /// <summary>For pie/donut/funnel: slice count overrides <see cref="Categories"/>.</summary>
+    public int? SliceCount { get; init; }
+}
+
 /// <summary>
 /// Builds "phantom" ECharts options — a real chart rendered with synthesized placeholder data
-/// in a muted palette. Each <c>Create(kind, tick)</c> call produces a fresh random variation
-/// seeded on <c>tick</c>, so Chart.razor can cycle through phantom frames every ~1.5s while
-/// loading — the effect reads as "incoming data" rather than a static placeholder.
-/// When <c>IsLoading</c> flips off, Chart.razor swaps to the real option with
-/// <c>notMerge=true</c> so the muted palette doesn't bleed into real colors.
+/// in a muted palette. Each <c>Create(kind, tick, shape)</c> produces a fresh random variation
+/// seeded on <c>tick</c> so Chart.razor can cycle through frames every ~1.4s while loading.
+/// When a <see cref="PhantomShape"/> is supplied, the placeholder mirrors the real chart's
+/// structure (same category count, same number of series, matching stack mode) — so the
+/// phantom looks like the real thing with randomized values.
 /// </summary>
 internal static class ChartPlaceholderFactory
 {
-    // Muted palette — flat slate with decreasing opacity per series. Picked to look
-    // intentionally "loading" on light AND dark themes without theme-token gymnastics.
     private static readonly List<string> MutedPalette = new()
     {
         "rgba(148, 163, 184, 0.55)",
@@ -21,64 +31,109 @@ internal static class ChartPlaceholderFactory
         "rgba(148, 163, 184, 0.14)",
     };
 
-    private static readonly List<string> BarsCategories =
-        new() { "A", "B", "C", "D", "E", "F", "G", "H" };
-
-    private static readonly List<string> LineCategories =
-        new() { "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12" };
-
-    private static readonly List<string> PieSliceNames =
-        new() { "·", "·", "·", "·" };
-
-    public static EChartOption Create(ChartSkeletonKind kind, int tick = 0)
+    /// <summary>Derive a <see cref="PhantomShape"/> from the real chart option so the phantom
+    /// mirrors the actual layout (category count, series count, stacking, area fill).</summary>
+    public static PhantomShape? InferShape(EChartOption? option)
     {
-        var rng = new Random(unchecked(kind.GetHashCode() * 397 ^ tick));
-        return kind switch
+        if (option is null) return null;
+
+        int categories = option.XAxis?.FirstOrDefault()?.Data?.Count
+                         ?? option.YAxis?.FirstOrDefault()?.Data?.Count
+                         ?? 0;
+        int seriesCount = option.Series?.Count ?? 0;
+        bool stacked = option.Series?.Any(s => !string.IsNullOrEmpty(s.Stack)) ?? false;
+        bool filled = option.Series?.Any(s => s.AreaStyle is not null) ?? false;
+
+        int? sliceCount = null;
+        var firstSeries = option.Series?.FirstOrDefault();
+        if (firstSeries?.Type is "pie" or "funnel" or "rosetype")
         {
-            ChartSkeletonKind.Bars => BuildBars(rng),
-            ChartSkeletonKind.Line => BuildLine(rng, filled: false),
-            ChartSkeletonKind.Area => BuildLine(rng, filled: true),
-            ChartSkeletonKind.Pie => BuildPie(rng),
-            ChartSkeletonKind.Scatter => BuildScatter(rng),
-            ChartSkeletonKind.Grid => BuildHeatmap(rng),
-            _ => BuildBars(rng)
+            if (firstSeries.Data is System.Collections.ICollection coll) sliceCount = coll.Count;
+        }
+
+        if (categories == 0 && seriesCount == 0 && sliceCount is null) return null;
+
+        return new PhantomShape
+        {
+            Categories = categories > 0 ? categories : 8,
+            SeriesCount = Math.Max(1, seriesCount),
+            Stacked = stacked,
+            FilledArea = filled,
+            SliceCount = sliceCount
         };
     }
 
-    private static EChartOption BuildBars(Random rng)
+    public static EChartOption Create(ChartSkeletonKind kind, int tick = 0, PhantomShape? shape = null)
     {
-        var values = new List<double>(8);
-        for (int i = 0; i < 8; i++) values.Add(20 + rng.Next(80));
+        shape ??= new PhantomShape();
+        var rng = new Random(unchecked(kind.GetHashCode() * 397 ^ tick));
+
+        return kind switch
+        {
+            ChartSkeletonKind.Bars => BuildBars(rng, shape),
+            ChartSkeletonKind.Line => BuildLine(rng, shape, filled: shape.FilledArea),
+            ChartSkeletonKind.Area => BuildLine(rng, shape, filled: true),
+            ChartSkeletonKind.Pie => BuildPie(rng, shape),
+            ChartSkeletonKind.Scatter => BuildScatter(rng, shape),
+            ChartSkeletonKind.Grid => BuildHeatmap(rng, shape),
+            _ => BuildBars(rng, shape)
+        };
+    }
+
+    public static string CreateJson(ChartSkeletonKind kind, int tick = 0, PhantomShape? shape = null) =>
+        Create(kind, tick, shape).ToJson();
+
+    // ---- builders ----
+
+    private static List<string> CategoryLabels(int count)
+    {
+        var list = new List<string>(count);
+        for (int i = 0; i < count; i++) list.Add(" ");
+        return list;
+    }
+
+    private static EChartOption BuildBars(Random rng, PhantomShape shape)
+    {
+        int categories = Math.Max(2, shape.Categories);
+        int seriesCount = Math.Max(1, shape.SeriesCount);
+
+        var series = new List<EChartSeries>(seriesCount);
+        for (int s = 0; s < seriesCount; s++)
+        {
+            var values = new List<double>(categories);
+            for (int i = 0; i < categories; i++) values.Add(20 + rng.Next(80));
+            series.Add(new EChartSeries
+            {
+                Name = "·",
+                Type = "bar",
+                Data = values,
+                Stack = shape.Stacked ? "_stack_" : null,
+                BarMaxWidth = 28,
+                ItemStyle = new() { BorderRadius = 4 }
+            });
+        }
 
         return new EChartOption
         {
             Color = MutedPalette,
             Grid = new EChartGrid { Left = "3%", Right = "4%", Bottom = "8%", Top = "14%", ContainLabel = true },
-            Legend = BuildLegendHint(new() { "·", "·", "·" }),
-            XAxis = new() { new EChartAxis { Type = "category", Data = BarsCategories, AxisLabel = new() { Color = "transparent" } } },
+            Legend = BuildLegendHint(seriesCount),
+            XAxis = new() { new EChartAxis { Type = "category", Data = CategoryLabels(categories), AxisLabel = new() { Color = "transparent" } } },
             YAxis = new() { new EChartAxis { Type = "value", AxisLabel = new() { Color = "transparent" } } },
-            Series = new()
-            {
-                new EChartSeries
-                {
-                    Name = "·",
-                    Type = "bar",
-                    Data = values,
-                    BarWidth = 18,
-                    ItemStyle = new() { BorderRadius = 4 }
-                }
-            }
+            Series = series
         };
     }
 
-    private static EChartOption BuildLine(Random rng, bool filled)
+    private static EChartOption BuildLine(Random rng, PhantomShape shape, bool filled)
     {
-        // Each series is a gentle random-walk so consecutive phantom frames morph smoothly.
+        int categories = Math.Max(3, shape.Categories);
+        int seriesCount = Math.Max(1, shape.SeriesCount);
+
         List<double> Walk(double start, double drift, double noise)
         {
-            var result = new List<double>(12);
+            var result = new List<double>(categories);
             double value = start;
-            for (int i = 0; i < 12; i++)
+            for (int i = 0; i < categories; i++)
             {
                 value += drift + (rng.NextDouble() - 0.5) * noise;
                 result.Add(Math.Round(Math.Clamp(value, 5, 95), 1));
@@ -86,49 +141,51 @@ internal static class ChartPlaceholderFactory
             return result;
         }
 
-        var s1 = Walk(30, 5, 12);
-        var s2 = Walk(22, 4, 10);
-        var s3 = Walk(15, 3, 8);
-
-        EChartSeries Line(string name, List<double> data) => new()
+        var series = new List<EChartSeries>(seriesCount);
+        for (int s = 0; s < seriesCount; s++)
         {
-            Name = name,
-            Type = "line",
-            Data = data,
-            Smooth = true,
-            ShowSymbol = false,
-            LineStyle = new() { Width = 2 },
-            AreaStyle = filled ? new EChartAreaStyle { Opacity = 0.18 } : null
-        };
-
-        return new EChartOption
-        {
-            Color = MutedPalette,
-            Grid = new EChartGrid { Left = "3%", Right = "4%", Bottom = "8%", Top = "14%", ContainLabel = true },
-            Legend = BuildLegendHint(new() { "·", "·", "·" }),
-            XAxis = new() { new EChartAxis { Type = "category", Data = LineCategories, BoundaryGap = false, AxisLabel = new() { Color = "transparent" } } },
-            YAxis = new() { new EChartAxis { Type = "value", AxisLabel = new() { Color = "transparent" } } },
-            Series = new() { Line("·1", s1), Line("·2", s2), Line("·3", s3) }
-        };
-    }
-
-    private static EChartOption BuildPie(Random rng)
-    {
-        // Fresh random weights each tick — slices visibly redistribute between frames.
-        var weights = new double[4];
-        double total = 0;
-        for (int i = 0; i < 4; i++) { weights[i] = 10 + rng.NextDouble() * 40; total += weights[i]; }
-
-        var data = new List<EChartPieData>();
-        for (int i = 0; i < 4; i++)
-        {
-            data.Add(new EChartPieData { Name = PieSliceNames[i], Value = Math.Round(weights[i] / total * 100, 1) });
+            double start = 15 + s * 10;
+            series.Add(new EChartSeries
+            {
+                Name = "·",
+                Type = "line",
+                Data = Walk(start, 3 + s, 10 + s * 2),
+                Smooth = true,
+                ShowSymbol = false,
+                Stack = shape.Stacked ? "_stack_" : null,
+                LineStyle = new() { Width = 2 },
+                AreaStyle = filled ? new EChartAreaStyle { Opacity = 0.18 } : null
+            });
         }
 
         return new EChartOption
         {
             Color = MutedPalette,
-            Legend = BuildLegendHint(PieSliceNames),
+            Grid = new EChartGrid { Left = "3%", Right = "4%", Bottom = "8%", Top = "14%", ContainLabel = true },
+            Legend = BuildLegendHint(seriesCount),
+            XAxis = new() { new EChartAxis { Type = "category", Data = CategoryLabels(categories), BoundaryGap = false, AxisLabel = new() { Color = "transparent" } } },
+            YAxis = new() { new EChartAxis { Type = "value", AxisLabel = new() { Color = "transparent" } } },
+            Series = series
+        };
+    }
+
+    private static EChartOption BuildPie(Random rng, PhantomShape shape)
+    {
+        int slices = shape.SliceCount ?? Math.Max(3, Math.Min(8, shape.Categories));
+        var weights = new double[slices];
+        double total = 0;
+        for (int i = 0; i < slices; i++) { weights[i] = 10 + rng.NextDouble() * 40; total += weights[i]; }
+
+        var data = new List<EChartPieData>(slices);
+        for (int i = 0; i < slices; i++)
+        {
+            data.Add(new EChartPieData { Name = " ", Value = Math.Round(weights[i] / total * 100, 1) });
+        }
+
+        return new EChartOption
+        {
+            Color = MutedPalette,
+            Legend = BuildLegendHint(slices),
             Series = new()
             {
                 new EChartSeries
@@ -145,10 +202,11 @@ internal static class ChartPlaceholderFactory
         };
     }
 
-    private static EChartOption BuildScatter(Random rng)
+    private static EChartOption BuildScatter(Random rng, PhantomShape shape)
     {
-        var pts = new List<double[]>(20);
-        for (int i = 0; i < 20; i++)
+        int points = Math.Max(8, Math.Min(60, shape.Categories > 8 ? shape.Categories * 2 : 20));
+        var pts = new List<double[]>(points);
+        for (int i = 0; i < points; i++)
         {
             pts.Add(new[] { Math.Round(5 + rng.NextDouble() * 90, 1), Math.Round(10 + rng.NextDouble() * 85, 1) });
         }
@@ -157,7 +215,7 @@ internal static class ChartPlaceholderFactory
         {
             Color = MutedPalette,
             Grid = new EChartGrid { Left = "3%", Right = "4%", Bottom = "8%", Top = "14%", ContainLabel = true },
-            Legend = BuildLegendHint(new() { "·" }),
+            Legend = BuildLegendHint(1),
             XAxis = new() { new EChartAxis { Type = "value", AxisLabel = new() { Color = "transparent" } } },
             YAxis = new() { new EChartAxis { Type = "value", AxisLabel = new() { Color = "transparent" } } },
             Series = new()
@@ -167,12 +225,15 @@ internal static class ChartPlaceholderFactory
         };
     }
 
-    private static EChartOption BuildHeatmap(Random rng)
+    private static EChartOption BuildHeatmap(Random rng, PhantomShape shape)
     {
-        var points = new List<int[]>();
-        for (int x = 0; x < 8; x++)
+        int cols = Math.Max(3, Math.Min(24, shape.Categories));
+        int rows = Math.Max(3, Math.Min(12, shape.SeriesCount > 1 ? shape.SeriesCount : 5));
+
+        var points = new List<int[]>(cols * rows);
+        for (int x = 0; x < cols; x++)
         {
-            for (int y = 0; y < 5; y++)
+            for (int y = 0; y < rows; y++)
             {
                 points.Add(new[] { x, y, 15 + rng.Next(75) });
             }
@@ -182,8 +243,8 @@ internal static class ChartPlaceholderFactory
         {
             Color = MutedPalette,
             Grid = new EChartGrid { Left = "3%", Right = "4%", Bottom = "8%", Top = "14%", ContainLabel = true },
-            XAxis = new() { new EChartAxis { Type = "category", Data = new() { "1", "2", "3", "4", "5", "6", "7", "8" }, AxisLabel = new() { Color = "transparent" } } },
-            YAxis = new() { new EChartAxis { Type = "category", Data = new() { "a", "b", "c", "d", "e" }, AxisLabel = new() { Color = "transparent" } } },
+            XAxis = new() { new EChartAxis { Type = "category", Data = CategoryLabels(cols), AxisLabel = new() { Color = "transparent" } } },
+            YAxis = new() { new EChartAxis { Type = "category", Data = CategoryLabels(rows), AxisLabel = new() { Color = "transparent" } } },
             VisualMap = new EChartVisualMap
             {
                 Min = 0,
@@ -198,12 +259,15 @@ internal static class ChartPlaceholderFactory
         };
     }
 
-    private static EChartLegend BuildLegendHint(List<string> data) => new()
+    private static EChartLegend BuildLegendHint(int entries)
     {
-        Data = data,
-        Top = "3%",
-        TextStyle = new() { Color = "transparent" }
-    };
-
-    public static string CreateJson(ChartSkeletonKind kind, int tick = 0) => Create(kind, tick).ToJson();
+        var data = new List<string>(entries);
+        for (int i = 0; i < entries; i++) data.Add(" ");
+        return new EChartLegend
+        {
+            Data = data,
+            Top = "3%",
+            TextStyle = new() { Color = "transparent" }
+        };
+    }
 }

--- a/src/Lumeo/UI/Chart/ChartPlaceholderFactory.cs
+++ b/src/Lumeo/UI/Chart/ChartPlaceholderFactory.cs
@@ -124,7 +124,6 @@ internal static class ChartPlaceholderFactory
 
         return new EChartOption
         {
-            Color = MutedPalette,
             Grid = new EChartGrid { Left = "3%", Right = "4%", Bottom = "8%", Top = "14%", ContainLabel = true },
             Legend = BuildLegendHint(seriesCount),
             XAxis = new() { new EChartAxis { Type = "category", Data = CategoryLabels(categories), AxisLabel = SkeletonBoxAxisLabel() } },
@@ -169,7 +168,6 @@ internal static class ChartPlaceholderFactory
 
         return new EChartOption
         {
-            Color = MutedPalette,
             Grid = new EChartGrid { Left = "3%", Right = "4%", Bottom = "8%", Top = "14%", ContainLabel = true },
             Legend = BuildLegendHint(seriesCount),
             XAxis = new() { new EChartAxis { Type = "category", Data = CategoryLabels(categories), BoundaryGap = false, AxisLabel = SkeletonBoxAxisLabel() } },
@@ -193,7 +191,6 @@ internal static class ChartPlaceholderFactory
 
         return new EChartOption
         {
-            Color = MutedPalette,
             Legend = BuildLegendHint(slices),
             Series = new()
             {
@@ -222,7 +219,6 @@ internal static class ChartPlaceholderFactory
 
         return new EChartOption
         {
-            Color = MutedPalette,
             Grid = new EChartGrid { Left = "3%", Right = "4%", Bottom = "8%", Top = "14%", ContainLabel = true },
             Legend = BuildLegendHint(1),
             XAxis = new() { new EChartAxis { Type = "value", AxisLabel = SkeletonBoxAxisLabel() } },
@@ -250,7 +246,6 @@ internal static class ChartPlaceholderFactory
 
         return new EChartOption
         {
-            Color = MutedPalette,
             Grid = new EChartGrid { Left = "3%", Right = "4%", Bottom = "8%", Top = "14%", ContainLabel = true },
             XAxis = new() { new EChartAxis { Type = "category", Data = CategoryLabels(cols), AxisLabel = SkeletonBoxAxisLabel() } },
             YAxis = new() { new EChartAxis { Type = "category", Data = CategoryLabels(rows), AxisLabel = SkeletonBoxAxisLabel() } },
@@ -324,7 +319,6 @@ internal static class ChartPlaceholderFactory
 
         return new EChartOption
         {
-            Color = MutedPalette,
             Legend = BuildLegendHint(seriesCount),
             Radar = new EChartRadar { Indicator = indicators, Shape = "polygon" },
             Series = new()
@@ -358,7 +352,6 @@ internal static class ChartPlaceholderFactory
 
         return new EChartOption
         {
-            Color = MutedPalette,
             Series = new()
             {
                 new EChartSeries
@@ -406,7 +399,6 @@ internal static class ChartPlaceholderFactory
 
         return new EChartOption
         {
-            Color = MutedPalette,
             Series = new()
             {
                 new EChartSeries
@@ -417,8 +409,7 @@ internal static class ChartPlaceholderFactory
                     Nodes = nodes,
                     Links = links,
                     Roam = false,
-                    Label = new() { Show = false },
-                    LineStyle = new() { Width = 1, Color = "rgba(148,163,184,0.35)" }
+                    Label = new() { Show = false }
                 }
             }
         };
@@ -454,7 +445,6 @@ internal static class ChartPlaceholderFactory
 
         return new EChartOption
         {
-            Color = MutedPalette,
             Series = new()
             {
                 new EChartSeries
@@ -467,9 +457,7 @@ internal static class ChartPlaceholderFactory
                     Right = "18%",
                     Top = "5%",
                     Bottom = "5%",
-                    Label = new() { Show = false },
-                    LineStyle = new() { Width = 1, Color = "rgba(148,163,184,0.35)" },
-                    ItemStyle = new() { Color = "rgba(148,163,184,0.55)", BorderColor = "rgba(0,0,0,0)" }
+                    Label = new() { Show = false }
                 }
             }
         };
@@ -492,7 +480,6 @@ internal static class ChartPlaceholderFactory
 
         return new EChartOption
         {
-            Color = MutedPalette,
             Parallel = new EChartParallel { Left = "6%", Right = "14%", Top = "10%", Bottom = "10%" },
             ParallelAxis = parallelAxis,
             Series = new()
@@ -501,8 +488,7 @@ internal static class ChartPlaceholderFactory
                 {
                     Name = "·",
                     Type = "parallel",
-                    Data = data,
-                    LineStyle = new() { Width = 1, Color = "rgba(148,163,184,0.45)" }
+                    Data = data
                 }
             }
         };
@@ -521,7 +507,6 @@ internal static class ChartPlaceholderFactory
 
         return new EChartOption
         {
-            Color = MutedPalette,
             Series = new()
             {
                 new EChartSeries
@@ -546,7 +531,6 @@ internal static class ChartPlaceholderFactory
 
         return new EChartOption
         {
-            Color = MutedPalette,
             Series = new()
             {
                 new EChartSeries
@@ -560,8 +544,7 @@ internal static class ChartPlaceholderFactory
                     Progress = new EChartSeriesProgress { Show = true, Width = 10 },
                     Pointer = new EChartPointer { Show = true },
                     Detail = new EChartSeriesDetail { FontSize = 0, Formatter = " " },
-                    Data = new List<EChartPieData> { new() { Name = " ", Value = value } },
-                    ItemStyle = new() { Color = "rgba(148,163,184,0.55)" }
+                    Data = new List<EChartPieData> { new() { Name = " ", Value = value } }
                 }
             }
         };
@@ -575,7 +558,6 @@ internal static class ChartPlaceholderFactory
 
         return new EChartOption
         {
-            Color = MutedPalette,
             Polar = new { radius = new[] { "20%", "75%" } },
             AngleAxis = new() { new { type = "category", data = CategoryLabels(bars), axisLabel = new { color = "transparent", backgroundColor = SkeletonBoxColor, width = 18, height = 8, borderRadius = 2 } } },
             RadiusAxis = new() { new { axisLabel = new { color = "transparent", backgroundColor = SkeletonBoxColor, width = 18, height = 8, borderRadius = 2 } } },
@@ -610,7 +592,6 @@ internal static class ChartPlaceholderFactory
 
         return new EChartOption
         {
-            Color = MutedPalette,
             Grid = new EChartGrid { Left = "3%", Right = "4%", Bottom = "8%", Top = "10%", ContainLabel = true },
             XAxis = new() { new EChartAxis { Type = "category", Data = CategoryLabels(candles), AxisLabel = SkeletonBoxAxisLabel() } },
             YAxis = new() { new EChartAxis { Type = "value", AxisLabel = SkeletonBoxAxisLabel() } },
@@ -620,12 +601,7 @@ internal static class ChartPlaceholderFactory
                 {
                     Name = "·",
                     Type = "candlestick",
-                    Data = data,
-                    ItemStyle = new()
-                    {
-                        Color = "rgba(148,163,184,0.55)",
-                        BorderColor = "rgba(148,163,184,0.70)"
-                    }
+                    Data = data
                 }
             }
         };

--- a/src/Lumeo/UI/Chart/ChartSkeleton.razor
+++ b/src/Lumeo/UI/Chart/ChartSkeleton.razor
@@ -1,0 +1,97 @@
+@namespace Lumeo
+@using System.Globalization
+
+<div class="@CssClass" style="@InlineStyle" role="status" aria-live="polite" aria-label="Loading chart" data-lumeo-chart-skeleton="@Kind.ToString().ToLowerInvariant()" @attributes="AdditionalAttributes">
+    <svg class="lumeo-chart-skel-svg w-full h-full" viewBox="0 0 100 100" preserveAspectRatio="none" aria-hidden="true" focusable="false">
+        @if (Kind == ChartSkeletonKind.Bars)
+        {
+            @for (int i = 0; i < BarHeights.Length; i++)
+            {
+                var h = BarHeights[i];
+                var x = F(4 + i * (BarWidth + 2));
+                var y = F(100 - h - 4);
+                var delay = F(i * 0.12) + "s";
+                <rect class="lumeo-chart-skel-shape" x="@x" y="@y" width="@F(BarWidth)" height="@F(h)" rx="1.2" ry="1.2" fill="@MutedFill" style="animation-delay: @delay;" />
+            }
+        }
+        else if (Kind == ChartSkeletonKind.Line || Kind == ChartSkeletonKind.Area)
+        {
+            @if (Kind == ChartSkeletonKind.Area)
+            {
+                <polygon class="lumeo-chart-skel-shape" points="@(LinePoints + " 98,96 2,96")" fill="@SoftFill" />
+            }
+            <polyline class="lumeo-chart-skel-shape" points="@LinePoints" fill="none" stroke="@MutedFill" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round" vector-effect="non-scaling-stroke" />
+        }
+        else if (Kind == ChartSkeletonKind.Pie)
+        {
+            <circle class="lumeo-chart-skel-shape" cx="50" cy="50" r="30" fill="none" stroke="@MutedFill" stroke-width="14" vector-effect="non-scaling-stroke" />
+        }
+        else if (Kind == ChartSkeletonKind.Scatter)
+        {
+            @for (int i = 0; i < ScatterDots.Length; i++)
+            {
+                var (x, y, r) = ScatterDots[i];
+                <circle class="lumeo-chart-skel-shape" cx="@F(x)" cy="@F(y)" r="@F(r)" fill="@MutedFill" style="animation-delay: @(F(i * 0.07))s;" />
+            }
+        }
+        else if (Kind == ChartSkeletonKind.Grid)
+        {
+            @for (int r = 0; r < GridRows; r++)
+            {
+                @for (int c = 0; c < GridCols; c++)
+                {
+                    var x = F(4 + c * (GridCellW + 1.2));
+                    var y = F(4 + r * (GridCellH + 1.2));
+                    var delay = F(((r + c) % 5) * 0.1) + "s";
+                    var op = F(GridOpacities[(r * GridCols + c) % GridOpacities.Length]);
+                    <rect class="lumeo-chart-skel-shape" x="@x" y="@y" width="@F(GridCellW)" height="@F(GridCellH)" rx="0.6" ry="0.6" fill="@MutedFill" style="animation-delay: @delay; opacity: @op;" />
+                }
+            }
+        }
+        else
+        {
+            <rect class="lumeo-chart-skel-shape" x="6" y="6" width="88" height="88" rx="2" ry="2" fill="@SoftFill" />
+            <circle class="lumeo-chart-skel-shape" cx="50" cy="50" r="10" fill="none" stroke="@MutedFill" stroke-width="3" vector-effect="non-scaling-stroke" />
+        }
+    </svg>
+</div>
+
+@code {
+    [Parameter] public ChartSkeletonKind Kind { get; set; } = ChartSkeletonKind.Generic;
+    [Parameter] public string Width { get; set; } = "100%";
+    [Parameter] public string Height { get; set; } = "350px";
+    [Parameter] public string? Class { get; set; }
+    [Parameter(CaptureUnmatchedValues = true)] public Dictionary<string, object>? AdditionalAttributes { get; set; }
+
+    // Muted fills derive from the app's foreground token so we look right in light and
+    // dark mode alike without hard-coding colors. 10% for shapes, 6% for area fills.
+    private const string MutedFill = "color-mix(in oklab, var(--color-foreground) 10%, transparent)";
+    private const string SoftFill = "color-mix(in oklab, var(--color-foreground) 6%, transparent)";
+    private const string LinePoints = "2,72 14,48 26,62 38,34 50,54 62,28 74,46 86,22 98,40";
+
+    // Bar layout — 8 bars across 100-unit viewBox with 4px padding and 2px gaps.
+    private static readonly double[] BarHeights = { 38, 62, 48, 78, 56, 82, 44, 70 };
+    private const double BarWidth = (100 - 4 * 2 - 2 * (8 - 1)) / 8.0;
+
+    // Grid layout — 5x5 heatmap-style cells.
+    private const int GridRows = 5;
+    private const int GridCols = 5;
+    private const double GridCellW = (100 - 4 * 2 - 1.2 * (GridCols - 1)) / GridCols;
+    private const double GridCellH = (100 - 4 * 2 - 1.2 * (GridRows - 1)) / GridRows;
+    private static readonly double[] GridOpacities = { 0.4,0.7,0.5,0.9,0.55,0.8,0.45,0.65,0.35,0.75,0.6,0.5,0.85,0.4,0.7,0.55,0.95,0.45,0.6,0.8,0.5,0.7,0.4,0.65,0.55 };
+
+    // Stable pseudo-random dots for Scatter — seeded so renders are deterministic.
+    private static readonly (double X, double Y, double R)[] ScatterDots =
+    {
+        (12, 78, 2.4), (22, 62, 3.1), (18, 88, 2.0), (32, 48, 2.8), (40, 70, 2.2),
+        (48, 35, 3.0), (54, 58, 2.6), (62, 82, 2.3), (70, 40, 3.2), (76, 66, 2.5),
+        (84, 28, 2.7), (90, 52, 2.1), (28, 25, 2.9), (58, 18, 2.4), (78, 12, 2.6),
+    };
+
+    private string CssClass => $"lumeo-chart-skeleton inline-block w-full rounded-lg overflow-hidden bg-muted/30 relative {Class}".Trim();
+    private string InlineStyle => $"width: {Width}; height: {Height};";
+
+    // Invariant culture so decimals serialize with dots, not locale-specific commas —
+    // SVG attribute parsing requires `.` as the separator.
+    private static string F(double v) => v.ToString("0.##", CultureInfo.InvariantCulture);
+}

--- a/src/Lumeo/UI/Chart/ChartSkeleton.razor
+++ b/src/Lumeo/UI/Chart/ChartSkeleton.razor
@@ -30,13 +30,19 @@
         }
         else if (Kind == ChartSkeletonKind.Pie)
         {
-            @* Real 4-slice pie — each slice gets a staggered scale+opacity pulse
-               so the whole pie reads as "slices shifting" rather than a static ring. *@
+            @* Four pie wedges. Each slice pulses scale via SVG animateTransform
+               (reliable across browsers) anchored to the pie centre (50, 50),
+               with a staggered begin offset so the wedges breathe in sequence. *@
             @for (int i = 0; i < PieSlices.Length; i++)
             {
                 var d = PieSlices[i];
                 var delay = F(i * 0.18) + "s";
-                <path class="lumeo-chart-skel-shape" data-skel-shape="pie-slice" d="@d" fill="@MutedFill" style="animation-delay: @delay, @delay; transform-origin: 50px 50px;" />
+                <path class="lumeo-chart-skel-shape" data-skel-shape="pie-slice" d="@d" fill="@MutedFill" style="animation-delay: @delay;">
+                    <animateTransform attributeName="transform" type="scale" additive="sum"
+                                      values="0.8;1.05;0.8" dur="1.6s" begin="@delay" repeatCount="indefinite" />
+                    <animateTransform attributeName="transform" type="translate" additive="sum"
+                                      values="10 10;-2.5 -2.5;10 10" dur="1.6s" begin="@delay" repeatCount="indefinite" />
+                </path>
             }
         }
         else if (Kind == ChartSkeletonKind.Scatter)

--- a/src/Lumeo/UI/Chart/ChartSkeleton.razor
+++ b/src/Lumeo/UI/Chart/ChartSkeleton.razor
@@ -3,6 +3,13 @@
 
 <div class="@CssClass" style="@InlineStyle" role="status" aria-live="polite" aria-label="Loading chart" data-lumeo-chart-skeleton="@Kind.ToString().ToLowerInvariant()" @attributes="AdditionalAttributes">
     <svg class="lumeo-chart-skel-svg w-full h-full" viewBox="0 0 100 100" preserveAspectRatio="none" aria-hidden="true" focusable="false">
+        @* Subtle horizontal guide lines for chart kinds that sit on a value axis — gives the skeleton a proper "chart" feel even before the real axes appear. *@
+        @if (Kind == ChartSkeletonKind.Bars || Kind == ChartSkeletonKind.Line || Kind == ChartSkeletonKind.Area)
+        {
+            <line x1="2" y1="25" x2="98" y2="25" stroke="@GridFill" stroke-width="0.3" stroke-dasharray="1 2" vector-effect="non-scaling-stroke" />
+            <line x1="2" y1="50" x2="98" y2="50" stroke="@GridFill" stroke-width="0.3" stroke-dasharray="1 2" vector-effect="non-scaling-stroke" />
+            <line x1="2" y1="75" x2="98" y2="75" stroke="@GridFill" stroke-width="0.3" stroke-dasharray="1 2" vector-effect="non-scaling-stroke" />
+        }
         @if (Kind == ChartSkeletonKind.Bars)
         {
             @* SVG-native animate elements — guaranteed to animate height/y across browsers. *@
@@ -86,6 +93,7 @@
     // dark mode alike without hard-coding colors. 10% for shapes, 6% for area fills.
     private const string MutedFill = "color-mix(in oklab, var(--color-foreground) 10%, transparent)";
     private const string SoftFill = "color-mix(in oklab, var(--color-foreground) 6%, transparent)";
+    private const string GridFill = "color-mix(in oklab, var(--color-foreground) 8%, transparent)";
     private const string LinePoints = "2,72 14,48 26,62 38,34 50,54 62,28 74,46 86,22 98,40";
 
     // Bar layout — 8 bars across 100-unit viewBox with 4px padding and 2px gaps.

--- a/src/Lumeo/UI/Chart/ChartSkeleton.razor
+++ b/src/Lumeo/UI/Chart/ChartSkeleton.razor
@@ -11,7 +11,7 @@
                 var x = F(4 + i * (BarWidth + 2));
                 var y = F(100 - h - 4);
                 var delay = F(i * 0.12) + "s";
-                <rect class="lumeo-chart-skel-shape" x="@x" y="@y" width="@F(BarWidth)" height="@F(h)" rx="1.2" ry="1.2" fill="@MutedFill" style="animation-delay: @delay;" />
+                <rect class="lumeo-chart-skel-shape" data-skel-shape="bar" x="@x" y="@y" width="@F(BarWidth)" height="@F(h)" rx="1.2" ry="1.2" fill="@MutedFill" style="animation-delay: @delay, @delay;" />
             }
         }
         else if (Kind == ChartSkeletonKind.Line || Kind == ChartSkeletonKind.Area)
@@ -20,18 +20,18 @@
             {
                 <polygon class="lumeo-chart-skel-shape" points="@(LinePoints + " 98,96 2,96")" fill="@SoftFill" />
             }
-            <polyline class="lumeo-chart-skel-shape" points="@LinePoints" fill="none" stroke="@MutedFill" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round" vector-effect="non-scaling-stroke" />
+            <polyline class="lumeo-chart-skel-shape" data-skel-shape="line" points="@LinePoints" fill="none" stroke="@MutedFill" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round" vector-effect="non-scaling-stroke" />
         }
         else if (Kind == ChartSkeletonKind.Pie)
         {
-            <circle class="lumeo-chart-skel-shape" cx="50" cy="50" r="30" fill="none" stroke="@MutedFill" stroke-width="14" vector-effect="non-scaling-stroke" />
+            <circle class="lumeo-chart-skel-shape" data-skel-shape="pie-ring" cx="50" cy="50" r="30" fill="none" stroke="@MutedFill" stroke-width="14" stroke-linecap="round" vector-effect="non-scaling-stroke" />
         }
         else if (Kind == ChartSkeletonKind.Scatter)
         {
             @for (int i = 0; i < ScatterDots.Length; i++)
             {
                 var (x, y, r) = ScatterDots[i];
-                <circle class="lumeo-chart-skel-shape" cx="@F(x)" cy="@F(y)" r="@F(r)" fill="@MutedFill" style="animation-delay: @(F(i * 0.07))s;" />
+                <circle class="lumeo-chart-skel-shape" data-skel-shape="dot" cx="@F(x)" cy="@F(y)" r="@F(r)" fill="@MutedFill" style="animation-delay: @(F(i * 0.07))s, @(F(i * 0.07))s;" />
             }
         }
         else if (Kind == ChartSkeletonKind.Grid)

--- a/src/Lumeo/UI/Chart/ChartSkeleton.razor
+++ b/src/Lumeo/UI/Chart/ChartSkeleton.razor
@@ -33,24 +33,30 @@
             {
                 <polygon class="lumeo-chart-skel-shape" points="@(LinePoints + " 98,96 2,96")" fill="@SoftFill" />
             }
+            @* Multiple overlapping polylines read as a multi-series line chart
+               instead of a single sparse line. Each gets its own draw stagger. *@
+            <polyline class="lumeo-chart-skel-shape" data-skel-shape="line" points="@LineSecondaryPoints" fill="none" stroke="@SoftFill" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" vector-effect="non-scaling-stroke" style="animation-delay: 0.4s;" />
+            <polyline class="lumeo-chart-skel-shape" data-skel-shape="line" points="@LineTertiaryPoints" fill="none" stroke="@SoftFill" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" vector-effect="non-scaling-stroke" style="animation-delay: 0.8s;" />
             <polyline class="lumeo-chart-skel-shape" data-skel-shape="line" points="@LinePoints" fill="none" stroke="@MutedFill" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" vector-effect="non-scaling-stroke" />
         }
         else if (Kind == ChartSkeletonKind.Pie)
         {
-            @* Four pie wedges. Each slice pulses scale via SVG animateTransform
-               (reliable across browsers) anchored to the pie centre (50, 50),
-               with a staggered begin offset so the wedges breathe in sequence. *@
-            @for (int i = 0; i < PieSlices.Length; i++)
-            {
-                var d = PieSlices[i];
-                var delay = F(i * 0.18) + "s";
-                <path class="lumeo-chart-skel-shape" data-skel-shape="pie-slice" d="@d" fill="@MutedFill" style="animation-delay: @delay;">
-                    <animateTransform attributeName="transform" type="scale" additive="sum"
-                                      values="0.8;1.05;0.8" dur="1.6s" begin="@delay" repeatCount="indefinite" />
-                    <animateTransform attributeName="transform" type="translate" additive="sum"
-                                      values="10 10;-2.5 -2.5;10 10" dur="1.6s" begin="@delay" repeatCount="indefinite" />
-                </path>
-            }
+            @* Flat pie: 4 wedges at a fixed scale so the silhouette stays pie-shaped
+               (matches the real flat pie chart). We rotate the whole group slowly
+               around the centre while each slice pulses opacity at a stagger —
+               reads as 'loading' without the 3D burst the scale-out animation
+               previously implied. *@
+            <g>
+                @for (int i = 0; i < PieSlices.Length; i++)
+                {
+                    var d = PieSlices[i];
+                    var delay = F(i * 0.2) + "s";
+                    <path class="lumeo-chart-skel-shape" data-skel-shape="pie-slice" d="@d" fill="@MutedFill" style="animation-delay: @delay;" />
+                }
+                <animateTransform attributeName="transform" type="rotate"
+                                  values="0 50 50; 360 50 50"
+                                  dur="6s" repeatCount="indefinite" />
+            </g>
         }
         else if (Kind == ChartSkeletonKind.Scatter)
         {
@@ -95,6 +101,9 @@
     private const string SoftFill = "color-mix(in oklab, var(--color-foreground) 6%, transparent)";
     private const string GridFill = "color-mix(in oklab, var(--color-foreground) 8%, transparent)";
     private const string LinePoints = "2,72 14,48 26,62 38,34 50,54 62,28 74,46 86,22 98,40";
+    // Two secondary lines offset so the skeleton reads as multi-series, not a lone line.
+    private const string LineSecondaryPoints = "2,55 14,70 26,58 38,52 50,68 62,50 74,64 86,56 98,66";
+    private const string LineTertiaryPoints  = "2,82 14,78 26,80 38,72 50,84 62,76 74,82 86,74 98,78";
 
     // Bar layout — 8 bars across 100-unit viewBox with 4px padding and 2px gaps.
     private static readonly double[] BarHeights = { 38, 62, 48, 78, 56, 82, 44, 70 };

--- a/src/Lumeo/UI/Chart/ChartSkeleton.razor
+++ b/src/Lumeo/UI/Chart/ChartSkeleton.razor
@@ -5,13 +5,19 @@
     <svg class="lumeo-chart-skel-svg w-full h-full" viewBox="0 0 100 100" preserveAspectRatio="none" aria-hidden="true" focusable="false">
         @if (Kind == ChartSkeletonKind.Bars)
         {
+            @* SVG-native animate elements — guaranteed to animate height/y across browsers. *@
             @for (int i = 0; i < BarHeights.Length; i++)
             {
                 var h = BarHeights[i];
+                var minH = h * 0.35;
                 var x = F(4 + i * (BarWidth + 2));
-                var y = F(100 - h - 4);
                 var delay = F(i * 0.12) + "s";
-                <rect class="lumeo-chart-skel-shape" data-skel-shape="bar" x="@x" y="@y" width="@F(BarWidth)" height="@F(h)" rx="1.2" ry="1.2" fill="@MutedFill" style="animation-delay: @delay, @delay;" />
+                var hValues = $"{F(h)};{F(minH)};{F(h)}";
+                var yValues = $"{F(100 - h - 4)};{F(100 - minH - 4)};{F(100 - h - 4)}";
+                <rect class="lumeo-chart-skel-shape" data-skel-shape="bar" x="@x" y="@F(100 - h - 4)" width="@F(BarWidth)" height="@F(h)" rx="1.2" ry="1.2" fill="@MutedFill" style="animation-delay: @delay;">
+                    <animate attributeName="height" values="@hValues" dur="1.6s" begin="@delay" repeatCount="indefinite" />
+                    <animate attributeName="y"      values="@yValues" dur="1.6s" begin="@delay" repeatCount="indefinite" />
+                </rect>
             }
         }
         else if (Kind == ChartSkeletonKind.Line || Kind == ChartSkeletonKind.Area)
@@ -20,11 +26,18 @@
             {
                 <polygon class="lumeo-chart-skel-shape" points="@(LinePoints + " 98,96 2,96")" fill="@SoftFill" />
             }
-            <polyline class="lumeo-chart-skel-shape" data-skel-shape="line" points="@LinePoints" fill="none" stroke="@MutedFill" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round" vector-effect="non-scaling-stroke" />
+            <polyline class="lumeo-chart-skel-shape" data-skel-shape="line" points="@LinePoints" fill="none" stroke="@MutedFill" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" vector-effect="non-scaling-stroke" />
         }
         else if (Kind == ChartSkeletonKind.Pie)
         {
-            <circle class="lumeo-chart-skel-shape" data-skel-shape="pie-ring" cx="50" cy="50" r="30" fill="none" stroke="@MutedFill" stroke-width="14" stroke-linecap="round" vector-effect="non-scaling-stroke" />
+            @* Real 4-slice pie — each slice gets a staggered scale+opacity pulse
+               so the whole pie reads as "slices shifting" rather than a static ring. *@
+            @for (int i = 0; i < PieSlices.Length; i++)
+            {
+                var d = PieSlices[i];
+                var delay = F(i * 0.18) + "s";
+                <path class="lumeo-chart-skel-shape" data-skel-shape="pie-slice" d="@d" fill="@MutedFill" style="animation-delay: @delay, @delay; transform-origin: 50px 50px;" />
+            }
         }
         else if (Kind == ChartSkeletonKind.Scatter)
         {
@@ -79,6 +92,17 @@
     private const double GridCellW = (100 - 4 * 2 - 1.2 * (GridCols - 1)) / GridCols;
     private const double GridCellH = (100 - 4 * 2 - 1.2 * (GridRows - 1)) / GridRows;
     private static readonly double[] GridOpacities = { 0.4,0.7,0.5,0.9,0.55,0.8,0.45,0.65,0.35,0.75,0.6,0.5,0.85,0.4,0.7,0.55,0.95,0.45,0.6,0.8,0.5,0.7,0.4,0.65,0.55 };
+
+    // Four pie slices covering 360° — 90° each. Pre-computed SVG arc paths
+    // centered at (50, 50) with radius 32. Each slice is a filled wedge.
+    // Arc endpoints at angles 0°, 90°, 180°, 270° = (82,50) (50,82) (18,50) (50,18).
+    private static readonly string[] PieSlices =
+    {
+        "M 50 50 L 82 50 A 32 32 0 0 1 50 82 Z",
+        "M 50 50 L 50 82 A 32 32 0 0 1 18 50 Z",
+        "M 50 50 L 18 50 A 32 32 0 0 1 50 18 Z",
+        "M 50 50 L 50 18 A 32 32 0 0 1 82 50 Z",
+    };
 
     // Stable pseudo-random dots for Scatter — seeded so renders are deterministic.
     private static readonly (double X, double Y, double R)[] ScatterDots =

--- a/src/Lumeo/UI/Chart/ChartSkeleton.razor
+++ b/src/Lumeo/UI/Chart/ChartSkeleton.razor
@@ -3,25 +3,35 @@
 
 <div class="@CssClass" style="@InlineStyle" role="status" aria-live="polite" aria-label="Loading chart" data-lumeo-chart-skeleton="@Kind.ToString().ToLowerInvariant()" @attributes="AdditionalAttributes">
     <svg class="lumeo-chart-skel-svg w-full h-full" viewBox="0 0 100 100" preserveAspectRatio="none" aria-hidden="true" focusable="false">
-        @* Subtle horizontal guide lines for chart kinds that sit on a value axis — gives the skeleton a proper "chart" feel even before the real axes appear. *@
+        @* Legend/axis hints use opacity 0.35 so they're subtle background structure.
+           Plot area matches where ECharts renders: no layout jump on swap. *@
+        @if (IsCartesian)
+        {
+            @foreach (var (x, w) in LegendPills) { <rect data-skel-axis="legend" x="@F(x)" y="5" width="@F(w)" height="3" rx="1.5" ry="1.5" fill="@MutedFill" opacity="0.35" /> }
+            @foreach (var y in YTickYs)         { <rect data-skel-axis="y" x="2" y="@F(y)" width="5" height="1.4" rx="0.4" ry="0.4" fill="@MutedFill" opacity="0.35" /> }
+            @foreach (var x in XTickXs)         { <rect data-skel-axis="x" x="@F(x)" y="92" width="8" height="1.6" rx="0.4" ry="0.4" fill="@MutedFill" opacity="0.35" /> }
+        }
+
+        @* Guide lines at 25/50/75% of inner plot area. *@
         @if (Kind == ChartSkeletonKind.Bars || Kind == ChartSkeletonKind.Line || Kind == ChartSkeletonKind.Area)
         {
-            <line x1="2" y1="25" x2="98" y2="25" stroke="@GridFill" stroke-width="0.3" stroke-dasharray="1 2" vector-effect="non-scaling-stroke" />
-            <line x1="2" y1="50" x2="98" y2="50" stroke="@GridFill" stroke-width="0.3" stroke-dasharray="1 2" vector-effect="non-scaling-stroke" />
-            <line x1="2" y1="75" x2="98" y2="75" stroke="@GridFill" stroke-width="0.3" stroke-dasharray="1 2" vector-effect="non-scaling-stroke" />
+            <line x1="10" y1="32.5" x2="98" y2="32.5" stroke="@GridFill" stroke-width="0.3" stroke-dasharray="1 2" vector-effect="non-scaling-stroke" />
+            <line x1="10" y1="51"   x2="98" y2="51"   stroke="@GridFill" stroke-width="0.3" stroke-dasharray="1 2" vector-effect="non-scaling-stroke" />
+            <line x1="10" y1="69.5" x2="98" y2="69.5" stroke="@GridFill" stroke-width="0.3" stroke-dasharray="1 2" vector-effect="non-scaling-stroke" />
         }
         @if (Kind == ChartSkeletonKind.Bars)
         {
-            @* SVG-native animate elements — guaranteed to animate height/y across browsers. *@
+            @* 8 bars inside plot area, floor at y=PlotBottom. *@
             @for (int i = 0; i < BarHeights.Length; i++)
             {
-                var h = BarHeights[i];
+                var hRatio = BarHeights[i] / 100.0;
+                var h = hRatio * PlotH;
                 var minH = h * 0.35;
-                var x = F(4 + i * (BarWidth + 2));
+                var x = F(PlotX + 1 + i * (BarWidth + 1));
                 var delay = F(i * 0.12) + "s";
                 var hValues = $"{F(h)};{F(minH)};{F(h)}";
-                var yValues = $"{F(100 - h - 4)};{F(100 - minH - 4)};{F(100 - h - 4)}";
-                <rect class="lumeo-chart-skel-shape" data-skel-shape="bar" x="@x" y="@F(100 - h - 4)" width="@F(BarWidth)" height="@F(h)" rx="1.2" ry="1.2" fill="@MutedFill" style="animation-delay: @delay;">
+                var yValues = $"{F(PlotBottom - h)};{F(PlotBottom - minH)};{F(PlotBottom - h)}";
+                <rect class="lumeo-chart-skel-shape" data-skel-shape="bar" x="@x" y="@F(PlotBottom - h)" width="@F(BarWidth)" height="@F(h)" rx="1.2" ry="1.2" fill="@MutedFill" style="animation-delay: @delay;">
                     <animate attributeName="height" values="@hValues" dur="1.6s" begin="@delay" repeatCount="indefinite" />
                     <animate attributeName="y"      values="@yValues" dur="1.6s" begin="@delay" repeatCount="indefinite" />
                 </rect>
@@ -31,31 +41,32 @@
         {
             @if (Kind == ChartSkeletonKind.Area)
             {
-                <polygon class="lumeo-chart-skel-shape" points="@(LinePoints + " 98,96 2,96")" fill="@SoftFill" />
+                <polygon class="lumeo-chart-skel-shape" points="@(LinePoints + $" {F(PlotRight)},{F(PlotBottom)} {F(PlotX)},{F(PlotBottom)}")" fill="@SoftFill" />
             }
-            @* Multiple overlapping polylines read as a multi-series line chart
-               instead of a single sparse line. Each gets its own draw stagger. *@
             <polyline class="lumeo-chart-skel-shape" data-skel-shape="line" points="@LineSecondaryPoints" fill="none" stroke="@SoftFill" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" vector-effect="non-scaling-stroke" style="animation-delay: 0.4s;" />
             <polyline class="lumeo-chart-skel-shape" data-skel-shape="line" points="@LineTertiaryPoints" fill="none" stroke="@SoftFill" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" vector-effect="non-scaling-stroke" style="animation-delay: 0.8s;" />
             <polyline class="lumeo-chart-skel-shape" data-skel-shape="line" points="@LinePoints" fill="none" stroke="@MutedFill" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" vector-effect="non-scaling-stroke" />
         }
         else if (Kind == ChartSkeletonKind.Pie)
         {
-            @* Flat pie: 4 wedges at a fixed scale so the silhouette stays pie-shaped
-               (matches the real flat pie chart). We rotate the whole group slowly
-               around the centre while each slice pulses opacity at a stagger —
-               reads as 'loading' without the 3D burst the scale-out animation
-               previously implied. *@
-            <g>
-                @for (int i = 0; i < PieSlices.Length; i++)
-                {
-                    var d = PieSlices[i];
-                    var delay = F(i * 0.2) + "s";
-                    <path class="lumeo-chart-skel-shape" data-skel-shape="pie-slice" d="@d" fill="@MutedFill" style="animation-delay: @delay;" />
-                }
-                <animateTransform attributeName="transform" type="rotate"
-                                  values="0 50 50; 360 50 50"
-                                  dur="6s" repeatCount="indefinite" />
+            @* Pie: top 10% reserves legend (3 pills), pie shifts down 5 and uses radius 26. *@
+            @foreach (var (x, w) in LegendPills) { <rect data-skel-axis="legend" x="@F(x)" y="3" width="@F(w)" height="3" rx="1.5" ry="1.5" fill="@MutedFill" opacity="0.35" /> }
+
+            @* External label-anchor lines at 45°/135°/225°/315° — radius 30 to 45 (after translate). *@
+            <g transform="translate(0 5)">
+                @foreach (var (x1, y1, x2, y2) in PieLabelLines) { <line data-skel-axis="pie-label" x1="@F(x1)" y1="@F(y1)" x2="@F(x2)" y2="@F(y2)" stroke="@MutedFill" stroke-width="0.5" opacity="0.35" vector-effect="non-scaling-stroke" /> }
+
+                <g>
+                    @for (int i = 0; i < PieSlices.Length; i++)
+                    {
+                        var d = PieSlices[i];
+                        var delay = F(i * 0.2) + "s";
+                        <path class="lumeo-chart-skel-shape" data-skel-shape="pie-slice" d="@d" fill="@MutedFill" style="animation-delay: @delay;" />
+                    }
+                    <animateTransform attributeName="transform" type="rotate"
+                                      values="0 50 50; 360 50 50"
+                                      dur="6s" repeatCount="indefinite" />
+                </g>
             </g>
         }
         else if (Kind == ChartSkeletonKind.Scatter)
@@ -63,20 +74,26 @@
             @for (int i = 0; i < ScatterDots.Length; i++)
             {
                 var (x, y, r) = ScatterDots[i];
-                <circle class="lumeo-chart-skel-shape" data-skel-shape="dot" cx="@F(x)" cy="@F(y)" r="@F(r)" fill="@MutedFill" style="animation-delay: @(F(i * 0.07))s, @(F(i * 0.07))s;" />
+                // Map dots from 0..100 space into the plot area (x 10..98, y 14..88).
+                var px = PlotX + x * (PlotW / 100.0);
+                var py = 14 + y * (PlotH / 100.0);
+                <circle class="lumeo-chart-skel-shape" data-skel-shape="dot" cx="@F(px)" cy="@F(py)" r="@F(r)" fill="@MutedFill" style="animation-delay: @(F(i * 0.07))s, @(F(i * 0.07))s;" />
             }
         }
         else if (Kind == ChartSkeletonKind.Grid)
         {
+            // Grid cells also live inside the plot area so heatmaps leave room for legend + axis ticks.
+            var cellW = (PlotW - 1.2 * (GridCols - 1)) / GridCols;
+            var cellH = (PlotH - 1.2 * (GridRows - 1)) / GridRows;
             @for (int r = 0; r < GridRows; r++)
             {
                 @for (int c = 0; c < GridCols; c++)
                 {
-                    var x = F(4 + c * (GridCellW + 1.2));
-                    var y = F(4 + r * (GridCellH + 1.2));
+                    var x = F(PlotX + c * (cellW + 1.2));
+                    var y = F(14 + r * (cellH + 1.2));
                     var delay = F(((r + c) % 5) * 0.1) + "s";
                     var op = F(GridOpacities[(r * GridCols + c) % GridOpacities.Length]);
-                    <rect class="lumeo-chart-skel-shape" x="@x" y="@y" width="@F(GridCellW)" height="@F(GridCellH)" rx="0.6" ry="0.6" fill="@MutedFill" style="animation-delay: @delay; opacity: @op;" />
+                    <rect class="lumeo-chart-skel-shape" x="@x" y="@y" width="@F(cellW)" height="@F(cellH)" rx="0.6" ry="0.6" fill="@MutedFill" style="animation-delay: @delay; opacity: @op;" />
                 }
             }
         }
@@ -95,39 +112,56 @@
     [Parameter] public string? Class { get; set; }
     [Parameter(CaptureUnmatchedValues = true)] public Dictionary<string, object>? AdditionalAttributes { get; set; }
 
-    // Muted fills derive from the app's foreground token so we look right in light and
-    // dark mode alike without hard-coding colors. 10% for shapes, 6% for area fills.
+    // Muted fills — 10%/6%/8% of the foreground token so light/dark mode both work.
     private const string MutedFill = "color-mix(in oklab, var(--color-foreground) 10%, transparent)";
     private const string SoftFill = "color-mix(in oklab, var(--color-foreground) 6%, transparent)";
     private const string GridFill = "color-mix(in oklab, var(--color-foreground) 8%, transparent)";
-    private const string LinePoints = "2,72 14,48 26,62 38,34 50,54 62,28 74,46 86,22 98,40";
-    // Two secondary lines offset so the skeleton reads as multi-series, not a lone line.
-    private const string LineSecondaryPoints = "2,55 14,70 26,58 38,52 50,68 62,50 74,64 86,56 98,66";
-    private const string LineTertiaryPoints  = "2,82 14,78 26,80 38,72 50,84 62,76 74,82 86,74 98,78";
 
-    // Bar layout — 8 bars across 100-unit viewBox with 4px padding and 2px gaps.
+    // Inner plot area (matches real ECharts render box): 10% left, 12% bottom, 14% top, 2% right padding.
+    private const double PlotX = 10;
+    private const double PlotRight = 98;
+    private const double PlotTop = 14;
+    private const double PlotBottom = 88;
+    private const double PlotW = PlotRight - PlotX;   // 88
+    private const double PlotH = PlotBottom - PlotTop; // 74
+
+    // Polylines inside plot area — percentages map into the 14..88 vertical range.
+    private static readonly string LinePoints = BuildLine(new double[] { 72, 48, 62, 34, 54, 28, 46, 22, 40 });
+    private static readonly string LineSecondaryPoints = BuildLine(new double[] { 55, 70, 58, 52, 68, 50, 64, 56, 66 });
+    private static readonly string LineTertiaryPoints  = BuildLine(new double[] { 82, 78, 80, 72, 84, 76, 82, 74, 78 });
+
+    private static string BuildLine(double[] pct)
+    {
+        var sb = new System.Text.StringBuilder();
+        for (int i = 0; i < pct.Length; i++)
+        {
+            var x = PlotX + (i / (double)(pct.Length - 1)) * PlotW;
+            var y = PlotTop + (pct[i] / 100.0) * PlotH;
+            if (i > 0) sb.Append(' ');
+            sb.Append(x.ToString("0.##", CultureInfo.InvariantCulture)).Append(',').Append(y.ToString("0.##", CultureInfo.InvariantCulture));
+        }
+        return sb.ToString();
+    }
+
+    // 8 bars, 1-unit gaps inside PlotW.
     private static readonly double[] BarHeights = { 38, 62, 48, 78, 56, 82, 44, 70 };
-    private const double BarWidth = (100 - 4 * 2 - 2 * (8 - 1)) / 8.0;
+    private const double BarWidth = (PlotW - 2 - 1 * (8 - 1)) / 8.0;
 
-    // Grid layout — 5x5 heatmap-style cells.
+    // 5x5 heatmap grid.
     private const int GridRows = 5;
     private const int GridCols = 5;
-    private const double GridCellW = (100 - 4 * 2 - 1.2 * (GridCols - 1)) / GridCols;
-    private const double GridCellH = (100 - 4 * 2 - 1.2 * (GridRows - 1)) / GridRows;
     private static readonly double[] GridOpacities = { 0.4,0.7,0.5,0.9,0.55,0.8,0.45,0.65,0.35,0.75,0.6,0.5,0.85,0.4,0.7,0.55,0.95,0.45,0.6,0.8,0.5,0.7,0.4,0.65,0.55 };
 
-    // Four pie slices covering 360° — 90° each. Pre-computed SVG arc paths
-    // centered at (50, 50) with radius 32. Each slice is a filled wedge.
-    // Arc endpoints at angles 0°, 90°, 180°, 270° = (82,50) (50,82) (18,50) (50,18).
+    // 4 pie wedges centered at (50,50), radius 26.
     private static readonly string[] PieSlices =
     {
-        "M 50 50 L 82 50 A 32 32 0 0 1 50 82 Z",
-        "M 50 50 L 50 82 A 32 32 0 0 1 18 50 Z",
-        "M 50 50 L 18 50 A 32 32 0 0 1 50 18 Z",
-        "M 50 50 L 50 18 A 32 32 0 0 1 82 50 Z",
+        "M 50 50 L 76 50 A 26 26 0 0 1 50 76 Z",
+        "M 50 50 L 50 76 A 26 26 0 0 1 24 50 Z",
+        "M 50 50 L 24 50 A 26 26 0 0 1 50 24 Z",
+        "M 50 50 L 50 24 A 26 26 0 0 1 76 50 Z",
     };
 
-    // Stable pseudo-random dots for Scatter — seeded so renders are deterministic.
+    // Seeded scatter dots (0..100 space, remapped into plot area at render).
     private static readonly (double X, double Y, double R)[] ScatterDots =
     {
         (12, 78, 2.4), (22, 62, 3.1), (18, 88, 2.0), (32, 48, 2.8), (40, 70, 2.2),
@@ -135,10 +169,28 @@
         (84, 28, 2.7), (90, 52, 2.1), (28, 25, 2.9), (58, 18, 2.4), (78, 12, 2.6),
     };
 
+    // Axis / legend hints.
+    private static readonly (double X, double W)[] LegendPills = { (32, 12), (46, 10), (58, 11) };
+    private static readonly double[] YTickYs = { 22, 40, 58, 76 };
+    private static readonly double[] XTickXs = { 14, 28, 42, 56, 70, 84 };
+    // Pie external label anchors at 45°/135°/225°/315°, r=30 → 45 relative to (50,50).
+    private static readonly (double X1, double Y1, double X2, double Y2)[] PieLabelLines =
+    {
+        (71.21, 28.79, 81.82, 18.18),
+        (28.79, 28.79, 18.18, 18.18),
+        (28.79, 71.21, 18.18, 81.82),
+        (71.21, 71.21, 81.82, 81.82),
+    };
+
+    private bool IsCartesian => Kind == ChartSkeletonKind.Bars
+                             || Kind == ChartSkeletonKind.Line
+                             || Kind == ChartSkeletonKind.Area
+                             || Kind == ChartSkeletonKind.Scatter
+                             || Kind == ChartSkeletonKind.Grid;
+
     private string CssClass => $"lumeo-chart-skeleton inline-block w-full rounded-lg overflow-hidden bg-muted/30 relative {Class}".Trim();
     private string InlineStyle => $"width: {Width}; height: {Height};";
 
-    // Invariant culture so decimals serialize with dots, not locale-specific commas —
-    // SVG attribute parsing requires `.` as the separator.
+    // Invariant culture: SVG attributes require `.` as decimal separator.
     private static string F(double v) => v.ToString("0.##", CultureInfo.InvariantCulture);
 }

--- a/src/Lumeo/UI/Chart/ChartSkeletonKind.cs
+++ b/src/Lumeo/UI/Chart/ChartSkeletonKind.cs
@@ -20,3 +20,13 @@ public enum ChartSkeletonKind
     /// <summary>Rounded rect + centered ring — fallback for Radar/Sankey/Tree/Graph/Geo/etc.</summary>
     Generic,
 }
+
+/// <summary>How the loading state is presented.
+/// Phantom = render the real chart with synthesized data in a muted palette and morph
+/// to real data via ECharts' option-change animation (default — feels continuous).
+/// Silhouette = fall back to the legacy SVG skeleton overlay.</summary>
+public enum ChartSkeletonStyle
+{
+    Phantom,
+    Silhouette,
+}

--- a/src/Lumeo/UI/Chart/ChartSkeletonKind.cs
+++ b/src/Lumeo/UI/Chart/ChartSkeletonKind.cs
@@ -1,0 +1,22 @@
+namespace Lumeo;
+
+/// <summary>Shape family for <see cref="ChartSkeleton"/>. Each value renders a different
+/// SVG silhouette that matches the shape of an actual chart, so loading states don't cause
+/// layout shift or empty whitespace flicker before ECharts mounts.</summary>
+public enum ChartSkeletonKind
+{
+    /// <summary>Row of vertical bars with staggered pulse — for Bar/Waterfall/Candlestick/BoxPlot.</summary>
+    Bars,
+    /// <summary>Zigzag polyline — for LineChart / MixedChart.</summary>
+    Line,
+    /// <summary>Zigzag polyline with filled area beneath — for AreaChart.</summary>
+    Area,
+    /// <summary>Donut ring — for Pie/Donut/Gauge/Radial/Sunburst/Funnel/Nightingale/LiquidFill.</summary>
+    Pie,
+    /// <summary>Randomised pulsing dots — for Scatter / EffectScatter.</summary>
+    Scatter,
+    /// <summary>5x5 grid with varying opacities — for Treemap/Heatmap/CalendarHeatmap.</summary>
+    Grid,
+    /// <summary>Rounded rect + centered ring — fallback for Radar/Sankey/Tree/Graph/Geo/etc.</summary>
+    Generic,
+}

--- a/src/Lumeo/UI/Chart/ChartSkeletonKind.cs
+++ b/src/Lumeo/UI/Chart/ChartSkeletonKind.cs
@@ -17,8 +17,26 @@ public enum ChartSkeletonKind
     Scatter,
     /// <summary>5x5 grid with varying opacities — for Treemap/Heatmap/CalendarHeatmap.</summary>
     Grid,
-    /// <summary>Rounded rect + centered ring — fallback for Radar/Sankey/Tree/Graph/Geo/etc.</summary>
+    /// <summary>Rounded rect + centered ring — fallback for unrecognized chart types.</summary>
     Generic,
+    /// <summary>Polygon web with radial axes — for RadarChart.</summary>
+    Radar,
+    /// <summary>Flow diagram (source → target nodes with curved links) — for SankeyChart.</summary>
+    Sankey,
+    /// <summary>Force-directed nodes + edges — for GraphChart.</summary>
+    Graph,
+    /// <summary>Branching hierarchy — for TreeChart.</summary>
+    Tree,
+    /// <summary>Parallel-coordinates lines across multiple axes — for ParallelChart.</summary>
+    Parallel,
+    /// <summary>Funnel-shaped stepped trapezoids — for FunnelChart.</summary>
+    Funnel,
+    /// <summary>Semi-circle dial with needle — for GaugeChart.</summary>
+    Gauge,
+    /// <summary>Radial bars around a polar origin — for PolarBar.</summary>
+    Polar,
+    /// <summary>OHLC-style wicks + boxes — for CandlestickChart.</summary>
+    Candlestick,
 }
 
 /// <summary>How the loading state is presented.

--- a/src/Lumeo/UI/Chart/Charts/AreaChart.razor
+++ b/src/Lumeo/UI/Chart/Charts/AreaChart.razor
@@ -1,6 +1,6 @@
 @namespace Lumeo
 
-<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" IsLoading="@IsLoading" ShowLoadingSkeleton="@ShowLoadingSkeleton" SkeletonKind="@SkeletonKind" @attributes="AdditionalAttributes" />
+<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" IsLoading="@IsLoading" ShowLoadingSkeleton="@ShowLoadingSkeleton" SkeletonKind="@SkeletonKind" SkeletonStyle="@SkeletonStyle" @attributes="AdditionalAttributes" />
 
 @code {
     [Parameter] public List<string> Categories { get; set; } = new();
@@ -23,6 +23,8 @@
     [Parameter] public bool ShowLoadingSkeleton { get; set; } = true;
     /// <summary>Shape family for the loading skeleton. Defaults to <c>ChartSkeletonKind.Area</c> for this chart type; override if you want a different silhouette.</summary>
     [Parameter] public ChartSkeletonKind SkeletonKind { get; set; } = ChartSkeletonKind.Area;
+    /// <summary>Phantom (default) renders the real chart with placeholder data and morphs to real data via ECharts' option-change animation. Silhouette falls back to the legacy SVG skeleton overlay.</summary>
+    [Parameter] public ChartSkeletonStyle SkeletonStyle { get; set; } = ChartSkeletonStyle.Phantom;
 
     [Parameter] public bool ShowDataLabels { get; set; }
     [Parameter] public string LabelPosition { get; set; } = "top";

--- a/src/Lumeo/UI/Chart/Charts/AreaChart.razor
+++ b/src/Lumeo/UI/Chart/Charts/AreaChart.razor
@@ -1,6 +1,6 @@
 @namespace Lumeo
 
-<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" IsLoading="@IsLoading" ShowLoadingSkeleton="@ShowLoadingSkeleton" SkeletonKind="@SkeletonKind" SkeletonStyle="@SkeletonStyle" @attributes="AdditionalAttributes" />
+<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" IsLoading="@IsLoading" ShowLoadingSkeleton="@ShowLoadingSkeleton" SkeletonKind="@SkeletonKind" SkeletonStyle="@SkeletonStyle" PhantomCycleMs="@PhantomCycleMs" @attributes="AdditionalAttributes" />
 
 @code {
     [Parameter] public List<string> Categories { get; set; } = new();
@@ -25,6 +25,8 @@
     [Parameter] public ChartSkeletonKind SkeletonKind { get; set; } = ChartSkeletonKind.Area;
     /// <summary>Phantom (default) renders the real chart with placeholder data and morphs to real data via ECharts' option-change animation. Silhouette falls back to the legacy SVG skeleton overlay.</summary>
     [Parameter] public ChartSkeletonStyle SkeletonStyle { get; set; } = ChartSkeletonStyle.Phantom;
+    /// <summary>Phantom-mode refresh interval in milliseconds. Lower = faster data cycling while loading. Defaults to 1400.</summary>
+    [Parameter] public int PhantomCycleMs { get; set; } = 1400;
 
     [Parameter] public bool ShowDataLabels { get; set; }
     [Parameter] public string LabelPosition { get; set; } = "top";

--- a/src/Lumeo/UI/Chart/Charts/AreaChart.razor
+++ b/src/Lumeo/UI/Chart/Charts/AreaChart.razor
@@ -1,6 +1,6 @@
 @namespace Lumeo
 
-<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" @attributes="AdditionalAttributes" />
+<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" IsLoading="@IsLoading" ShowLoadingSkeleton="@ShowLoadingSkeleton" SkeletonKind="@SkeletonKind" @attributes="AdditionalAttributes" />
 
 @code {
     [Parameter] public List<string> Categories { get; set; } = new();
@@ -17,6 +17,12 @@
     [Parameter] public string? Theme { get; set; }
     [Parameter] public string? Class { get; set; }
     [Parameter(CaptureUnmatchedValues = true)] public Dictionary<string, object>? AdditionalAttributes { get; set; }
+    /// <summary>When true, overlays a shape-aware loading skeleton on top of the chart (consumer is fetching data). Flips back to the real chart once set to false.</summary>
+    [Parameter] public bool IsLoading { get; set; }
+    /// <summary>When true (default), renders a shape-aware skeleton while the chart has not yet mounted and whenever <see cref="IsLoading"/> is true. Set to <c>false</c> to opt out.</summary>
+    [Parameter] public bool ShowLoadingSkeleton { get; set; } = true;
+    /// <summary>Shape family for the loading skeleton. Defaults to <c>ChartSkeletonKind.Area</c> for this chart type; override if you want a different silhouette.</summary>
+    [Parameter] public ChartSkeletonKind SkeletonKind { get; set; } = ChartSkeletonKind.Area;
 
     [Parameter] public bool ShowDataLabels { get; set; }
     [Parameter] public string LabelPosition { get; set; } = "top";

--- a/src/Lumeo/UI/Chart/Charts/BarChart.razor
+++ b/src/Lumeo/UI/Chart/Charts/BarChart.razor
@@ -1,6 +1,6 @@
 @namespace Lumeo
 
-<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" @attributes="AdditionalAttributes" />
+<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" IsLoading="@IsLoading" ShowLoadingSkeleton="@ShowLoadingSkeleton" SkeletonKind="@SkeletonKind" @attributes="AdditionalAttributes" />
 
 @code {
     [Parameter] public List<string> Categories { get; set; } = new();
@@ -15,6 +15,12 @@
     [Parameter] public string? Theme { get; set; }
     [Parameter] public string? Class { get; set; }
     [Parameter(CaptureUnmatchedValues = true)] public Dictionary<string, object>? AdditionalAttributes { get; set; }
+    /// <summary>When true, overlays a shape-aware loading skeleton on top of the chart (consumer is fetching data). Flips back to the real chart once set to false.</summary>
+    [Parameter] public bool IsLoading { get; set; }
+    /// <summary>When true (default), renders a shape-aware skeleton while the chart has not yet mounted and whenever <see cref="IsLoading"/> is true. Set to <c>false</c> to opt out.</summary>
+    [Parameter] public bool ShowLoadingSkeleton { get; set; } = true;
+    /// <summary>Shape family for the loading skeleton. Defaults to <c>ChartSkeletonKind.Bars</c> for this chart type; override if you want a different silhouette.</summary>
+    [Parameter] public ChartSkeletonKind SkeletonKind { get; set; } = ChartSkeletonKind.Bars;
 
     [Parameter] public bool ShowDataLabels { get; set; }
     [Parameter] public string LabelPosition { get; set; } = "top";

--- a/src/Lumeo/UI/Chart/Charts/BarChart.razor
+++ b/src/Lumeo/UI/Chart/Charts/BarChart.razor
@@ -1,6 +1,6 @@
 @namespace Lumeo
 
-<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" IsLoading="@IsLoading" ShowLoadingSkeleton="@ShowLoadingSkeleton" SkeletonKind="@SkeletonKind" @attributes="AdditionalAttributes" />
+<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" IsLoading="@IsLoading" ShowLoadingSkeleton="@ShowLoadingSkeleton" SkeletonKind="@SkeletonKind" SkeletonStyle="@SkeletonStyle" @attributes="AdditionalAttributes" />
 
 @code {
     [Parameter] public List<string> Categories { get; set; } = new();
@@ -21,6 +21,8 @@
     [Parameter] public bool ShowLoadingSkeleton { get; set; } = true;
     /// <summary>Shape family for the loading skeleton. Defaults to <c>ChartSkeletonKind.Bars</c> for this chart type; override if you want a different silhouette.</summary>
     [Parameter] public ChartSkeletonKind SkeletonKind { get; set; } = ChartSkeletonKind.Bars;
+    /// <summary>Phantom (default) renders the real chart with placeholder data and morphs to real data via ECharts' option-change animation. Silhouette falls back to the legacy SVG skeleton overlay.</summary>
+    [Parameter] public ChartSkeletonStyle SkeletonStyle { get; set; } = ChartSkeletonStyle.Phantom;
 
     [Parameter] public bool ShowDataLabels { get; set; }
     [Parameter] public string LabelPosition { get; set; } = "top";

--- a/src/Lumeo/UI/Chart/Charts/BarChart.razor
+++ b/src/Lumeo/UI/Chart/Charts/BarChart.razor
@@ -1,6 +1,6 @@
 @namespace Lumeo
 
-<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" IsLoading="@IsLoading" ShowLoadingSkeleton="@ShowLoadingSkeleton" SkeletonKind="@SkeletonKind" SkeletonStyle="@SkeletonStyle" @attributes="AdditionalAttributes" />
+<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" IsLoading="@IsLoading" ShowLoadingSkeleton="@ShowLoadingSkeleton" SkeletonKind="@SkeletonKind" SkeletonStyle="@SkeletonStyle" PhantomCycleMs="@PhantomCycleMs" @attributes="AdditionalAttributes" />
 
 @code {
     [Parameter] public List<string> Categories { get; set; } = new();
@@ -23,6 +23,8 @@
     [Parameter] public ChartSkeletonKind SkeletonKind { get; set; } = ChartSkeletonKind.Bars;
     /// <summary>Phantom (default) renders the real chart with placeholder data and morphs to real data via ECharts' option-change animation. Silhouette falls back to the legacy SVG skeleton overlay.</summary>
     [Parameter] public ChartSkeletonStyle SkeletonStyle { get; set; } = ChartSkeletonStyle.Phantom;
+    /// <summary>Phantom-mode refresh interval in milliseconds. Lower = faster data cycling while loading. Defaults to 1400.</summary>
+    [Parameter] public int PhantomCycleMs { get; set; } = 1400;
 
     [Parameter] public bool ShowDataLabels { get; set; }
     [Parameter] public string LabelPosition { get; set; } = "top";

--- a/src/Lumeo/UI/Chart/Charts/BoxPlotChart.razor
+++ b/src/Lumeo/UI/Chart/Charts/BoxPlotChart.razor
@@ -1,6 +1,6 @@
 @namespace Lumeo
 
-<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" IsLoading="@IsLoading" ShowLoadingSkeleton="@ShowLoadingSkeleton" SkeletonKind="@SkeletonKind" @attributes="AdditionalAttributes" />
+<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" IsLoading="@IsLoading" ShowLoadingSkeleton="@ShowLoadingSkeleton" SkeletonKind="@SkeletonKind" SkeletonStyle="@SkeletonStyle" @attributes="AdditionalAttributes" />
 
 @code {
     [Parameter] public List<string> Categories { get; set; } = new();
@@ -19,6 +19,8 @@
     [Parameter] public bool ShowLoadingSkeleton { get; set; } = true;
     /// <summary>Shape family for the loading skeleton. Defaults to <c>ChartSkeletonKind.Bars</c> for this chart type; override if you want a different silhouette.</summary>
     [Parameter] public ChartSkeletonKind SkeletonKind { get; set; } = ChartSkeletonKind.Bars;
+    /// <summary>Phantom (default) renders the real chart with placeholder data and morphs to real data via ECharts' option-change animation. Silhouette falls back to the legacy SVG skeleton overlay.</summary>
+    [Parameter] public ChartSkeletonStyle SkeletonStyle { get; set; } = ChartSkeletonStyle.Phantom;
 
     [Parameter] public bool ShowDataLabels { get; set; }
     [Parameter] public string LabelPosition { get; set; } = "top";

--- a/src/Lumeo/UI/Chart/Charts/BoxPlotChart.razor
+++ b/src/Lumeo/UI/Chart/Charts/BoxPlotChart.razor
@@ -1,6 +1,6 @@
 @namespace Lumeo
 
-<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" @attributes="AdditionalAttributes" />
+<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" IsLoading="@IsLoading" ShowLoadingSkeleton="@ShowLoadingSkeleton" SkeletonKind="@SkeletonKind" @attributes="AdditionalAttributes" />
 
 @code {
     [Parameter] public List<string> Categories { get; set; } = new();
@@ -13,6 +13,12 @@
     [Parameter] public string? Theme { get; set; }
     [Parameter] public string? Class { get; set; }
     [Parameter(CaptureUnmatchedValues = true)] public Dictionary<string, object>? AdditionalAttributes { get; set; }
+    /// <summary>When true, overlays a shape-aware loading skeleton on top of the chart (consumer is fetching data). Flips back to the real chart once set to false.</summary>
+    [Parameter] public bool IsLoading { get; set; }
+    /// <summary>When true (default), renders a shape-aware skeleton while the chart has not yet mounted and whenever <see cref="IsLoading"/> is true. Set to <c>false</c> to opt out.</summary>
+    [Parameter] public bool ShowLoadingSkeleton { get; set; } = true;
+    /// <summary>Shape family for the loading skeleton. Defaults to <c>ChartSkeletonKind.Bars</c> for this chart type; override if you want a different silhouette.</summary>
+    [Parameter] public ChartSkeletonKind SkeletonKind { get; set; } = ChartSkeletonKind.Bars;
 
     [Parameter] public bool ShowDataLabels { get; set; }
     [Parameter] public string LabelPosition { get; set; } = "top";

--- a/src/Lumeo/UI/Chart/Charts/BoxPlotChart.razor
+++ b/src/Lumeo/UI/Chart/Charts/BoxPlotChart.razor
@@ -1,6 +1,6 @@
 @namespace Lumeo
 
-<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" IsLoading="@IsLoading" ShowLoadingSkeleton="@ShowLoadingSkeleton" SkeletonKind="@SkeletonKind" SkeletonStyle="@SkeletonStyle" @attributes="AdditionalAttributes" />
+<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" IsLoading="@IsLoading" ShowLoadingSkeleton="@ShowLoadingSkeleton" SkeletonKind="@SkeletonKind" SkeletonStyle="@SkeletonStyle" PhantomCycleMs="@PhantomCycleMs" @attributes="AdditionalAttributes" />
 
 @code {
     [Parameter] public List<string> Categories { get; set; } = new();
@@ -21,6 +21,8 @@
     [Parameter] public ChartSkeletonKind SkeletonKind { get; set; } = ChartSkeletonKind.Bars;
     /// <summary>Phantom (default) renders the real chart with placeholder data and morphs to real data via ECharts' option-change animation. Silhouette falls back to the legacy SVG skeleton overlay.</summary>
     [Parameter] public ChartSkeletonStyle SkeletonStyle { get; set; } = ChartSkeletonStyle.Phantom;
+    /// <summary>Phantom-mode refresh interval in milliseconds. Lower = faster data cycling while loading. Defaults to 1400.</summary>
+    [Parameter] public int PhantomCycleMs { get; set; } = 1400;
 
     [Parameter] public bool ShowDataLabels { get; set; }
     [Parameter] public string LabelPosition { get; set; } = "top";

--- a/src/Lumeo/UI/Chart/Charts/CalendarHeatmapChart.razor
+++ b/src/Lumeo/UI/Chart/Charts/CalendarHeatmapChart.razor
@@ -1,6 +1,6 @@
 @namespace Lumeo
 
-<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" IsLoading="@IsLoading" ShowLoadingSkeleton="@ShowLoadingSkeleton" SkeletonKind="@SkeletonKind" @attributes="AdditionalAttributes" />
+<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" IsLoading="@IsLoading" ShowLoadingSkeleton="@ShowLoadingSkeleton" SkeletonKind="@SkeletonKind" SkeletonStyle="@SkeletonStyle" @attributes="AdditionalAttributes" />
 
 @code {
     [Parameter] public object? Data { get; set; }
@@ -20,6 +20,8 @@
     [Parameter] public bool ShowLoadingSkeleton { get; set; } = true;
     /// <summary>Shape family for the loading skeleton. Defaults to <c>ChartSkeletonKind.Grid</c> for this chart type; override if you want a different silhouette.</summary>
     [Parameter] public ChartSkeletonKind SkeletonKind { get; set; } = ChartSkeletonKind.Grid;
+    /// <summary>Phantom (default) renders the real chart with placeholder data and morphs to real data via ECharts' option-change animation. Silhouette falls back to the legacy SVG skeleton overlay.</summary>
+    [Parameter] public ChartSkeletonStyle SkeletonStyle { get; set; } = ChartSkeletonStyle.Phantom;
 
     [Parameter] public bool ShowDataLabels { get; set; }
     [Parameter] public string LabelPosition { get; set; } = "inside";

--- a/src/Lumeo/UI/Chart/Charts/CalendarHeatmapChart.razor
+++ b/src/Lumeo/UI/Chart/Charts/CalendarHeatmapChart.razor
@@ -1,6 +1,6 @@
 @namespace Lumeo
 
-<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" IsLoading="@IsLoading" ShowLoadingSkeleton="@ShowLoadingSkeleton" SkeletonKind="@SkeletonKind" SkeletonStyle="@SkeletonStyle" @attributes="AdditionalAttributes" />
+<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" IsLoading="@IsLoading" ShowLoadingSkeleton="@ShowLoadingSkeleton" SkeletonKind="@SkeletonKind" SkeletonStyle="@SkeletonStyle" PhantomCycleMs="@PhantomCycleMs" @attributes="AdditionalAttributes" />
 
 @code {
     [Parameter] public object? Data { get; set; }
@@ -22,6 +22,8 @@
     [Parameter] public ChartSkeletonKind SkeletonKind { get; set; } = ChartSkeletonKind.Grid;
     /// <summary>Phantom (default) renders the real chart with placeholder data and morphs to real data via ECharts' option-change animation. Silhouette falls back to the legacy SVG skeleton overlay.</summary>
     [Parameter] public ChartSkeletonStyle SkeletonStyle { get; set; } = ChartSkeletonStyle.Phantom;
+    /// <summary>Phantom-mode refresh interval in milliseconds. Lower = faster data cycling while loading. Defaults to 1400.</summary>
+    [Parameter] public int PhantomCycleMs { get; set; } = 1400;
 
     [Parameter] public bool ShowDataLabels { get; set; }
     [Parameter] public string LabelPosition { get; set; } = "inside";

--- a/src/Lumeo/UI/Chart/Charts/CalendarHeatmapChart.razor
+++ b/src/Lumeo/UI/Chart/Charts/CalendarHeatmapChart.razor
@@ -1,6 +1,6 @@
 @namespace Lumeo
 
-<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" @attributes="AdditionalAttributes" />
+<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" IsLoading="@IsLoading" ShowLoadingSkeleton="@ShowLoadingSkeleton" SkeletonKind="@SkeletonKind" @attributes="AdditionalAttributes" />
 
 @code {
     [Parameter] public object? Data { get; set; }
@@ -14,6 +14,12 @@
     [Parameter] public string? Theme { get; set; }
     [Parameter] public string? Class { get; set; }
     [Parameter(CaptureUnmatchedValues = true)] public Dictionary<string, object>? AdditionalAttributes { get; set; }
+    /// <summary>When true, overlays a shape-aware loading skeleton on top of the chart (consumer is fetching data). Flips back to the real chart once set to false.</summary>
+    [Parameter] public bool IsLoading { get; set; }
+    /// <summary>When true (default), renders a shape-aware skeleton while the chart has not yet mounted and whenever <see cref="IsLoading"/> is true. Set to <c>false</c> to opt out.</summary>
+    [Parameter] public bool ShowLoadingSkeleton { get; set; } = true;
+    /// <summary>Shape family for the loading skeleton. Defaults to <c>ChartSkeletonKind.Grid</c> for this chart type; override if you want a different silhouette.</summary>
+    [Parameter] public ChartSkeletonKind SkeletonKind { get; set; } = ChartSkeletonKind.Grid;
 
     [Parameter] public bool ShowDataLabels { get; set; }
     [Parameter] public string LabelPosition { get; set; } = "inside";

--- a/src/Lumeo/UI/Chart/Charts/CandlestickChart.razor
+++ b/src/Lumeo/UI/Chart/Charts/CandlestickChart.razor
@@ -17,8 +17,8 @@
     [Parameter] public bool IsLoading { get; set; }
     /// <summary>When true (default), renders a shape-aware skeleton while the chart has not yet mounted and whenever <see cref="IsLoading"/> is true. Set to <c>false</c> to opt out.</summary>
     [Parameter] public bool ShowLoadingSkeleton { get; set; } = true;
-    /// <summary>Shape family for the loading skeleton. Defaults to <c>ChartSkeletonKind.Bars</c> for this chart type; override if you want a different silhouette.</summary>
-    [Parameter] public ChartSkeletonKind SkeletonKind { get; set; } = ChartSkeletonKind.Bars;
+    /// <summary>Shape family for the loading skeleton. Defaults to <c>ChartSkeletonKind.Candlestick</c> for this chart type; override if you want a different silhouette.</summary>
+    [Parameter] public ChartSkeletonKind SkeletonKind { get; set; } = ChartSkeletonKind.Candlestick;
     /// <summary>Phantom (default) renders the real chart with placeholder data and morphs to real data via ECharts' option-change animation. Silhouette falls back to the legacy SVG skeleton overlay.</summary>
     [Parameter] public ChartSkeletonStyle SkeletonStyle { get; set; } = ChartSkeletonStyle.Phantom;
     /// <summary>Phantom-mode refresh interval in milliseconds. Lower = faster data cycling while loading. Defaults to 1400.</summary>

--- a/src/Lumeo/UI/Chart/Charts/CandlestickChart.razor
+++ b/src/Lumeo/UI/Chart/Charts/CandlestickChart.razor
@@ -1,6 +1,6 @@
 @namespace Lumeo
 
-<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" IsLoading="@IsLoading" ShowLoadingSkeleton="@ShowLoadingSkeleton" SkeletonKind="@SkeletonKind" @attributes="AdditionalAttributes" />
+<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" IsLoading="@IsLoading" ShowLoadingSkeleton="@ShowLoadingSkeleton" SkeletonKind="@SkeletonKind" SkeletonStyle="@SkeletonStyle" @attributes="AdditionalAttributes" />
 
 @code {
     [Parameter] public List<string> Categories { get; set; } = new();
@@ -19,6 +19,8 @@
     [Parameter] public bool ShowLoadingSkeleton { get; set; } = true;
     /// <summary>Shape family for the loading skeleton. Defaults to <c>ChartSkeletonKind.Bars</c> for this chart type; override if you want a different silhouette.</summary>
     [Parameter] public ChartSkeletonKind SkeletonKind { get; set; } = ChartSkeletonKind.Bars;
+    /// <summary>Phantom (default) renders the real chart with placeholder data and morphs to real data via ECharts' option-change animation. Silhouette falls back to the legacy SVG skeleton overlay.</summary>
+    [Parameter] public ChartSkeletonStyle SkeletonStyle { get; set; } = ChartSkeletonStyle.Phantom;
 
     [Parameter] public bool ShowDataLabels { get; set; }
     [Parameter] public string LabelPosition { get; set; } = "top";

--- a/src/Lumeo/UI/Chart/Charts/CandlestickChart.razor
+++ b/src/Lumeo/UI/Chart/Charts/CandlestickChart.razor
@@ -1,6 +1,6 @@
 @namespace Lumeo
 
-<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" @attributes="AdditionalAttributes" />
+<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" IsLoading="@IsLoading" ShowLoadingSkeleton="@ShowLoadingSkeleton" SkeletonKind="@SkeletonKind" @attributes="AdditionalAttributes" />
 
 @code {
     [Parameter] public List<string> Categories { get; set; } = new();
@@ -13,6 +13,12 @@
     [Parameter] public string? Theme { get; set; }
     [Parameter] public string? Class { get; set; }
     [Parameter(CaptureUnmatchedValues = true)] public Dictionary<string, object>? AdditionalAttributes { get; set; }
+    /// <summary>When true, overlays a shape-aware loading skeleton on top of the chart (consumer is fetching data). Flips back to the real chart once set to false.</summary>
+    [Parameter] public bool IsLoading { get; set; }
+    /// <summary>When true (default), renders a shape-aware skeleton while the chart has not yet mounted and whenever <see cref="IsLoading"/> is true. Set to <c>false</c> to opt out.</summary>
+    [Parameter] public bool ShowLoadingSkeleton { get; set; } = true;
+    /// <summary>Shape family for the loading skeleton. Defaults to <c>ChartSkeletonKind.Bars</c> for this chart type; override if you want a different silhouette.</summary>
+    [Parameter] public ChartSkeletonKind SkeletonKind { get; set; } = ChartSkeletonKind.Bars;
 
     [Parameter] public bool ShowDataLabels { get; set; }
     [Parameter] public string LabelPosition { get; set; } = "top";

--- a/src/Lumeo/UI/Chart/Charts/CandlestickChart.razor
+++ b/src/Lumeo/UI/Chart/Charts/CandlestickChart.razor
@@ -1,6 +1,6 @@
 @namespace Lumeo
 
-<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" IsLoading="@IsLoading" ShowLoadingSkeleton="@ShowLoadingSkeleton" SkeletonKind="@SkeletonKind" SkeletonStyle="@SkeletonStyle" @attributes="AdditionalAttributes" />
+<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" IsLoading="@IsLoading" ShowLoadingSkeleton="@ShowLoadingSkeleton" SkeletonKind="@SkeletonKind" SkeletonStyle="@SkeletonStyle" PhantomCycleMs="@PhantomCycleMs" @attributes="AdditionalAttributes" />
 
 @code {
     [Parameter] public List<string> Categories { get; set; } = new();
@@ -21,6 +21,8 @@
     [Parameter] public ChartSkeletonKind SkeletonKind { get; set; } = ChartSkeletonKind.Bars;
     /// <summary>Phantom (default) renders the real chart with placeholder data and morphs to real data via ECharts' option-change animation. Silhouette falls back to the legacy SVG skeleton overlay.</summary>
     [Parameter] public ChartSkeletonStyle SkeletonStyle { get; set; } = ChartSkeletonStyle.Phantom;
+    /// <summary>Phantom-mode refresh interval in milliseconds. Lower = faster data cycling while loading. Defaults to 1400.</summary>
+    [Parameter] public int PhantomCycleMs { get; set; } = 1400;
 
     [Parameter] public bool ShowDataLabels { get; set; }
     [Parameter] public string LabelPosition { get; set; } = "top";

--- a/src/Lumeo/UI/Chart/Charts/DonutChart.razor
+++ b/src/Lumeo/UI/Chart/Charts/DonutChart.razor
@@ -1,6 +1,6 @@
 @namespace Lumeo
 
-<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" IsLoading="@IsLoading" ShowLoadingSkeleton="@ShowLoadingSkeleton" SkeletonKind="@SkeletonKind" @attributes="AdditionalAttributes" />
+<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" IsLoading="@IsLoading" ShowLoadingSkeleton="@ShowLoadingSkeleton" SkeletonKind="@SkeletonKind" SkeletonStyle="@SkeletonStyle" @attributes="AdditionalAttributes" />
 
 @code {
     [Parameter] public List<DonutChartData> Data { get; set; } = new();
@@ -22,6 +22,8 @@
     [Parameter] public bool ShowLoadingSkeleton { get; set; } = true;
     /// <summary>Shape family for the loading skeleton. Defaults to <c>ChartSkeletonKind.Pie</c> for this chart type; override if you want a different silhouette.</summary>
     [Parameter] public ChartSkeletonKind SkeletonKind { get; set; } = ChartSkeletonKind.Pie;
+    /// <summary>Phantom (default) renders the real chart with placeholder data and morphs to real data via ECharts' option-change animation. Silhouette falls back to the legacy SVG skeleton overlay.</summary>
+    [Parameter] public ChartSkeletonStyle SkeletonStyle { get; set; } = ChartSkeletonStyle.Phantom;
 
     [Parameter] public bool ShowDataLabels { get; set; }
     [Parameter] public string LabelPosition { get; set; } = "outside";

--- a/src/Lumeo/UI/Chart/Charts/DonutChart.razor
+++ b/src/Lumeo/UI/Chart/Charts/DonutChart.razor
@@ -1,6 +1,6 @@
 @namespace Lumeo
 
-<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" IsLoading="@IsLoading" ShowLoadingSkeleton="@ShowLoadingSkeleton" SkeletonKind="@SkeletonKind" SkeletonStyle="@SkeletonStyle" @attributes="AdditionalAttributes" />
+<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" IsLoading="@IsLoading" ShowLoadingSkeleton="@ShowLoadingSkeleton" SkeletonKind="@SkeletonKind" SkeletonStyle="@SkeletonStyle" PhantomCycleMs="@PhantomCycleMs" @attributes="AdditionalAttributes" />
 
 @code {
     [Parameter] public List<DonutChartData> Data { get; set; } = new();
@@ -24,6 +24,8 @@
     [Parameter] public ChartSkeletonKind SkeletonKind { get; set; } = ChartSkeletonKind.Pie;
     /// <summary>Phantom (default) renders the real chart with placeholder data and morphs to real data via ECharts' option-change animation. Silhouette falls back to the legacy SVG skeleton overlay.</summary>
     [Parameter] public ChartSkeletonStyle SkeletonStyle { get; set; } = ChartSkeletonStyle.Phantom;
+    /// <summary>Phantom-mode refresh interval in milliseconds. Lower = faster data cycling while loading. Defaults to 1400.</summary>
+    [Parameter] public int PhantomCycleMs { get; set; } = 1400;
 
     [Parameter] public bool ShowDataLabels { get; set; }
     [Parameter] public string LabelPosition { get; set; } = "outside";

--- a/src/Lumeo/UI/Chart/Charts/DonutChart.razor
+++ b/src/Lumeo/UI/Chart/Charts/DonutChart.razor
@@ -1,6 +1,6 @@
 @namespace Lumeo
 
-<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" @attributes="AdditionalAttributes" />
+<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" IsLoading="@IsLoading" ShowLoadingSkeleton="@ShowLoadingSkeleton" SkeletonKind="@SkeletonKind" @attributes="AdditionalAttributes" />
 
 @code {
     [Parameter] public List<DonutChartData> Data { get; set; } = new();
@@ -16,6 +16,12 @@
     [Parameter] public string? Theme { get; set; }
     [Parameter] public string? Class { get; set; }
     [Parameter(CaptureUnmatchedValues = true)] public Dictionary<string, object>? AdditionalAttributes { get; set; }
+    /// <summary>When true, overlays a shape-aware loading skeleton on top of the chart (consumer is fetching data). Flips back to the real chart once set to false.</summary>
+    [Parameter] public bool IsLoading { get; set; }
+    /// <summary>When true (default), renders a shape-aware skeleton while the chart has not yet mounted and whenever <see cref="IsLoading"/> is true. Set to <c>false</c> to opt out.</summary>
+    [Parameter] public bool ShowLoadingSkeleton { get; set; } = true;
+    /// <summary>Shape family for the loading skeleton. Defaults to <c>ChartSkeletonKind.Pie</c> for this chart type; override if you want a different silhouette.</summary>
+    [Parameter] public ChartSkeletonKind SkeletonKind { get; set; } = ChartSkeletonKind.Pie;
 
     [Parameter] public bool ShowDataLabels { get; set; }
     [Parameter] public string LabelPosition { get; set; } = "outside";

--- a/src/Lumeo/UI/Chart/Charts/EffectScatterChart.razor
+++ b/src/Lumeo/UI/Chart/Charts/EffectScatterChart.razor
@@ -1,6 +1,6 @@
 @namespace Lumeo
 
-<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" IsLoading="@IsLoading" ShowLoadingSkeleton="@ShowLoadingSkeleton" SkeletonKind="@SkeletonKind" @attributes="AdditionalAttributes" />
+<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" IsLoading="@IsLoading" ShowLoadingSkeleton="@ShowLoadingSkeleton" SkeletonKind="@SkeletonKind" SkeletonStyle="@SkeletonStyle" @attributes="AdditionalAttributes" />
 
 @code {
     [Parameter] public List<EffectScatterSeriesData> Series { get; set; } = new();
@@ -18,6 +18,8 @@
     [Parameter] public bool ShowLoadingSkeleton { get; set; } = true;
     /// <summary>Shape family for the loading skeleton. Defaults to <c>ChartSkeletonKind.Scatter</c> for this chart type; override if you want a different silhouette.</summary>
     [Parameter] public ChartSkeletonKind SkeletonKind { get; set; } = ChartSkeletonKind.Scatter;
+    /// <summary>Phantom (default) renders the real chart with placeholder data and morphs to real data via ECharts' option-change animation. Silhouette falls back to the legacy SVG skeleton overlay.</summary>
+    [Parameter] public ChartSkeletonStyle SkeletonStyle { get; set; } = ChartSkeletonStyle.Phantom;
 
     [Parameter] public bool ShowDataLabels { get; set; }
     [Parameter] public string LabelPosition { get; set; } = "top";

--- a/src/Lumeo/UI/Chart/Charts/EffectScatterChart.razor
+++ b/src/Lumeo/UI/Chart/Charts/EffectScatterChart.razor
@@ -1,6 +1,6 @@
 @namespace Lumeo
 
-<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" IsLoading="@IsLoading" ShowLoadingSkeleton="@ShowLoadingSkeleton" SkeletonKind="@SkeletonKind" SkeletonStyle="@SkeletonStyle" @attributes="AdditionalAttributes" />
+<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" IsLoading="@IsLoading" ShowLoadingSkeleton="@ShowLoadingSkeleton" SkeletonKind="@SkeletonKind" SkeletonStyle="@SkeletonStyle" PhantomCycleMs="@PhantomCycleMs" @attributes="AdditionalAttributes" />
 
 @code {
     [Parameter] public List<EffectScatterSeriesData> Series { get; set; } = new();
@@ -20,6 +20,8 @@
     [Parameter] public ChartSkeletonKind SkeletonKind { get; set; } = ChartSkeletonKind.Scatter;
     /// <summary>Phantom (default) renders the real chart with placeholder data and morphs to real data via ECharts' option-change animation. Silhouette falls back to the legacy SVG skeleton overlay.</summary>
     [Parameter] public ChartSkeletonStyle SkeletonStyle { get; set; } = ChartSkeletonStyle.Phantom;
+    /// <summary>Phantom-mode refresh interval in milliseconds. Lower = faster data cycling while loading. Defaults to 1400.</summary>
+    [Parameter] public int PhantomCycleMs { get; set; } = 1400;
 
     [Parameter] public bool ShowDataLabels { get; set; }
     [Parameter] public string LabelPosition { get; set; } = "top";

--- a/src/Lumeo/UI/Chart/Charts/EffectScatterChart.razor
+++ b/src/Lumeo/UI/Chart/Charts/EffectScatterChart.razor
@@ -1,6 +1,6 @@
 @namespace Lumeo
 
-<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" @attributes="AdditionalAttributes" />
+<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" IsLoading="@IsLoading" ShowLoadingSkeleton="@ShowLoadingSkeleton" SkeletonKind="@SkeletonKind" @attributes="AdditionalAttributes" />
 
 @code {
     [Parameter] public List<EffectScatterSeriesData> Series { get; set; } = new();
@@ -12,6 +12,12 @@
     [Parameter] public string? Theme { get; set; }
     [Parameter] public string? Class { get; set; }
     [Parameter(CaptureUnmatchedValues = true)] public Dictionary<string, object>? AdditionalAttributes { get; set; }
+    /// <summary>When true, overlays a shape-aware loading skeleton on top of the chart (consumer is fetching data). Flips back to the real chart once set to false.</summary>
+    [Parameter] public bool IsLoading { get; set; }
+    /// <summary>When true (default), renders a shape-aware skeleton while the chart has not yet mounted and whenever <see cref="IsLoading"/> is true. Set to <c>false</c> to opt out.</summary>
+    [Parameter] public bool ShowLoadingSkeleton { get; set; } = true;
+    /// <summary>Shape family for the loading skeleton. Defaults to <c>ChartSkeletonKind.Scatter</c> for this chart type; override if you want a different silhouette.</summary>
+    [Parameter] public ChartSkeletonKind SkeletonKind { get; set; } = ChartSkeletonKind.Scatter;
 
     [Parameter] public bool ShowDataLabels { get; set; }
     [Parameter] public string LabelPosition { get; set; } = "top";

--- a/src/Lumeo/UI/Chart/Charts/FunnelChart.razor
+++ b/src/Lumeo/UI/Chart/Charts/FunnelChart.razor
@@ -1,6 +1,6 @@
 @namespace Lumeo
 
-<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" IsLoading="@IsLoading" ShowLoadingSkeleton="@ShowLoadingSkeleton" SkeletonKind="@SkeletonKind" @attributes="AdditionalAttributes" />
+<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" IsLoading="@IsLoading" ShowLoadingSkeleton="@ShowLoadingSkeleton" SkeletonKind="@SkeletonKind" SkeletonStyle="@SkeletonStyle" @attributes="AdditionalAttributes" />
 
 @code {
     [Parameter] public List<FunnelData> Data { get; set; } = new();
@@ -19,6 +19,8 @@
     [Parameter] public bool ShowLoadingSkeleton { get; set; } = true;
     /// <summary>Shape family for the loading skeleton. Defaults to <c>ChartSkeletonKind.Pie</c> for this chart type; override if you want a different silhouette.</summary>
     [Parameter] public ChartSkeletonKind SkeletonKind { get; set; } = ChartSkeletonKind.Pie;
+    /// <summary>Phantom (default) renders the real chart with placeholder data and morphs to real data via ECharts' option-change animation. Silhouette falls back to the legacy SVG skeleton overlay.</summary>
+    [Parameter] public ChartSkeletonStyle SkeletonStyle { get; set; } = ChartSkeletonStyle.Phantom;
 
     [Parameter] public bool ShowDataLabels { get; set; }
     [Parameter] public string LabelPosition { get; set; } = "inside";

--- a/src/Lumeo/UI/Chart/Charts/FunnelChart.razor
+++ b/src/Lumeo/UI/Chart/Charts/FunnelChart.razor
@@ -1,6 +1,6 @@
 @namespace Lumeo
 
-<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" IsLoading="@IsLoading" ShowLoadingSkeleton="@ShowLoadingSkeleton" SkeletonKind="@SkeletonKind" SkeletonStyle="@SkeletonStyle" @attributes="AdditionalAttributes" />
+<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" IsLoading="@IsLoading" ShowLoadingSkeleton="@ShowLoadingSkeleton" SkeletonKind="@SkeletonKind" SkeletonStyle="@SkeletonStyle" PhantomCycleMs="@PhantomCycleMs" @attributes="AdditionalAttributes" />
 
 @code {
     [Parameter] public List<FunnelData> Data { get; set; } = new();
@@ -21,6 +21,8 @@
     [Parameter] public ChartSkeletonKind SkeletonKind { get; set; } = ChartSkeletonKind.Pie;
     /// <summary>Phantom (default) renders the real chart with placeholder data and morphs to real data via ECharts' option-change animation. Silhouette falls back to the legacy SVG skeleton overlay.</summary>
     [Parameter] public ChartSkeletonStyle SkeletonStyle { get; set; } = ChartSkeletonStyle.Phantom;
+    /// <summary>Phantom-mode refresh interval in milliseconds. Lower = faster data cycling while loading. Defaults to 1400.</summary>
+    [Parameter] public int PhantomCycleMs { get; set; } = 1400;
 
     [Parameter] public bool ShowDataLabels { get; set; }
     [Parameter] public string LabelPosition { get; set; } = "inside";

--- a/src/Lumeo/UI/Chart/Charts/FunnelChart.razor
+++ b/src/Lumeo/UI/Chart/Charts/FunnelChart.razor
@@ -1,6 +1,6 @@
 @namespace Lumeo
 
-<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" @attributes="AdditionalAttributes" />
+<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" IsLoading="@IsLoading" ShowLoadingSkeleton="@ShowLoadingSkeleton" SkeletonKind="@SkeletonKind" @attributes="AdditionalAttributes" />
 
 @code {
     [Parameter] public List<FunnelData> Data { get; set; } = new();
@@ -13,6 +13,12 @@
     [Parameter] public string? Theme { get; set; }
     [Parameter] public string? Class { get; set; }
     [Parameter(CaptureUnmatchedValues = true)] public Dictionary<string, object>? AdditionalAttributes { get; set; }
+    /// <summary>When true, overlays a shape-aware loading skeleton on top of the chart (consumer is fetching data). Flips back to the real chart once set to false.</summary>
+    [Parameter] public bool IsLoading { get; set; }
+    /// <summary>When true (default), renders a shape-aware skeleton while the chart has not yet mounted and whenever <see cref="IsLoading"/> is true. Set to <c>false</c> to opt out.</summary>
+    [Parameter] public bool ShowLoadingSkeleton { get; set; } = true;
+    /// <summary>Shape family for the loading skeleton. Defaults to <c>ChartSkeletonKind.Pie</c> for this chart type; override if you want a different silhouette.</summary>
+    [Parameter] public ChartSkeletonKind SkeletonKind { get; set; } = ChartSkeletonKind.Pie;
 
     [Parameter] public bool ShowDataLabels { get; set; }
     [Parameter] public string LabelPosition { get; set; } = "inside";

--- a/src/Lumeo/UI/Chart/Charts/FunnelChart.razor
+++ b/src/Lumeo/UI/Chart/Charts/FunnelChart.razor
@@ -17,8 +17,8 @@
     [Parameter] public bool IsLoading { get; set; }
     /// <summary>When true (default), renders a shape-aware skeleton while the chart has not yet mounted and whenever <see cref="IsLoading"/> is true. Set to <c>false</c> to opt out.</summary>
     [Parameter] public bool ShowLoadingSkeleton { get; set; } = true;
-    /// <summary>Shape family for the loading skeleton. Defaults to <c>ChartSkeletonKind.Pie</c> for this chart type; override if you want a different silhouette.</summary>
-    [Parameter] public ChartSkeletonKind SkeletonKind { get; set; } = ChartSkeletonKind.Pie;
+    /// <summary>Shape family for the loading skeleton. Defaults to <c>ChartSkeletonKind.Funnel</c> for this chart type; override if you want a different silhouette.</summary>
+    [Parameter] public ChartSkeletonKind SkeletonKind { get; set; } = ChartSkeletonKind.Funnel;
     /// <summary>Phantom (default) renders the real chart with placeholder data and morphs to real data via ECharts' option-change animation. Silhouette falls back to the legacy SVG skeleton overlay.</summary>
     [Parameter] public ChartSkeletonStyle SkeletonStyle { get; set; } = ChartSkeletonStyle.Phantom;
     /// <summary>Phantom-mode refresh interval in milliseconds. Lower = faster data cycling while loading. Defaults to 1400.</summary>

--- a/src/Lumeo/UI/Chart/Charts/GaugeChart.razor
+++ b/src/Lumeo/UI/Chart/Charts/GaugeChart.razor
@@ -1,6 +1,6 @@
 @namespace Lumeo
 
-<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" @attributes="AdditionalAttributes" />
+<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" IsLoading="@IsLoading" ShowLoadingSkeleton="@ShowLoadingSkeleton" SkeletonKind="@SkeletonKind" @attributes="AdditionalAttributes" />
 
 @code {
     [Parameter] public double Value { get; set; }
@@ -15,6 +15,12 @@
     [Parameter] public string? Theme { get; set; }
     [Parameter] public string? Class { get; set; }
     [Parameter(CaptureUnmatchedValues = true)] public Dictionary<string, object>? AdditionalAttributes { get; set; }
+    /// <summary>When true, overlays a shape-aware loading skeleton on top of the chart (consumer is fetching data). Flips back to the real chart once set to false.</summary>
+    [Parameter] public bool IsLoading { get; set; }
+    /// <summary>When true (default), renders a shape-aware skeleton while the chart has not yet mounted and whenever <see cref="IsLoading"/> is true. Set to <c>false</c> to opt out.</summary>
+    [Parameter] public bool ShowLoadingSkeleton { get; set; } = true;
+    /// <summary>Shape family for the loading skeleton. Defaults to <c>ChartSkeletonKind.Pie</c> for this chart type; override if you want a different silhouette.</summary>
+    [Parameter] public ChartSkeletonKind SkeletonKind { get; set; } = ChartSkeletonKind.Pie;
 
     [Parameter] public bool ShowDataLabels { get; set; }
     [Parameter] public string LabelPosition { get; set; } = "top";

--- a/src/Lumeo/UI/Chart/Charts/GaugeChart.razor
+++ b/src/Lumeo/UI/Chart/Charts/GaugeChart.razor
@@ -1,6 +1,6 @@
 @namespace Lumeo
 
-<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" IsLoading="@IsLoading" ShowLoadingSkeleton="@ShowLoadingSkeleton" SkeletonKind="@SkeletonKind" @attributes="AdditionalAttributes" />
+<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" IsLoading="@IsLoading" ShowLoadingSkeleton="@ShowLoadingSkeleton" SkeletonKind="@SkeletonKind" SkeletonStyle="@SkeletonStyle" @attributes="AdditionalAttributes" />
 
 @code {
     [Parameter] public double Value { get; set; }
@@ -21,6 +21,8 @@
     [Parameter] public bool ShowLoadingSkeleton { get; set; } = true;
     /// <summary>Shape family for the loading skeleton. Defaults to <c>ChartSkeletonKind.Pie</c> for this chart type; override if you want a different silhouette.</summary>
     [Parameter] public ChartSkeletonKind SkeletonKind { get; set; } = ChartSkeletonKind.Pie;
+    /// <summary>Phantom (default) renders the real chart with placeholder data and morphs to real data via ECharts' option-change animation. Silhouette falls back to the legacy SVG skeleton overlay.</summary>
+    [Parameter] public ChartSkeletonStyle SkeletonStyle { get; set; } = ChartSkeletonStyle.Phantom;
 
     [Parameter] public bool ShowDataLabels { get; set; }
     [Parameter] public string LabelPosition { get; set; } = "top";

--- a/src/Lumeo/UI/Chart/Charts/GaugeChart.razor
+++ b/src/Lumeo/UI/Chart/Charts/GaugeChart.razor
@@ -19,8 +19,8 @@
     [Parameter] public bool IsLoading { get; set; }
     /// <summary>When true (default), renders a shape-aware skeleton while the chart has not yet mounted and whenever <see cref="IsLoading"/> is true. Set to <c>false</c> to opt out.</summary>
     [Parameter] public bool ShowLoadingSkeleton { get; set; } = true;
-    /// <summary>Shape family for the loading skeleton. Defaults to <c>ChartSkeletonKind.Pie</c> for this chart type; override if you want a different silhouette.</summary>
-    [Parameter] public ChartSkeletonKind SkeletonKind { get; set; } = ChartSkeletonKind.Pie;
+    /// <summary>Shape family for the loading skeleton. Defaults to <c>ChartSkeletonKind.Gauge</c> for this chart type; override if you want a different silhouette.</summary>
+    [Parameter] public ChartSkeletonKind SkeletonKind { get; set; } = ChartSkeletonKind.Gauge;
     /// <summary>Phantom (default) renders the real chart with placeholder data and morphs to real data via ECharts' option-change animation. Silhouette falls back to the legacy SVG skeleton overlay.</summary>
     [Parameter] public ChartSkeletonStyle SkeletonStyle { get; set; } = ChartSkeletonStyle.Phantom;
     /// <summary>Phantom-mode refresh interval in milliseconds. Lower = faster data cycling while loading. Defaults to 1400.</summary>

--- a/src/Lumeo/UI/Chart/Charts/GaugeChart.razor
+++ b/src/Lumeo/UI/Chart/Charts/GaugeChart.razor
@@ -1,6 +1,6 @@
 @namespace Lumeo
 
-<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" IsLoading="@IsLoading" ShowLoadingSkeleton="@ShowLoadingSkeleton" SkeletonKind="@SkeletonKind" SkeletonStyle="@SkeletonStyle" @attributes="AdditionalAttributes" />
+<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" IsLoading="@IsLoading" ShowLoadingSkeleton="@ShowLoadingSkeleton" SkeletonKind="@SkeletonKind" SkeletonStyle="@SkeletonStyle" PhantomCycleMs="@PhantomCycleMs" @attributes="AdditionalAttributes" />
 
 @code {
     [Parameter] public double Value { get; set; }
@@ -23,6 +23,8 @@
     [Parameter] public ChartSkeletonKind SkeletonKind { get; set; } = ChartSkeletonKind.Pie;
     /// <summary>Phantom (default) renders the real chart with placeholder data and morphs to real data via ECharts' option-change animation. Silhouette falls back to the legacy SVG skeleton overlay.</summary>
     [Parameter] public ChartSkeletonStyle SkeletonStyle { get; set; } = ChartSkeletonStyle.Phantom;
+    /// <summary>Phantom-mode refresh interval in milliseconds. Lower = faster data cycling while loading. Defaults to 1400.</summary>
+    [Parameter] public int PhantomCycleMs { get; set; } = 1400;
 
     [Parameter] public bool ShowDataLabels { get; set; }
     [Parameter] public string LabelPosition { get; set; } = "top";

--- a/src/Lumeo/UI/Chart/Charts/GeoMapChart.razor
+++ b/src/Lumeo/UI/Chart/Charts/GeoMapChart.razor
@@ -1,7 +1,7 @@
 @namespace Lumeo
 @implements IAsyncDisposable
 
-<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" IsLoading="@IsLoading" ShowLoadingSkeleton="@ShowLoadingSkeleton" SkeletonKind="@SkeletonKind" @attributes="AdditionalAttributes" />
+<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" IsLoading="@IsLoading" ShowLoadingSkeleton="@ShowLoadingSkeleton" SkeletonKind="@SkeletonKind" SkeletonStyle="@SkeletonStyle" @attributes="AdditionalAttributes" />
 
 @inject IJSRuntime JSRuntime
 
@@ -25,6 +25,8 @@
     [Parameter] public bool ShowLoadingSkeleton { get; set; } = true;
     /// <summary>Shape family for the loading skeleton. Defaults to <c>ChartSkeletonKind.Generic</c> for this chart type; override if you want a different silhouette.</summary>
     [Parameter] public ChartSkeletonKind SkeletonKind { get; set; } = ChartSkeletonKind.Generic;
+    /// <summary>Phantom (default) renders the real chart with placeholder data and morphs to real data via ECharts' option-change animation. Silhouette falls back to the legacy SVG skeleton overlay.</summary>
+    [Parameter] public ChartSkeletonStyle SkeletonStyle { get; set; } = ChartSkeletonStyle.Phantom;
 
     [Parameter] public bool ShowDataLabels { get; set; }
     [Parameter] public string LabelPosition { get; set; } = "inside";

--- a/src/Lumeo/UI/Chart/Charts/GeoMapChart.razor
+++ b/src/Lumeo/UI/Chart/Charts/GeoMapChart.razor
@@ -1,7 +1,7 @@
 @namespace Lumeo
 @implements IAsyncDisposable
 
-<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" IsLoading="@IsLoading" ShowLoadingSkeleton="@ShowLoadingSkeleton" SkeletonKind="@SkeletonKind" SkeletonStyle="@SkeletonStyle" @attributes="AdditionalAttributes" />
+<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" IsLoading="@IsLoading" ShowLoadingSkeleton="@ShowLoadingSkeleton" SkeletonKind="@SkeletonKind" SkeletonStyle="@SkeletonStyle" PhantomCycleMs="@PhantomCycleMs" @attributes="AdditionalAttributes" />
 
 @inject IJSRuntime JSRuntime
 
@@ -27,6 +27,8 @@
     [Parameter] public ChartSkeletonKind SkeletonKind { get; set; } = ChartSkeletonKind.Generic;
     /// <summary>Phantom (default) renders the real chart with placeholder data and morphs to real data via ECharts' option-change animation. Silhouette falls back to the legacy SVG skeleton overlay.</summary>
     [Parameter] public ChartSkeletonStyle SkeletonStyle { get; set; } = ChartSkeletonStyle.Phantom;
+    /// <summary>Phantom-mode refresh interval in milliseconds. Lower = faster data cycling while loading. Defaults to 1400.</summary>
+    [Parameter] public int PhantomCycleMs { get; set; } = 1400;
 
     [Parameter] public bool ShowDataLabels { get; set; }
     [Parameter] public string LabelPosition { get; set; } = "inside";

--- a/src/Lumeo/UI/Chart/Charts/GeoMapChart.razor
+++ b/src/Lumeo/UI/Chart/Charts/GeoMapChart.razor
@@ -1,7 +1,7 @@
 @namespace Lumeo
 @implements IAsyncDisposable
 
-<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" @attributes="AdditionalAttributes" />
+<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" IsLoading="@IsLoading" ShowLoadingSkeleton="@ShowLoadingSkeleton" SkeletonKind="@SkeletonKind" @attributes="AdditionalAttributes" />
 
 @inject IJSRuntime JSRuntime
 
@@ -19,6 +19,12 @@
     [Parameter] public string? Theme { get; set; }
     [Parameter] public string? Class { get; set; }
     [Parameter(CaptureUnmatchedValues = true)] public Dictionary<string, object>? AdditionalAttributes { get; set; }
+    /// <summary>When true, overlays a shape-aware loading skeleton on top of the chart (consumer is fetching data). Flips back to the real chart once set to false.</summary>
+    [Parameter] public bool IsLoading { get; set; }
+    /// <summary>When true (default), renders a shape-aware skeleton while the chart has not yet mounted and whenever <see cref="IsLoading"/> is true. Set to <c>false</c> to opt out.</summary>
+    [Parameter] public bool ShowLoadingSkeleton { get; set; } = true;
+    /// <summary>Shape family for the loading skeleton. Defaults to <c>ChartSkeletonKind.Generic</c> for this chart type; override if you want a different silhouette.</summary>
+    [Parameter] public ChartSkeletonKind SkeletonKind { get; set; } = ChartSkeletonKind.Generic;
 
     [Parameter] public bool ShowDataLabels { get; set; }
     [Parameter] public string LabelPosition { get; set; } = "inside";

--- a/src/Lumeo/UI/Chart/Charts/GraphChart.razor
+++ b/src/Lumeo/UI/Chart/Charts/GraphChart.razor
@@ -1,6 +1,6 @@
 @namespace Lumeo
 
-<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" IsLoading="@IsLoading" ShowLoadingSkeleton="@ShowLoadingSkeleton" SkeletonKind="@SkeletonKind" @attributes="AdditionalAttributes" />
+<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" IsLoading="@IsLoading" ShowLoadingSkeleton="@ShowLoadingSkeleton" SkeletonKind="@SkeletonKind" SkeletonStyle="@SkeletonStyle" @attributes="AdditionalAttributes" />
 
 @code {
     [Parameter] public List<GraphNode> Nodes { get; set; } = new();
@@ -22,6 +22,8 @@
     [Parameter] public bool ShowLoadingSkeleton { get; set; } = true;
     /// <summary>Shape family for the loading skeleton. Defaults to <c>ChartSkeletonKind.Generic</c> for this chart type; override if you want a different silhouette.</summary>
     [Parameter] public ChartSkeletonKind SkeletonKind { get; set; } = ChartSkeletonKind.Generic;
+    /// <summary>Phantom (default) renders the real chart with placeholder data and morphs to real data via ECharts' option-change animation. Silhouette falls back to the legacy SVG skeleton overlay.</summary>
+    [Parameter] public ChartSkeletonStyle SkeletonStyle { get; set; } = ChartSkeletonStyle.Phantom;
 
     [Parameter] public bool ShowDataLabels { get; set; }
     [Parameter] public string LabelPosition { get; set; } = "right";

--- a/src/Lumeo/UI/Chart/Charts/GraphChart.razor
+++ b/src/Lumeo/UI/Chart/Charts/GraphChart.razor
@@ -20,8 +20,8 @@
     [Parameter] public bool IsLoading { get; set; }
     /// <summary>When true (default), renders a shape-aware skeleton while the chart has not yet mounted and whenever <see cref="IsLoading"/> is true. Set to <c>false</c> to opt out.</summary>
     [Parameter] public bool ShowLoadingSkeleton { get; set; } = true;
-    /// <summary>Shape family for the loading skeleton. Defaults to <c>ChartSkeletonKind.Generic</c> for this chart type; override if you want a different silhouette.</summary>
-    [Parameter] public ChartSkeletonKind SkeletonKind { get; set; } = ChartSkeletonKind.Generic;
+    /// <summary>Shape family for the loading skeleton. Defaults to <c>ChartSkeletonKind.Graph</c> for this chart type; override if you want a different silhouette.</summary>
+    [Parameter] public ChartSkeletonKind SkeletonKind { get; set; } = ChartSkeletonKind.Graph;
     /// <summary>Phantom (default) renders the real chart with placeholder data and morphs to real data via ECharts' option-change animation. Silhouette falls back to the legacy SVG skeleton overlay.</summary>
     [Parameter] public ChartSkeletonStyle SkeletonStyle { get; set; } = ChartSkeletonStyle.Phantom;
     /// <summary>Phantom-mode refresh interval in milliseconds. Lower = faster data cycling while loading. Defaults to 1400.</summary>

--- a/src/Lumeo/UI/Chart/Charts/GraphChart.razor
+++ b/src/Lumeo/UI/Chart/Charts/GraphChart.razor
@@ -1,6 +1,6 @@
 @namespace Lumeo
 
-<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" IsLoading="@IsLoading" ShowLoadingSkeleton="@ShowLoadingSkeleton" SkeletonKind="@SkeletonKind" SkeletonStyle="@SkeletonStyle" @attributes="AdditionalAttributes" />
+<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" IsLoading="@IsLoading" ShowLoadingSkeleton="@ShowLoadingSkeleton" SkeletonKind="@SkeletonKind" SkeletonStyle="@SkeletonStyle" PhantomCycleMs="@PhantomCycleMs" @attributes="AdditionalAttributes" />
 
 @code {
     [Parameter] public List<GraphNode> Nodes { get; set; } = new();
@@ -24,6 +24,8 @@
     [Parameter] public ChartSkeletonKind SkeletonKind { get; set; } = ChartSkeletonKind.Generic;
     /// <summary>Phantom (default) renders the real chart with placeholder data and morphs to real data via ECharts' option-change animation. Silhouette falls back to the legacy SVG skeleton overlay.</summary>
     [Parameter] public ChartSkeletonStyle SkeletonStyle { get; set; } = ChartSkeletonStyle.Phantom;
+    /// <summary>Phantom-mode refresh interval in milliseconds. Lower = faster data cycling while loading. Defaults to 1400.</summary>
+    [Parameter] public int PhantomCycleMs { get; set; } = 1400;
 
     [Parameter] public bool ShowDataLabels { get; set; }
     [Parameter] public string LabelPosition { get; set; } = "right";

--- a/src/Lumeo/UI/Chart/Charts/GraphChart.razor
+++ b/src/Lumeo/UI/Chart/Charts/GraphChart.razor
@@ -1,6 +1,6 @@
 @namespace Lumeo
 
-<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" @attributes="AdditionalAttributes" />
+<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" IsLoading="@IsLoading" ShowLoadingSkeleton="@ShowLoadingSkeleton" SkeletonKind="@SkeletonKind" @attributes="AdditionalAttributes" />
 
 @code {
     [Parameter] public List<GraphNode> Nodes { get; set; } = new();
@@ -16,6 +16,12 @@
     [Parameter] public string? Theme { get; set; }
     [Parameter] public string? Class { get; set; }
     [Parameter(CaptureUnmatchedValues = true)] public Dictionary<string, object>? AdditionalAttributes { get; set; }
+    /// <summary>When true, overlays a shape-aware loading skeleton on top of the chart (consumer is fetching data). Flips back to the real chart once set to false.</summary>
+    [Parameter] public bool IsLoading { get; set; }
+    /// <summary>When true (default), renders a shape-aware skeleton while the chart has not yet mounted and whenever <see cref="IsLoading"/> is true. Set to <c>false</c> to opt out.</summary>
+    [Parameter] public bool ShowLoadingSkeleton { get; set; } = true;
+    /// <summary>Shape family for the loading skeleton. Defaults to <c>ChartSkeletonKind.Generic</c> for this chart type; override if you want a different silhouette.</summary>
+    [Parameter] public ChartSkeletonKind SkeletonKind { get; set; } = ChartSkeletonKind.Generic;
 
     [Parameter] public bool ShowDataLabels { get; set; }
     [Parameter] public string LabelPosition { get; set; } = "right";

--- a/src/Lumeo/UI/Chart/Charts/HeatmapChart.razor
+++ b/src/Lumeo/UI/Chart/Charts/HeatmapChart.razor
@@ -1,6 +1,6 @@
 @namespace Lumeo
 
-<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" IsLoading="@IsLoading" ShowLoadingSkeleton="@ShowLoadingSkeleton" SkeletonKind="@SkeletonKind" @attributes="AdditionalAttributes" />
+<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" IsLoading="@IsLoading" ShowLoadingSkeleton="@ShowLoadingSkeleton" SkeletonKind="@SkeletonKind" SkeletonStyle="@SkeletonStyle" @attributes="AdditionalAttributes" />
 
 @code {
     [Parameter] public List<string> XCategories { get; set; } = new();
@@ -20,6 +20,8 @@
     [Parameter] public bool ShowLoadingSkeleton { get; set; } = true;
     /// <summary>Shape family for the loading skeleton. Defaults to <c>ChartSkeletonKind.Grid</c> for this chart type; override if you want a different silhouette.</summary>
     [Parameter] public ChartSkeletonKind SkeletonKind { get; set; } = ChartSkeletonKind.Grid;
+    /// <summary>Phantom (default) renders the real chart with placeholder data and morphs to real data via ECharts' option-change animation. Silhouette falls back to the legacy SVG skeleton overlay.</summary>
+    [Parameter] public ChartSkeletonStyle SkeletonStyle { get; set; } = ChartSkeletonStyle.Phantom;
 
     [Parameter] public bool ShowDataLabels { get; set; }
     [Parameter] public string LabelPosition { get; set; } = "inside";

--- a/src/Lumeo/UI/Chart/Charts/HeatmapChart.razor
+++ b/src/Lumeo/UI/Chart/Charts/HeatmapChart.razor
@@ -1,6 +1,6 @@
 @namespace Lumeo
 
-<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" IsLoading="@IsLoading" ShowLoadingSkeleton="@ShowLoadingSkeleton" SkeletonKind="@SkeletonKind" SkeletonStyle="@SkeletonStyle" @attributes="AdditionalAttributes" />
+<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" IsLoading="@IsLoading" ShowLoadingSkeleton="@ShowLoadingSkeleton" SkeletonKind="@SkeletonKind" SkeletonStyle="@SkeletonStyle" PhantomCycleMs="@PhantomCycleMs" @attributes="AdditionalAttributes" />
 
 @code {
     [Parameter] public List<string> XCategories { get; set; } = new();
@@ -22,6 +22,8 @@
     [Parameter] public ChartSkeletonKind SkeletonKind { get; set; } = ChartSkeletonKind.Grid;
     /// <summary>Phantom (default) renders the real chart with placeholder data and morphs to real data via ECharts' option-change animation. Silhouette falls back to the legacy SVG skeleton overlay.</summary>
     [Parameter] public ChartSkeletonStyle SkeletonStyle { get; set; } = ChartSkeletonStyle.Phantom;
+    /// <summary>Phantom-mode refresh interval in milliseconds. Lower = faster data cycling while loading. Defaults to 1400.</summary>
+    [Parameter] public int PhantomCycleMs { get; set; } = 1400;
 
     [Parameter] public bool ShowDataLabels { get; set; }
     [Parameter] public string LabelPosition { get; set; } = "inside";

--- a/src/Lumeo/UI/Chart/Charts/HeatmapChart.razor
+++ b/src/Lumeo/UI/Chart/Charts/HeatmapChart.razor
@@ -1,6 +1,6 @@
 @namespace Lumeo
 
-<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" @attributes="AdditionalAttributes" />
+<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" IsLoading="@IsLoading" ShowLoadingSkeleton="@ShowLoadingSkeleton" SkeletonKind="@SkeletonKind" @attributes="AdditionalAttributes" />
 
 @code {
     [Parameter] public List<string> XCategories { get; set; } = new();
@@ -14,6 +14,12 @@
     [Parameter] public string? Theme { get; set; }
     [Parameter] public string? Class { get; set; }
     [Parameter(CaptureUnmatchedValues = true)] public Dictionary<string, object>? AdditionalAttributes { get; set; }
+    /// <summary>When true, overlays a shape-aware loading skeleton on top of the chart (consumer is fetching data). Flips back to the real chart once set to false.</summary>
+    [Parameter] public bool IsLoading { get; set; }
+    /// <summary>When true (default), renders a shape-aware skeleton while the chart has not yet mounted and whenever <see cref="IsLoading"/> is true. Set to <c>false</c> to opt out.</summary>
+    [Parameter] public bool ShowLoadingSkeleton { get; set; } = true;
+    /// <summary>Shape family for the loading skeleton. Defaults to <c>ChartSkeletonKind.Grid</c> for this chart type; override if you want a different silhouette.</summary>
+    [Parameter] public ChartSkeletonKind SkeletonKind { get; set; } = ChartSkeletonKind.Grid;
 
     [Parameter] public bool ShowDataLabels { get; set; }
     [Parameter] public string LabelPosition { get; set; } = "inside";

--- a/src/Lumeo/UI/Chart/Charts/LineChart.razor
+++ b/src/Lumeo/UI/Chart/Charts/LineChart.razor
@@ -1,6 +1,6 @@
 @namespace Lumeo
 
-<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" IsLoading="@IsLoading" ShowLoadingSkeleton="@ShowLoadingSkeleton" SkeletonKind="@SkeletonKind" SkeletonStyle="@SkeletonStyle" @attributes="AdditionalAttributes" />
+<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" IsLoading="@IsLoading" ShowLoadingSkeleton="@ShowLoadingSkeleton" SkeletonKind="@SkeletonKind" SkeletonStyle="@SkeletonStyle" PhantomCycleMs="@PhantomCycleMs" @attributes="AdditionalAttributes" />
 
 @code {
     [Parameter] public List<string> Categories { get; set; } = new();
@@ -23,6 +23,8 @@
     [Parameter] public ChartSkeletonKind SkeletonKind { get; set; } = ChartSkeletonKind.Line;
     /// <summary>Phantom (default) renders the real chart with placeholder data and morphs to real data via ECharts' option-change animation. Silhouette falls back to the legacy SVG skeleton overlay.</summary>
     [Parameter] public ChartSkeletonStyle SkeletonStyle { get; set; } = ChartSkeletonStyle.Phantom;
+    /// <summary>Phantom-mode refresh interval in milliseconds. Lower = faster data cycling while loading. Defaults to 1400.</summary>
+    [Parameter] public int PhantomCycleMs { get; set; } = 1400;
 
     [Parameter] public bool ShowDataLabels { get; set; }
     [Parameter] public string LabelPosition { get; set; } = "top";

--- a/src/Lumeo/UI/Chart/Charts/LineChart.razor
+++ b/src/Lumeo/UI/Chart/Charts/LineChart.razor
@@ -1,6 +1,6 @@
 @namespace Lumeo
 
-<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" @attributes="AdditionalAttributes" />
+<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" IsLoading="@IsLoading" ShowLoadingSkeleton="@ShowLoadingSkeleton" SkeletonKind="@SkeletonKind" @attributes="AdditionalAttributes" />
 
 @code {
     [Parameter] public List<string> Categories { get; set; } = new();
@@ -15,6 +15,12 @@
     [Parameter] public string? Theme { get; set; }
     [Parameter] public string? Class { get; set; }
     [Parameter(CaptureUnmatchedValues = true)] public Dictionary<string, object>? AdditionalAttributes { get; set; }
+    /// <summary>When true, overlays a shape-aware loading skeleton on top of the chart (consumer is fetching data). Flips back to the real chart once set to false.</summary>
+    [Parameter] public bool IsLoading { get; set; }
+    /// <summary>When true (default), renders a shape-aware skeleton while the chart has not yet mounted and whenever <see cref="IsLoading"/> is true. Set to <c>false</c> to opt out.</summary>
+    [Parameter] public bool ShowLoadingSkeleton { get; set; } = true;
+    /// <summary>Shape family for the loading skeleton. Defaults to <c>ChartSkeletonKind.Line</c> for this chart type; override if you want a different silhouette.</summary>
+    [Parameter] public ChartSkeletonKind SkeletonKind { get; set; } = ChartSkeletonKind.Line;
 
     [Parameter] public bool ShowDataLabels { get; set; }
     [Parameter] public string LabelPosition { get; set; } = "top";

--- a/src/Lumeo/UI/Chart/Charts/LineChart.razor
+++ b/src/Lumeo/UI/Chart/Charts/LineChart.razor
@@ -1,6 +1,6 @@
 @namespace Lumeo
 
-<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" IsLoading="@IsLoading" ShowLoadingSkeleton="@ShowLoadingSkeleton" SkeletonKind="@SkeletonKind" @attributes="AdditionalAttributes" />
+<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" IsLoading="@IsLoading" ShowLoadingSkeleton="@ShowLoadingSkeleton" SkeletonKind="@SkeletonKind" SkeletonStyle="@SkeletonStyle" @attributes="AdditionalAttributes" />
 
 @code {
     [Parameter] public List<string> Categories { get; set; } = new();
@@ -21,6 +21,8 @@
     [Parameter] public bool ShowLoadingSkeleton { get; set; } = true;
     /// <summary>Shape family for the loading skeleton. Defaults to <c>ChartSkeletonKind.Line</c> for this chart type; override if you want a different silhouette.</summary>
     [Parameter] public ChartSkeletonKind SkeletonKind { get; set; } = ChartSkeletonKind.Line;
+    /// <summary>Phantom (default) renders the real chart with placeholder data and morphs to real data via ECharts' option-change animation. Silhouette falls back to the legacy SVG skeleton overlay.</summary>
+    [Parameter] public ChartSkeletonStyle SkeletonStyle { get; set; } = ChartSkeletonStyle.Phantom;
 
     [Parameter] public bool ShowDataLabels { get; set; }
     [Parameter] public string LabelPosition { get; set; } = "top";

--- a/src/Lumeo/UI/Chart/Charts/LiquidFillChart.razor
+++ b/src/Lumeo/UI/Chart/Charts/LiquidFillChart.razor
@@ -2,7 +2,7 @@
 @implements IAsyncDisposable
 
 <Chart OptionJson="@_optionJson" Width="@Width" Height="@Height" Theme="@Theme"
-       EChartsSource="@EChartsSource" Class="@Class" IsLoading="@IsLoading" ShowLoadingSkeleton="@ShowLoadingSkeleton" SkeletonKind="@SkeletonKind" @attributes="AdditionalAttributes" />
+       EChartsSource="@EChartsSource" Class="@Class" IsLoading="@IsLoading" ShowLoadingSkeleton="@ShowLoadingSkeleton" SkeletonKind="@SkeletonKind" SkeletonStyle="@SkeletonStyle" @attributes="AdditionalAttributes" />
 
 @inject IJSRuntime JSRuntime
 
@@ -25,6 +25,8 @@
     [Parameter] public bool ShowLoadingSkeleton { get; set; } = true;
     /// <summary>Shape family for the loading skeleton. Defaults to <c>ChartSkeletonKind.Pie</c> for this chart type; override if you want a different silhouette.</summary>
     [Parameter] public ChartSkeletonKind SkeletonKind { get; set; } = ChartSkeletonKind.Pie;
+    /// <summary>Phantom (default) renders the real chart with placeholder data and morphs to real data via ECharts' option-change animation. Silhouette falls back to the legacy SVG skeleton overlay.</summary>
+    [Parameter] public ChartSkeletonStyle SkeletonStyle { get; set; } = ChartSkeletonStyle.Phantom;
 
     [Parameter] public bool ShowDataLabels { get; set; }
     [Parameter] public string LabelPosition { get; set; } = "center";

--- a/src/Lumeo/UI/Chart/Charts/LiquidFillChart.razor
+++ b/src/Lumeo/UI/Chart/Charts/LiquidFillChart.razor
@@ -2,7 +2,7 @@
 @implements IAsyncDisposable
 
 <Chart OptionJson="@_optionJson" Width="@Width" Height="@Height" Theme="@Theme"
-       EChartsSource="@EChartsSource" Class="@Class" @attributes="AdditionalAttributes" />
+       EChartsSource="@EChartsSource" Class="@Class" IsLoading="@IsLoading" ShowLoadingSkeleton="@ShowLoadingSkeleton" SkeletonKind="@SkeletonKind" @attributes="AdditionalAttributes" />
 
 @inject IJSRuntime JSRuntime
 
@@ -19,6 +19,12 @@
     [Parameter] public string? Theme { get; set; }
     [Parameter] public string? Class { get; set; }
     [Parameter(CaptureUnmatchedValues = true)] public Dictionary<string, object>? AdditionalAttributes { get; set; }
+    /// <summary>When true, overlays a shape-aware loading skeleton on top of the chart (consumer is fetching data). Flips back to the real chart once set to false.</summary>
+    [Parameter] public bool IsLoading { get; set; }
+    /// <summary>When true (default), renders a shape-aware skeleton while the chart has not yet mounted and whenever <see cref="IsLoading"/> is true. Set to <c>false</c> to opt out.</summary>
+    [Parameter] public bool ShowLoadingSkeleton { get; set; } = true;
+    /// <summary>Shape family for the loading skeleton. Defaults to <c>ChartSkeletonKind.Pie</c> for this chart type; override if you want a different silhouette.</summary>
+    [Parameter] public ChartSkeletonKind SkeletonKind { get; set; } = ChartSkeletonKind.Pie;
 
     [Parameter] public bool ShowDataLabels { get; set; }
     [Parameter] public string LabelPosition { get; set; } = "center";

--- a/src/Lumeo/UI/Chart/Charts/LiquidFillChart.razor
+++ b/src/Lumeo/UI/Chart/Charts/LiquidFillChart.razor
@@ -2,7 +2,7 @@
 @implements IAsyncDisposable
 
 <Chart OptionJson="@_optionJson" Width="@Width" Height="@Height" Theme="@Theme"
-       EChartsSource="@EChartsSource" Class="@Class" IsLoading="@IsLoading" ShowLoadingSkeleton="@ShowLoadingSkeleton" SkeletonKind="@SkeletonKind" SkeletonStyle="@SkeletonStyle" @attributes="AdditionalAttributes" />
+       EChartsSource="@EChartsSource" Class="@Class" IsLoading="@IsLoading" ShowLoadingSkeleton="@ShowLoadingSkeleton" SkeletonKind="@SkeletonKind" SkeletonStyle="@SkeletonStyle" PhantomCycleMs="@PhantomCycleMs" @attributes="AdditionalAttributes" />
 
 @inject IJSRuntime JSRuntime
 
@@ -27,6 +27,8 @@
     [Parameter] public ChartSkeletonKind SkeletonKind { get; set; } = ChartSkeletonKind.Pie;
     /// <summary>Phantom (default) renders the real chart with placeholder data and morphs to real data via ECharts' option-change animation. Silhouette falls back to the legacy SVG skeleton overlay.</summary>
     [Parameter] public ChartSkeletonStyle SkeletonStyle { get; set; } = ChartSkeletonStyle.Phantom;
+    /// <summary>Phantom-mode refresh interval in milliseconds. Lower = faster data cycling while loading. Defaults to 1400.</summary>
+    [Parameter] public int PhantomCycleMs { get; set; } = 1400;
 
     [Parameter] public bool ShowDataLabels { get; set; }
     [Parameter] public string LabelPosition { get; set; } = "center";

--- a/src/Lumeo/UI/Chart/Charts/MixedChart.razor
+++ b/src/Lumeo/UI/Chart/Charts/MixedChart.razor
@@ -1,6 +1,6 @@
 @namespace Lumeo
 
-<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" @attributes="AdditionalAttributes" />
+<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" IsLoading="@IsLoading" ShowLoadingSkeleton="@ShowLoadingSkeleton" SkeletonKind="@SkeletonKind" @attributes="AdditionalAttributes" />
 
 @code {
     [Parameter] public List<string> Categories { get; set; } = new();
@@ -13,6 +13,12 @@
     [Parameter] public string? Theme { get; set; }
     [Parameter] public string? Class { get; set; }
     [Parameter(CaptureUnmatchedValues = true)] public Dictionary<string, object>? AdditionalAttributes { get; set; }
+    /// <summary>When true, overlays a shape-aware loading skeleton on top of the chart (consumer is fetching data). Flips back to the real chart once set to false.</summary>
+    [Parameter] public bool IsLoading { get; set; }
+    /// <summary>When true (default), renders a shape-aware skeleton while the chart has not yet mounted and whenever <see cref="IsLoading"/> is true. Set to <c>false</c> to opt out.</summary>
+    [Parameter] public bool ShowLoadingSkeleton { get; set; } = true;
+    /// <summary>Shape family for the loading skeleton. Defaults to <c>ChartSkeletonKind.Line</c> for this chart type; override if you want a different silhouette.</summary>
+    [Parameter] public ChartSkeletonKind SkeletonKind { get; set; } = ChartSkeletonKind.Line;
 
     [Parameter] public bool ShowDataLabels { get; set; }
     [Parameter] public string LabelPosition { get; set; } = "top";

--- a/src/Lumeo/UI/Chart/Charts/MixedChart.razor
+++ b/src/Lumeo/UI/Chart/Charts/MixedChart.razor
@@ -1,6 +1,6 @@
 @namespace Lumeo
 
-<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" IsLoading="@IsLoading" ShowLoadingSkeleton="@ShowLoadingSkeleton" SkeletonKind="@SkeletonKind" SkeletonStyle="@SkeletonStyle" @attributes="AdditionalAttributes" />
+<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" IsLoading="@IsLoading" ShowLoadingSkeleton="@ShowLoadingSkeleton" SkeletonKind="@SkeletonKind" SkeletonStyle="@SkeletonStyle" PhantomCycleMs="@PhantomCycleMs" @attributes="AdditionalAttributes" />
 
 @code {
     [Parameter] public List<string> Categories { get; set; } = new();
@@ -21,6 +21,8 @@
     [Parameter] public ChartSkeletonKind SkeletonKind { get; set; } = ChartSkeletonKind.Line;
     /// <summary>Phantom (default) renders the real chart with placeholder data and morphs to real data via ECharts' option-change animation. Silhouette falls back to the legacy SVG skeleton overlay.</summary>
     [Parameter] public ChartSkeletonStyle SkeletonStyle { get; set; } = ChartSkeletonStyle.Phantom;
+    /// <summary>Phantom-mode refresh interval in milliseconds. Lower = faster data cycling while loading. Defaults to 1400.</summary>
+    [Parameter] public int PhantomCycleMs { get; set; } = 1400;
 
     [Parameter] public bool ShowDataLabels { get; set; }
     [Parameter] public string LabelPosition { get; set; } = "top";

--- a/src/Lumeo/UI/Chart/Charts/MixedChart.razor
+++ b/src/Lumeo/UI/Chart/Charts/MixedChart.razor
@@ -1,6 +1,6 @@
 @namespace Lumeo
 
-<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" IsLoading="@IsLoading" ShowLoadingSkeleton="@ShowLoadingSkeleton" SkeletonKind="@SkeletonKind" @attributes="AdditionalAttributes" />
+<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" IsLoading="@IsLoading" ShowLoadingSkeleton="@ShowLoadingSkeleton" SkeletonKind="@SkeletonKind" SkeletonStyle="@SkeletonStyle" @attributes="AdditionalAttributes" />
 
 @code {
     [Parameter] public List<string> Categories { get; set; } = new();
@@ -19,6 +19,8 @@
     [Parameter] public bool ShowLoadingSkeleton { get; set; } = true;
     /// <summary>Shape family for the loading skeleton. Defaults to <c>ChartSkeletonKind.Line</c> for this chart type; override if you want a different silhouette.</summary>
     [Parameter] public ChartSkeletonKind SkeletonKind { get; set; } = ChartSkeletonKind.Line;
+    /// <summary>Phantom (default) renders the real chart with placeholder data and morphs to real data via ECharts' option-change animation. Silhouette falls back to the legacy SVG skeleton overlay.</summary>
+    [Parameter] public ChartSkeletonStyle SkeletonStyle { get; set; } = ChartSkeletonStyle.Phantom;
 
     [Parameter] public bool ShowDataLabels { get; set; }
     [Parameter] public string LabelPosition { get; set; } = "top";

--- a/src/Lumeo/UI/Chart/Charts/NightingaleChart.razor
+++ b/src/Lumeo/UI/Chart/Charts/NightingaleChart.razor
@@ -1,6 +1,6 @@
 @namespace Lumeo
 
-<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" @attributes="AdditionalAttributes" />
+<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" IsLoading="@IsLoading" ShowLoadingSkeleton="@ShowLoadingSkeleton" SkeletonKind="@SkeletonKind" @attributes="AdditionalAttributes" />
 
 @code {
     [Parameter] public List<NightingaleData> Data { get; set; } = new();
@@ -13,6 +13,12 @@
     [Parameter] public string? Theme { get; set; }
     [Parameter] public string? Class { get; set; }
     [Parameter(CaptureUnmatchedValues = true)] public Dictionary<string, object>? AdditionalAttributes { get; set; }
+    /// <summary>When true, overlays a shape-aware loading skeleton on top of the chart (consumer is fetching data). Flips back to the real chart once set to false.</summary>
+    [Parameter] public bool IsLoading { get; set; }
+    /// <summary>When true (default), renders a shape-aware skeleton while the chart has not yet mounted and whenever <see cref="IsLoading"/> is true. Set to <c>false</c> to opt out.</summary>
+    [Parameter] public bool ShowLoadingSkeleton { get; set; } = true;
+    /// <summary>Shape family for the loading skeleton. Defaults to <c>ChartSkeletonKind.Pie</c> for this chart type; override if you want a different silhouette.</summary>
+    [Parameter] public ChartSkeletonKind SkeletonKind { get; set; } = ChartSkeletonKind.Pie;
 
     [Parameter] public bool ShowDataLabels { get; set; }
     [Parameter] public string LabelPosition { get; set; } = "outside";

--- a/src/Lumeo/UI/Chart/Charts/NightingaleChart.razor
+++ b/src/Lumeo/UI/Chart/Charts/NightingaleChart.razor
@@ -1,6 +1,6 @@
 @namespace Lumeo
 
-<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" IsLoading="@IsLoading" ShowLoadingSkeleton="@ShowLoadingSkeleton" SkeletonKind="@SkeletonKind" SkeletonStyle="@SkeletonStyle" @attributes="AdditionalAttributes" />
+<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" IsLoading="@IsLoading" ShowLoadingSkeleton="@ShowLoadingSkeleton" SkeletonKind="@SkeletonKind" SkeletonStyle="@SkeletonStyle" PhantomCycleMs="@PhantomCycleMs" @attributes="AdditionalAttributes" />
 
 @code {
     [Parameter] public List<NightingaleData> Data { get; set; } = new();
@@ -21,6 +21,8 @@
     [Parameter] public ChartSkeletonKind SkeletonKind { get; set; } = ChartSkeletonKind.Pie;
     /// <summary>Phantom (default) renders the real chart with placeholder data and morphs to real data via ECharts' option-change animation. Silhouette falls back to the legacy SVG skeleton overlay.</summary>
     [Parameter] public ChartSkeletonStyle SkeletonStyle { get; set; } = ChartSkeletonStyle.Phantom;
+    /// <summary>Phantom-mode refresh interval in milliseconds. Lower = faster data cycling while loading. Defaults to 1400.</summary>
+    [Parameter] public int PhantomCycleMs { get; set; } = 1400;
 
     [Parameter] public bool ShowDataLabels { get; set; }
     [Parameter] public string LabelPosition { get; set; } = "outside";

--- a/src/Lumeo/UI/Chart/Charts/NightingaleChart.razor
+++ b/src/Lumeo/UI/Chart/Charts/NightingaleChart.razor
@@ -1,6 +1,6 @@
 @namespace Lumeo
 
-<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" IsLoading="@IsLoading" ShowLoadingSkeleton="@ShowLoadingSkeleton" SkeletonKind="@SkeletonKind" @attributes="AdditionalAttributes" />
+<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" IsLoading="@IsLoading" ShowLoadingSkeleton="@ShowLoadingSkeleton" SkeletonKind="@SkeletonKind" SkeletonStyle="@SkeletonStyle" @attributes="AdditionalAttributes" />
 
 @code {
     [Parameter] public List<NightingaleData> Data { get; set; } = new();
@@ -19,6 +19,8 @@
     [Parameter] public bool ShowLoadingSkeleton { get; set; } = true;
     /// <summary>Shape family for the loading skeleton. Defaults to <c>ChartSkeletonKind.Pie</c> for this chart type; override if you want a different silhouette.</summary>
     [Parameter] public ChartSkeletonKind SkeletonKind { get; set; } = ChartSkeletonKind.Pie;
+    /// <summary>Phantom (default) renders the real chart with placeholder data and morphs to real data via ECharts' option-change animation. Silhouette falls back to the legacy SVG skeleton overlay.</summary>
+    [Parameter] public ChartSkeletonStyle SkeletonStyle { get; set; } = ChartSkeletonStyle.Phantom;
 
     [Parameter] public bool ShowDataLabels { get; set; }
     [Parameter] public string LabelPosition { get; set; } = "outside";

--- a/src/Lumeo/UI/Chart/Charts/ParallelChart.razor
+++ b/src/Lumeo/UI/Chart/Charts/ParallelChart.razor
@@ -1,6 +1,6 @@
 @namespace Lumeo
 
-<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" IsLoading="@IsLoading" ShowLoadingSkeleton="@ShowLoadingSkeleton" SkeletonKind="@SkeletonKind" SkeletonStyle="@SkeletonStyle" @attributes="AdditionalAttributes" />
+<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" IsLoading="@IsLoading" ShowLoadingSkeleton="@ShowLoadingSkeleton" SkeletonKind="@SkeletonKind" SkeletonStyle="@SkeletonStyle" PhantomCycleMs="@PhantomCycleMs" @attributes="AdditionalAttributes" />
 
 @code {
     [Parameter] public List<ParallelDimension> Dimensions { get; set; } = new();
@@ -21,6 +21,8 @@
     [Parameter] public ChartSkeletonKind SkeletonKind { get; set; } = ChartSkeletonKind.Generic;
     /// <summary>Phantom (default) renders the real chart with placeholder data and morphs to real data via ECharts' option-change animation. Silhouette falls back to the legacy SVG skeleton overlay.</summary>
     [Parameter] public ChartSkeletonStyle SkeletonStyle { get; set; } = ChartSkeletonStyle.Phantom;
+    /// <summary>Phantom-mode refresh interval in milliseconds. Lower = faster data cycling while loading. Defaults to 1400.</summary>
+    [Parameter] public int PhantomCycleMs { get; set; } = 1400;
 
     [Parameter] public bool ShowDataLabels { get; set; }
     [Parameter] public string LabelPosition { get; set; } = "top";

--- a/src/Lumeo/UI/Chart/Charts/ParallelChart.razor
+++ b/src/Lumeo/UI/Chart/Charts/ParallelChart.razor
@@ -1,6 +1,6 @@
 @namespace Lumeo
 
-<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" IsLoading="@IsLoading" ShowLoadingSkeleton="@ShowLoadingSkeleton" SkeletonKind="@SkeletonKind" @attributes="AdditionalAttributes" />
+<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" IsLoading="@IsLoading" ShowLoadingSkeleton="@ShowLoadingSkeleton" SkeletonKind="@SkeletonKind" SkeletonStyle="@SkeletonStyle" @attributes="AdditionalAttributes" />
 
 @code {
     [Parameter] public List<ParallelDimension> Dimensions { get; set; } = new();
@@ -19,6 +19,8 @@
     [Parameter] public bool ShowLoadingSkeleton { get; set; } = true;
     /// <summary>Shape family for the loading skeleton. Defaults to <c>ChartSkeletonKind.Generic</c> for this chart type; override if you want a different silhouette.</summary>
     [Parameter] public ChartSkeletonKind SkeletonKind { get; set; } = ChartSkeletonKind.Generic;
+    /// <summary>Phantom (default) renders the real chart with placeholder data and morphs to real data via ECharts' option-change animation. Silhouette falls back to the legacy SVG skeleton overlay.</summary>
+    [Parameter] public ChartSkeletonStyle SkeletonStyle { get; set; } = ChartSkeletonStyle.Phantom;
 
     [Parameter] public bool ShowDataLabels { get; set; }
     [Parameter] public string LabelPosition { get; set; } = "top";

--- a/src/Lumeo/UI/Chart/Charts/ParallelChart.razor
+++ b/src/Lumeo/UI/Chart/Charts/ParallelChart.razor
@@ -1,6 +1,6 @@
 @namespace Lumeo
 
-<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" @attributes="AdditionalAttributes" />
+<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" IsLoading="@IsLoading" ShowLoadingSkeleton="@ShowLoadingSkeleton" SkeletonKind="@SkeletonKind" @attributes="AdditionalAttributes" />
 
 @code {
     [Parameter] public List<ParallelDimension> Dimensions { get; set; } = new();
@@ -13,6 +13,12 @@
     [Parameter] public string? Theme { get; set; }
     [Parameter] public string? Class { get; set; }
     [Parameter(CaptureUnmatchedValues = true)] public Dictionary<string, object>? AdditionalAttributes { get; set; }
+    /// <summary>When true, overlays a shape-aware loading skeleton on top of the chart (consumer is fetching data). Flips back to the real chart once set to false.</summary>
+    [Parameter] public bool IsLoading { get; set; }
+    /// <summary>When true (default), renders a shape-aware skeleton while the chart has not yet mounted and whenever <see cref="IsLoading"/> is true. Set to <c>false</c> to opt out.</summary>
+    [Parameter] public bool ShowLoadingSkeleton { get; set; } = true;
+    /// <summary>Shape family for the loading skeleton. Defaults to <c>ChartSkeletonKind.Generic</c> for this chart type; override if you want a different silhouette.</summary>
+    [Parameter] public ChartSkeletonKind SkeletonKind { get; set; } = ChartSkeletonKind.Generic;
 
     [Parameter] public bool ShowDataLabels { get; set; }
     [Parameter] public string LabelPosition { get; set; } = "top";

--- a/src/Lumeo/UI/Chart/Charts/ParallelChart.razor
+++ b/src/Lumeo/UI/Chart/Charts/ParallelChart.razor
@@ -17,8 +17,8 @@
     [Parameter] public bool IsLoading { get; set; }
     /// <summary>When true (default), renders a shape-aware skeleton while the chart has not yet mounted and whenever <see cref="IsLoading"/> is true. Set to <c>false</c> to opt out.</summary>
     [Parameter] public bool ShowLoadingSkeleton { get; set; } = true;
-    /// <summary>Shape family for the loading skeleton. Defaults to <c>ChartSkeletonKind.Generic</c> for this chart type; override if you want a different silhouette.</summary>
-    [Parameter] public ChartSkeletonKind SkeletonKind { get; set; } = ChartSkeletonKind.Generic;
+    /// <summary>Shape family for the loading skeleton. Defaults to <c>ChartSkeletonKind.Parallel</c> for this chart type; override if you want a different silhouette.</summary>
+    [Parameter] public ChartSkeletonKind SkeletonKind { get; set; } = ChartSkeletonKind.Parallel;
     /// <summary>Phantom (default) renders the real chart with placeholder data and morphs to real data via ECharts' option-change animation. Silhouette falls back to the legacy SVG skeleton overlay.</summary>
     [Parameter] public ChartSkeletonStyle SkeletonStyle { get; set; } = ChartSkeletonStyle.Phantom;
     /// <summary>Phantom-mode refresh interval in milliseconds. Lower = faster data cycling while loading. Defaults to 1400.</summary>

--- a/src/Lumeo/UI/Chart/Charts/PictorialBarChart.razor
+++ b/src/Lumeo/UI/Chart/Charts/PictorialBarChart.razor
@@ -1,6 +1,6 @@
 @namespace Lumeo
 
-<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" IsLoading="@IsLoading" ShowLoadingSkeleton="@ShowLoadingSkeleton" SkeletonKind="@SkeletonKind" @attributes="AdditionalAttributes" />
+<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" IsLoading="@IsLoading" ShowLoadingSkeleton="@ShowLoadingSkeleton" SkeletonKind="@SkeletonKind" SkeletonStyle="@SkeletonStyle" @attributes="AdditionalAttributes" />
 
 @code {
     [Parameter] public List<string> Categories { get; set; } = new();
@@ -19,6 +19,8 @@
     [Parameter] public bool ShowLoadingSkeleton { get; set; } = true;
     /// <summary>Shape family for the loading skeleton. Defaults to <c>ChartSkeletonKind.Bars</c> for this chart type; override if you want a different silhouette.</summary>
     [Parameter] public ChartSkeletonKind SkeletonKind { get; set; } = ChartSkeletonKind.Bars;
+    /// <summary>Phantom (default) renders the real chart with placeholder data and morphs to real data via ECharts' option-change animation. Silhouette falls back to the legacy SVG skeleton overlay.</summary>
+    [Parameter] public ChartSkeletonStyle SkeletonStyle { get; set; } = ChartSkeletonStyle.Phantom;
 
     [Parameter] public bool ShowDataLabels { get; set; }
     [Parameter] public string LabelPosition { get; set; } = "top";

--- a/src/Lumeo/UI/Chart/Charts/PictorialBarChart.razor
+++ b/src/Lumeo/UI/Chart/Charts/PictorialBarChart.razor
@@ -1,6 +1,6 @@
 @namespace Lumeo
 
-<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" @attributes="AdditionalAttributes" />
+<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" IsLoading="@IsLoading" ShowLoadingSkeleton="@ShowLoadingSkeleton" SkeletonKind="@SkeletonKind" @attributes="AdditionalAttributes" />
 
 @code {
     [Parameter] public List<string> Categories { get; set; } = new();
@@ -13,6 +13,12 @@
     [Parameter] public string? Theme { get; set; }
     [Parameter] public string? Class { get; set; }
     [Parameter(CaptureUnmatchedValues = true)] public Dictionary<string, object>? AdditionalAttributes { get; set; }
+    /// <summary>When true, overlays a shape-aware loading skeleton on top of the chart (consumer is fetching data). Flips back to the real chart once set to false.</summary>
+    [Parameter] public bool IsLoading { get; set; }
+    /// <summary>When true (default), renders a shape-aware skeleton while the chart has not yet mounted and whenever <see cref="IsLoading"/> is true. Set to <c>false</c> to opt out.</summary>
+    [Parameter] public bool ShowLoadingSkeleton { get; set; } = true;
+    /// <summary>Shape family for the loading skeleton. Defaults to <c>ChartSkeletonKind.Bars</c> for this chart type; override if you want a different silhouette.</summary>
+    [Parameter] public ChartSkeletonKind SkeletonKind { get; set; } = ChartSkeletonKind.Bars;
 
     [Parameter] public bool ShowDataLabels { get; set; }
     [Parameter] public string LabelPosition { get; set; } = "top";

--- a/src/Lumeo/UI/Chart/Charts/PictorialBarChart.razor
+++ b/src/Lumeo/UI/Chart/Charts/PictorialBarChart.razor
@@ -1,6 +1,6 @@
 @namespace Lumeo
 
-<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" IsLoading="@IsLoading" ShowLoadingSkeleton="@ShowLoadingSkeleton" SkeletonKind="@SkeletonKind" SkeletonStyle="@SkeletonStyle" @attributes="AdditionalAttributes" />
+<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" IsLoading="@IsLoading" ShowLoadingSkeleton="@ShowLoadingSkeleton" SkeletonKind="@SkeletonKind" SkeletonStyle="@SkeletonStyle" PhantomCycleMs="@PhantomCycleMs" @attributes="AdditionalAttributes" />
 
 @code {
     [Parameter] public List<string> Categories { get; set; } = new();
@@ -21,6 +21,8 @@
     [Parameter] public ChartSkeletonKind SkeletonKind { get; set; } = ChartSkeletonKind.Bars;
     /// <summary>Phantom (default) renders the real chart with placeholder data and morphs to real data via ECharts' option-change animation. Silhouette falls back to the legacy SVG skeleton overlay.</summary>
     [Parameter] public ChartSkeletonStyle SkeletonStyle { get; set; } = ChartSkeletonStyle.Phantom;
+    /// <summary>Phantom-mode refresh interval in milliseconds. Lower = faster data cycling while loading. Defaults to 1400.</summary>
+    [Parameter] public int PhantomCycleMs { get; set; } = 1400;
 
     [Parameter] public bool ShowDataLabels { get; set; }
     [Parameter] public string LabelPosition { get; set; } = "top";

--- a/src/Lumeo/UI/Chart/Charts/PieChart.razor
+++ b/src/Lumeo/UI/Chart/Charts/PieChart.razor
@@ -1,6 +1,6 @@
 @namespace Lumeo
 
-<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" IsLoading="@IsLoading" ShowLoadingSkeleton="@ShowLoadingSkeleton" SkeletonKind="@SkeletonKind" @attributes="AdditionalAttributes" />
+<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" IsLoading="@IsLoading" ShowLoadingSkeleton="@ShowLoadingSkeleton" SkeletonKind="@SkeletonKind" SkeletonStyle="@SkeletonStyle" @attributes="AdditionalAttributes" />
 
 @code {
     [Parameter] public List<PieChartData> Data { get; set; } = new();
@@ -19,6 +19,8 @@
     [Parameter] public bool ShowLoadingSkeleton { get; set; } = true;
     /// <summary>Shape family for the loading skeleton. Defaults to <c>ChartSkeletonKind.Pie</c> for this chart type; override if you want a different silhouette.</summary>
     [Parameter] public ChartSkeletonKind SkeletonKind { get; set; } = ChartSkeletonKind.Pie;
+    /// <summary>Phantom (default) renders the real chart with placeholder data and morphs to real data via ECharts' option-change animation. Silhouette falls back to the legacy SVG skeleton overlay.</summary>
+    [Parameter] public ChartSkeletonStyle SkeletonStyle { get; set; } = ChartSkeletonStyle.Phantom;
 
     [Parameter] public bool ShowDataLabels { get; set; }
     [Parameter] public string LabelPosition { get; set; } = "outside";

--- a/src/Lumeo/UI/Chart/Charts/PieChart.razor
+++ b/src/Lumeo/UI/Chart/Charts/PieChart.razor
@@ -1,6 +1,6 @@
 @namespace Lumeo
 
-<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" IsLoading="@IsLoading" ShowLoadingSkeleton="@ShowLoadingSkeleton" SkeletonKind="@SkeletonKind" SkeletonStyle="@SkeletonStyle" @attributes="AdditionalAttributes" />
+<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" IsLoading="@IsLoading" ShowLoadingSkeleton="@ShowLoadingSkeleton" SkeletonKind="@SkeletonKind" SkeletonStyle="@SkeletonStyle" PhantomCycleMs="@PhantomCycleMs" @attributes="AdditionalAttributes" />
 
 @code {
     [Parameter] public List<PieChartData> Data { get; set; } = new();
@@ -21,6 +21,8 @@
     [Parameter] public ChartSkeletonKind SkeletonKind { get; set; } = ChartSkeletonKind.Pie;
     /// <summary>Phantom (default) renders the real chart with placeholder data and morphs to real data via ECharts' option-change animation. Silhouette falls back to the legacy SVG skeleton overlay.</summary>
     [Parameter] public ChartSkeletonStyle SkeletonStyle { get; set; } = ChartSkeletonStyle.Phantom;
+    /// <summary>Phantom-mode refresh interval in milliseconds. Lower = faster data cycling while loading. Defaults to 1400.</summary>
+    [Parameter] public int PhantomCycleMs { get; set; } = 1400;
 
     [Parameter] public bool ShowDataLabels { get; set; }
     [Parameter] public string LabelPosition { get; set; } = "outside";

--- a/src/Lumeo/UI/Chart/Charts/PieChart.razor
+++ b/src/Lumeo/UI/Chart/Charts/PieChart.razor
@@ -1,6 +1,6 @@
 @namespace Lumeo
 
-<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" @attributes="AdditionalAttributes" />
+<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" IsLoading="@IsLoading" ShowLoadingSkeleton="@ShowLoadingSkeleton" SkeletonKind="@SkeletonKind" @attributes="AdditionalAttributes" />
 
 @code {
     [Parameter] public List<PieChartData> Data { get; set; } = new();
@@ -13,6 +13,12 @@
     [Parameter] public string? Theme { get; set; }
     [Parameter] public string? Class { get; set; }
     [Parameter(CaptureUnmatchedValues = true)] public Dictionary<string, object>? AdditionalAttributes { get; set; }
+    /// <summary>When true, overlays a shape-aware loading skeleton on top of the chart (consumer is fetching data). Flips back to the real chart once set to false.</summary>
+    [Parameter] public bool IsLoading { get; set; }
+    /// <summary>When true (default), renders a shape-aware skeleton while the chart has not yet mounted and whenever <see cref="IsLoading"/> is true. Set to <c>false</c> to opt out.</summary>
+    [Parameter] public bool ShowLoadingSkeleton { get; set; } = true;
+    /// <summary>Shape family for the loading skeleton. Defaults to <c>ChartSkeletonKind.Pie</c> for this chart type; override if you want a different silhouette.</summary>
+    [Parameter] public ChartSkeletonKind SkeletonKind { get; set; } = ChartSkeletonKind.Pie;
 
     [Parameter] public bool ShowDataLabels { get; set; }
     [Parameter] public string LabelPosition { get; set; } = "outside";

--- a/src/Lumeo/UI/Chart/Charts/PolarBarChart.razor
+++ b/src/Lumeo/UI/Chart/Charts/PolarBarChart.razor
@@ -1,6 +1,6 @@
 @namespace Lumeo
 
-<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" IsLoading="@IsLoading" ShowLoadingSkeleton="@ShowLoadingSkeleton" SkeletonKind="@SkeletonKind" @attributes="AdditionalAttributes" />
+<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" IsLoading="@IsLoading" ShowLoadingSkeleton="@ShowLoadingSkeleton" SkeletonKind="@SkeletonKind" SkeletonStyle="@SkeletonStyle" @attributes="AdditionalAttributes" />
 
 @code {
     [Parameter] public List<string> Categories { get; set; } = new();
@@ -19,6 +19,8 @@
     [Parameter] public bool ShowLoadingSkeleton { get; set; } = true;
     /// <summary>Shape family for the loading skeleton. Defaults to <c>ChartSkeletonKind.Generic</c> for this chart type; override if you want a different silhouette.</summary>
     [Parameter] public ChartSkeletonKind SkeletonKind { get; set; } = ChartSkeletonKind.Generic;
+    /// <summary>Phantom (default) renders the real chart with placeholder data and morphs to real data via ECharts' option-change animation. Silhouette falls back to the legacy SVG skeleton overlay.</summary>
+    [Parameter] public ChartSkeletonStyle SkeletonStyle { get; set; } = ChartSkeletonStyle.Phantom;
 
     [Parameter] public bool ShowDataLabels { get; set; }
     [Parameter] public string LabelPosition { get; set; } = "inside";

--- a/src/Lumeo/UI/Chart/Charts/PolarBarChart.razor
+++ b/src/Lumeo/UI/Chart/Charts/PolarBarChart.razor
@@ -1,6 +1,6 @@
 @namespace Lumeo
 
-<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" @attributes="AdditionalAttributes" />
+<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" IsLoading="@IsLoading" ShowLoadingSkeleton="@ShowLoadingSkeleton" SkeletonKind="@SkeletonKind" @attributes="AdditionalAttributes" />
 
 @code {
     [Parameter] public List<string> Categories { get; set; } = new();
@@ -13,6 +13,12 @@
     [Parameter] public string? Theme { get; set; }
     [Parameter] public string? Class { get; set; }
     [Parameter(CaptureUnmatchedValues = true)] public Dictionary<string, object>? AdditionalAttributes { get; set; }
+    /// <summary>When true, overlays a shape-aware loading skeleton on top of the chart (consumer is fetching data). Flips back to the real chart once set to false.</summary>
+    [Parameter] public bool IsLoading { get; set; }
+    /// <summary>When true (default), renders a shape-aware skeleton while the chart has not yet mounted and whenever <see cref="IsLoading"/> is true. Set to <c>false</c> to opt out.</summary>
+    [Parameter] public bool ShowLoadingSkeleton { get; set; } = true;
+    /// <summary>Shape family for the loading skeleton. Defaults to <c>ChartSkeletonKind.Generic</c> for this chart type; override if you want a different silhouette.</summary>
+    [Parameter] public ChartSkeletonKind SkeletonKind { get; set; } = ChartSkeletonKind.Generic;
 
     [Parameter] public bool ShowDataLabels { get; set; }
     [Parameter] public string LabelPosition { get; set; } = "inside";

--- a/src/Lumeo/UI/Chart/Charts/PolarBarChart.razor
+++ b/src/Lumeo/UI/Chart/Charts/PolarBarChart.razor
@@ -17,8 +17,8 @@
     [Parameter] public bool IsLoading { get; set; }
     /// <summary>When true (default), renders a shape-aware skeleton while the chart has not yet mounted and whenever <see cref="IsLoading"/> is true. Set to <c>false</c> to opt out.</summary>
     [Parameter] public bool ShowLoadingSkeleton { get; set; } = true;
-    /// <summary>Shape family for the loading skeleton. Defaults to <c>ChartSkeletonKind.Generic</c> for this chart type; override if you want a different silhouette.</summary>
-    [Parameter] public ChartSkeletonKind SkeletonKind { get; set; } = ChartSkeletonKind.Generic;
+    /// <summary>Shape family for the loading skeleton. Defaults to <c>ChartSkeletonKind.Polar</c> for this chart type; override if you want a different silhouette.</summary>
+    [Parameter] public ChartSkeletonKind SkeletonKind { get; set; } = ChartSkeletonKind.Polar;
     /// <summary>Phantom (default) renders the real chart with placeholder data and morphs to real data via ECharts' option-change animation. Silhouette falls back to the legacy SVG skeleton overlay.</summary>
     [Parameter] public ChartSkeletonStyle SkeletonStyle { get; set; } = ChartSkeletonStyle.Phantom;
     /// <summary>Phantom-mode refresh interval in milliseconds. Lower = faster data cycling while loading. Defaults to 1400.</summary>

--- a/src/Lumeo/UI/Chart/Charts/PolarBarChart.razor
+++ b/src/Lumeo/UI/Chart/Charts/PolarBarChart.razor
@@ -1,6 +1,6 @@
 @namespace Lumeo
 
-<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" IsLoading="@IsLoading" ShowLoadingSkeleton="@ShowLoadingSkeleton" SkeletonKind="@SkeletonKind" SkeletonStyle="@SkeletonStyle" @attributes="AdditionalAttributes" />
+<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" IsLoading="@IsLoading" ShowLoadingSkeleton="@ShowLoadingSkeleton" SkeletonKind="@SkeletonKind" SkeletonStyle="@SkeletonStyle" PhantomCycleMs="@PhantomCycleMs" @attributes="AdditionalAttributes" />
 
 @code {
     [Parameter] public List<string> Categories { get; set; } = new();
@@ -21,6 +21,8 @@
     [Parameter] public ChartSkeletonKind SkeletonKind { get; set; } = ChartSkeletonKind.Generic;
     /// <summary>Phantom (default) renders the real chart with placeholder data and morphs to real data via ECharts' option-change animation. Silhouette falls back to the legacy SVG skeleton overlay.</summary>
     [Parameter] public ChartSkeletonStyle SkeletonStyle { get; set; } = ChartSkeletonStyle.Phantom;
+    /// <summary>Phantom-mode refresh interval in milliseconds. Lower = faster data cycling while loading. Defaults to 1400.</summary>
+    [Parameter] public int PhantomCycleMs { get; set; } = 1400;
 
     [Parameter] public bool ShowDataLabels { get; set; }
     [Parameter] public string LabelPosition { get; set; } = "inside";

--- a/src/Lumeo/UI/Chart/Charts/RadarChart.razor
+++ b/src/Lumeo/UI/Chart/Charts/RadarChart.razor
@@ -1,6 +1,6 @@
 @namespace Lumeo
 
-<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" IsLoading="@IsLoading" ShowLoadingSkeleton="@ShowLoadingSkeleton" SkeletonKind="@SkeletonKind" @attributes="AdditionalAttributes" />
+<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" IsLoading="@IsLoading" ShowLoadingSkeleton="@ShowLoadingSkeleton" SkeletonKind="@SkeletonKind" SkeletonStyle="@SkeletonStyle" @attributes="AdditionalAttributes" />
 
 @code {
     [Parameter] public List<RadarIndicator> Indicators { get; set; } = new();
@@ -21,6 +21,8 @@
     [Parameter] public bool ShowLoadingSkeleton { get; set; } = true;
     /// <summary>Shape family for the loading skeleton. Defaults to <c>ChartSkeletonKind.Generic</c> for this chart type; override if you want a different silhouette.</summary>
     [Parameter] public ChartSkeletonKind SkeletonKind { get; set; } = ChartSkeletonKind.Generic;
+    /// <summary>Phantom (default) renders the real chart with placeholder data and morphs to real data via ECharts' option-change animation. Silhouette falls back to the legacy SVG skeleton overlay.</summary>
+    [Parameter] public ChartSkeletonStyle SkeletonStyle { get; set; } = ChartSkeletonStyle.Phantom;
 
     [Parameter] public bool ShowDataLabels { get; set; }
     [Parameter] public string LabelPosition { get; set; } = "top";

--- a/src/Lumeo/UI/Chart/Charts/RadarChart.razor
+++ b/src/Lumeo/UI/Chart/Charts/RadarChart.razor
@@ -1,6 +1,6 @@
 @namespace Lumeo
 
-<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" @attributes="AdditionalAttributes" />
+<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" IsLoading="@IsLoading" ShowLoadingSkeleton="@ShowLoadingSkeleton" SkeletonKind="@SkeletonKind" @attributes="AdditionalAttributes" />
 
 @code {
     [Parameter] public List<RadarIndicator> Indicators { get; set; } = new();
@@ -15,6 +15,12 @@
     [Parameter] public string? Theme { get; set; }
     [Parameter] public string? Class { get; set; }
     [Parameter(CaptureUnmatchedValues = true)] public Dictionary<string, object>? AdditionalAttributes { get; set; }
+    /// <summary>When true, overlays a shape-aware loading skeleton on top of the chart (consumer is fetching data). Flips back to the real chart once set to false.</summary>
+    [Parameter] public bool IsLoading { get; set; }
+    /// <summary>When true (default), renders a shape-aware skeleton while the chart has not yet mounted and whenever <see cref="IsLoading"/> is true. Set to <c>false</c> to opt out.</summary>
+    [Parameter] public bool ShowLoadingSkeleton { get; set; } = true;
+    /// <summary>Shape family for the loading skeleton. Defaults to <c>ChartSkeletonKind.Generic</c> for this chart type; override if you want a different silhouette.</summary>
+    [Parameter] public ChartSkeletonKind SkeletonKind { get; set; } = ChartSkeletonKind.Generic;
 
     [Parameter] public bool ShowDataLabels { get; set; }
     [Parameter] public string LabelPosition { get; set; } = "top";

--- a/src/Lumeo/UI/Chart/Charts/RadarChart.razor
+++ b/src/Lumeo/UI/Chart/Charts/RadarChart.razor
@@ -19,8 +19,8 @@
     [Parameter] public bool IsLoading { get; set; }
     /// <summary>When true (default), renders a shape-aware skeleton while the chart has not yet mounted and whenever <see cref="IsLoading"/> is true. Set to <c>false</c> to opt out.</summary>
     [Parameter] public bool ShowLoadingSkeleton { get; set; } = true;
-    /// <summary>Shape family for the loading skeleton. Defaults to <c>ChartSkeletonKind.Generic</c> for this chart type; override if you want a different silhouette.</summary>
-    [Parameter] public ChartSkeletonKind SkeletonKind { get; set; } = ChartSkeletonKind.Generic;
+    /// <summary>Shape family for the loading skeleton. Defaults to <c>ChartSkeletonKind.Radar</c> for this chart type; override if you want a different silhouette.</summary>
+    [Parameter] public ChartSkeletonKind SkeletonKind { get; set; } = ChartSkeletonKind.Radar;
     /// <summary>Phantom (default) renders the real chart with placeholder data and morphs to real data via ECharts' option-change animation. Silhouette falls back to the legacy SVG skeleton overlay.</summary>
     [Parameter] public ChartSkeletonStyle SkeletonStyle { get; set; } = ChartSkeletonStyle.Phantom;
     /// <summary>Phantom-mode refresh interval in milliseconds. Lower = faster data cycling while loading. Defaults to 1400.</summary>

--- a/src/Lumeo/UI/Chart/Charts/RadarChart.razor
+++ b/src/Lumeo/UI/Chart/Charts/RadarChart.razor
@@ -1,6 +1,6 @@
 @namespace Lumeo
 
-<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" IsLoading="@IsLoading" ShowLoadingSkeleton="@ShowLoadingSkeleton" SkeletonKind="@SkeletonKind" SkeletonStyle="@SkeletonStyle" @attributes="AdditionalAttributes" />
+<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" IsLoading="@IsLoading" ShowLoadingSkeleton="@ShowLoadingSkeleton" SkeletonKind="@SkeletonKind" SkeletonStyle="@SkeletonStyle" PhantomCycleMs="@PhantomCycleMs" @attributes="AdditionalAttributes" />
 
 @code {
     [Parameter] public List<RadarIndicator> Indicators { get; set; } = new();
@@ -23,6 +23,8 @@
     [Parameter] public ChartSkeletonKind SkeletonKind { get; set; } = ChartSkeletonKind.Generic;
     /// <summary>Phantom (default) renders the real chart with placeholder data and morphs to real data via ECharts' option-change animation. Silhouette falls back to the legacy SVG skeleton overlay.</summary>
     [Parameter] public ChartSkeletonStyle SkeletonStyle { get; set; } = ChartSkeletonStyle.Phantom;
+    /// <summary>Phantom-mode refresh interval in milliseconds. Lower = faster data cycling while loading. Defaults to 1400.</summary>
+    [Parameter] public int PhantomCycleMs { get; set; } = 1400;
 
     [Parameter] public bool ShowDataLabels { get; set; }
     [Parameter] public string LabelPosition { get; set; } = "top";

--- a/src/Lumeo/UI/Chart/Charts/RadialChart.razor
+++ b/src/Lumeo/UI/Chart/Charts/RadialChart.razor
@@ -1,6 +1,6 @@
 @namespace Lumeo
 
-<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" IsLoading="@IsLoading" ShowLoadingSkeleton="@ShowLoadingSkeleton" SkeletonKind="@SkeletonKind" @attributes="AdditionalAttributes" />
+<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" IsLoading="@IsLoading" ShowLoadingSkeleton="@ShowLoadingSkeleton" SkeletonKind="@SkeletonKind" SkeletonStyle="@SkeletonStyle" @attributes="AdditionalAttributes" />
 
 @code {
     [Parameter] public double Value { get; set; }
@@ -20,6 +20,8 @@
     [Parameter] public bool ShowLoadingSkeleton { get; set; } = true;
     /// <summary>Shape family for the loading skeleton. Defaults to <c>ChartSkeletonKind.Pie</c> for this chart type; override if you want a different silhouette.</summary>
     [Parameter] public ChartSkeletonKind SkeletonKind { get; set; } = ChartSkeletonKind.Pie;
+    /// <summary>Phantom (default) renders the real chart with placeholder data and morphs to real data via ECharts' option-change animation. Silhouette falls back to the legacy SVG skeleton overlay.</summary>
+    [Parameter] public ChartSkeletonStyle SkeletonStyle { get; set; } = ChartSkeletonStyle.Phantom;
 
     [Parameter] public bool ShowDataLabels { get; set; }
     [Parameter] public string LabelPosition { get; set; } = "top";

--- a/src/Lumeo/UI/Chart/Charts/RadialChart.razor
+++ b/src/Lumeo/UI/Chart/Charts/RadialChart.razor
@@ -1,6 +1,6 @@
 @namespace Lumeo
 
-<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" IsLoading="@IsLoading" ShowLoadingSkeleton="@ShowLoadingSkeleton" SkeletonKind="@SkeletonKind" SkeletonStyle="@SkeletonStyle" @attributes="AdditionalAttributes" />
+<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" IsLoading="@IsLoading" ShowLoadingSkeleton="@ShowLoadingSkeleton" SkeletonKind="@SkeletonKind" SkeletonStyle="@SkeletonStyle" PhantomCycleMs="@PhantomCycleMs" @attributes="AdditionalAttributes" />
 
 @code {
     [Parameter] public double Value { get; set; }
@@ -22,6 +22,8 @@
     [Parameter] public ChartSkeletonKind SkeletonKind { get; set; } = ChartSkeletonKind.Pie;
     /// <summary>Phantom (default) renders the real chart with placeholder data and morphs to real data via ECharts' option-change animation. Silhouette falls back to the legacy SVG skeleton overlay.</summary>
     [Parameter] public ChartSkeletonStyle SkeletonStyle { get; set; } = ChartSkeletonStyle.Phantom;
+    /// <summary>Phantom-mode refresh interval in milliseconds. Lower = faster data cycling while loading. Defaults to 1400.</summary>
+    [Parameter] public int PhantomCycleMs { get; set; } = 1400;
 
     [Parameter] public bool ShowDataLabels { get; set; }
     [Parameter] public string LabelPosition { get; set; } = "top";

--- a/src/Lumeo/UI/Chart/Charts/RadialChart.razor
+++ b/src/Lumeo/UI/Chart/Charts/RadialChart.razor
@@ -1,6 +1,6 @@
 @namespace Lumeo
 
-<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" @attributes="AdditionalAttributes" />
+<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" IsLoading="@IsLoading" ShowLoadingSkeleton="@ShowLoadingSkeleton" SkeletonKind="@SkeletonKind" @attributes="AdditionalAttributes" />
 
 @code {
     [Parameter] public double Value { get; set; }
@@ -14,6 +14,12 @@
     [Parameter] public string? Theme { get; set; }
     [Parameter] public string? Class { get; set; }
     [Parameter(CaptureUnmatchedValues = true)] public Dictionary<string, object>? AdditionalAttributes { get; set; }
+    /// <summary>When true, overlays a shape-aware loading skeleton on top of the chart (consumer is fetching data). Flips back to the real chart once set to false.</summary>
+    [Parameter] public bool IsLoading { get; set; }
+    /// <summary>When true (default), renders a shape-aware skeleton while the chart has not yet mounted and whenever <see cref="IsLoading"/> is true. Set to <c>false</c> to opt out.</summary>
+    [Parameter] public bool ShowLoadingSkeleton { get; set; } = true;
+    /// <summary>Shape family for the loading skeleton. Defaults to <c>ChartSkeletonKind.Pie</c> for this chart type; override if you want a different silhouette.</summary>
+    [Parameter] public ChartSkeletonKind SkeletonKind { get; set; } = ChartSkeletonKind.Pie;
 
     [Parameter] public bool ShowDataLabels { get; set; }
     [Parameter] public string LabelPosition { get; set; } = "top";

--- a/src/Lumeo/UI/Chart/Charts/SankeyChart.razor
+++ b/src/Lumeo/UI/Chart/Charts/SankeyChart.razor
@@ -1,6 +1,6 @@
 @namespace Lumeo
 
-<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" @attributes="AdditionalAttributes" />
+<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" IsLoading="@IsLoading" ShowLoadingSkeleton="@ShowLoadingSkeleton" SkeletonKind="@SkeletonKind" @attributes="AdditionalAttributes" />
 
 @code {
     [Parameter] public List<SankeyNode> Nodes { get; set; } = new();
@@ -13,6 +13,12 @@
     [Parameter] public string? Theme { get; set; }
     [Parameter] public string? Class { get; set; }
     [Parameter(CaptureUnmatchedValues = true)] public Dictionary<string, object>? AdditionalAttributes { get; set; }
+    /// <summary>When true, overlays a shape-aware loading skeleton on top of the chart (consumer is fetching data). Flips back to the real chart once set to false.</summary>
+    [Parameter] public bool IsLoading { get; set; }
+    /// <summary>When true (default), renders a shape-aware skeleton while the chart has not yet mounted and whenever <see cref="IsLoading"/> is true. Set to <c>false</c> to opt out.</summary>
+    [Parameter] public bool ShowLoadingSkeleton { get; set; } = true;
+    /// <summary>Shape family for the loading skeleton. Defaults to <c>ChartSkeletonKind.Generic</c> for this chart type; override if you want a different silhouette.</summary>
+    [Parameter] public ChartSkeletonKind SkeletonKind { get; set; } = ChartSkeletonKind.Generic;
 
     [Parameter] public bool ShowDataLabels { get; set; }
     [Parameter] public string LabelPosition { get; set; } = "right";

--- a/src/Lumeo/UI/Chart/Charts/SankeyChart.razor
+++ b/src/Lumeo/UI/Chart/Charts/SankeyChart.razor
@@ -1,6 +1,6 @@
 @namespace Lumeo
 
-<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" IsLoading="@IsLoading" ShowLoadingSkeleton="@ShowLoadingSkeleton" SkeletonKind="@SkeletonKind" @attributes="AdditionalAttributes" />
+<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" IsLoading="@IsLoading" ShowLoadingSkeleton="@ShowLoadingSkeleton" SkeletonKind="@SkeletonKind" SkeletonStyle="@SkeletonStyle" @attributes="AdditionalAttributes" />
 
 @code {
     [Parameter] public List<SankeyNode> Nodes { get; set; } = new();
@@ -19,6 +19,8 @@
     [Parameter] public bool ShowLoadingSkeleton { get; set; } = true;
     /// <summary>Shape family for the loading skeleton. Defaults to <c>ChartSkeletonKind.Generic</c> for this chart type; override if you want a different silhouette.</summary>
     [Parameter] public ChartSkeletonKind SkeletonKind { get; set; } = ChartSkeletonKind.Generic;
+    /// <summary>Phantom (default) renders the real chart with placeholder data and morphs to real data via ECharts' option-change animation. Silhouette falls back to the legacy SVG skeleton overlay.</summary>
+    [Parameter] public ChartSkeletonStyle SkeletonStyle { get; set; } = ChartSkeletonStyle.Phantom;
 
     [Parameter] public bool ShowDataLabels { get; set; }
     [Parameter] public string LabelPosition { get; set; } = "right";

--- a/src/Lumeo/UI/Chart/Charts/SankeyChart.razor
+++ b/src/Lumeo/UI/Chart/Charts/SankeyChart.razor
@@ -1,6 +1,6 @@
 @namespace Lumeo
 
-<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" IsLoading="@IsLoading" ShowLoadingSkeleton="@ShowLoadingSkeleton" SkeletonKind="@SkeletonKind" SkeletonStyle="@SkeletonStyle" @attributes="AdditionalAttributes" />
+<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" IsLoading="@IsLoading" ShowLoadingSkeleton="@ShowLoadingSkeleton" SkeletonKind="@SkeletonKind" SkeletonStyle="@SkeletonStyle" PhantomCycleMs="@PhantomCycleMs" @attributes="AdditionalAttributes" />
 
 @code {
     [Parameter] public List<SankeyNode> Nodes { get; set; } = new();
@@ -21,6 +21,8 @@
     [Parameter] public ChartSkeletonKind SkeletonKind { get; set; } = ChartSkeletonKind.Generic;
     /// <summary>Phantom (default) renders the real chart with placeholder data and morphs to real data via ECharts' option-change animation. Silhouette falls back to the legacy SVG skeleton overlay.</summary>
     [Parameter] public ChartSkeletonStyle SkeletonStyle { get; set; } = ChartSkeletonStyle.Phantom;
+    /// <summary>Phantom-mode refresh interval in milliseconds. Lower = faster data cycling while loading. Defaults to 1400.</summary>
+    [Parameter] public int PhantomCycleMs { get; set; } = 1400;
 
     [Parameter] public bool ShowDataLabels { get; set; }
     [Parameter] public string LabelPosition { get; set; } = "right";

--- a/src/Lumeo/UI/Chart/Charts/SankeyChart.razor
+++ b/src/Lumeo/UI/Chart/Charts/SankeyChart.razor
@@ -17,8 +17,8 @@
     [Parameter] public bool IsLoading { get; set; }
     /// <summary>When true (default), renders a shape-aware skeleton while the chart has not yet mounted and whenever <see cref="IsLoading"/> is true. Set to <c>false</c> to opt out.</summary>
     [Parameter] public bool ShowLoadingSkeleton { get; set; } = true;
-    /// <summary>Shape family for the loading skeleton. Defaults to <c>ChartSkeletonKind.Generic</c> for this chart type; override if you want a different silhouette.</summary>
-    [Parameter] public ChartSkeletonKind SkeletonKind { get; set; } = ChartSkeletonKind.Generic;
+    /// <summary>Shape family for the loading skeleton. Defaults to <c>ChartSkeletonKind.Sankey</c> for this chart type; override if you want a different silhouette.</summary>
+    [Parameter] public ChartSkeletonKind SkeletonKind { get; set; } = ChartSkeletonKind.Sankey;
     /// <summary>Phantom (default) renders the real chart with placeholder data and morphs to real data via ECharts' option-change animation. Silhouette falls back to the legacy SVG skeleton overlay.</summary>
     [Parameter] public ChartSkeletonStyle SkeletonStyle { get; set; } = ChartSkeletonStyle.Phantom;
     /// <summary>Phantom-mode refresh interval in milliseconds. Lower = faster data cycling while loading. Defaults to 1400.</summary>

--- a/src/Lumeo/UI/Chart/Charts/ScatterChart.razor
+++ b/src/Lumeo/UI/Chart/Charts/ScatterChart.razor
@@ -1,6 +1,6 @@
 @namespace Lumeo
 
-<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" @attributes="AdditionalAttributes" />
+<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" IsLoading="@IsLoading" ShowLoadingSkeleton="@ShowLoadingSkeleton" SkeletonKind="@SkeletonKind" @attributes="AdditionalAttributes" />
 
 @code {
     [Parameter] public List<ScatterSeriesData> Series { get; set; } = new();
@@ -13,6 +13,12 @@
     [Parameter] public string? Theme { get; set; }
     [Parameter] public string? Class { get; set; }
     [Parameter(CaptureUnmatchedValues = true)] public Dictionary<string, object>? AdditionalAttributes { get; set; }
+    /// <summary>When true, overlays a shape-aware loading skeleton on top of the chart (consumer is fetching data). Flips back to the real chart once set to false.</summary>
+    [Parameter] public bool IsLoading { get; set; }
+    /// <summary>When true (default), renders a shape-aware skeleton while the chart has not yet mounted and whenever <see cref="IsLoading"/> is true. Set to <c>false</c> to opt out.</summary>
+    [Parameter] public bool ShowLoadingSkeleton { get; set; } = true;
+    /// <summary>Shape family for the loading skeleton. Defaults to <c>ChartSkeletonKind.Scatter</c> for this chart type; override if you want a different silhouette.</summary>
+    [Parameter] public ChartSkeletonKind SkeletonKind { get; set; } = ChartSkeletonKind.Scatter;
 
     [Parameter] public bool ShowDataLabels { get; set; }
     [Parameter] public string LabelPosition { get; set; } = "top";

--- a/src/Lumeo/UI/Chart/Charts/ScatterChart.razor
+++ b/src/Lumeo/UI/Chart/Charts/ScatterChart.razor
@@ -1,6 +1,6 @@
 @namespace Lumeo
 
-<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" IsLoading="@IsLoading" ShowLoadingSkeleton="@ShowLoadingSkeleton" SkeletonKind="@SkeletonKind" @attributes="AdditionalAttributes" />
+<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" IsLoading="@IsLoading" ShowLoadingSkeleton="@ShowLoadingSkeleton" SkeletonKind="@SkeletonKind" SkeletonStyle="@SkeletonStyle" @attributes="AdditionalAttributes" />
 
 @code {
     [Parameter] public List<ScatterSeriesData> Series { get; set; } = new();
@@ -19,6 +19,8 @@
     [Parameter] public bool ShowLoadingSkeleton { get; set; } = true;
     /// <summary>Shape family for the loading skeleton. Defaults to <c>ChartSkeletonKind.Scatter</c> for this chart type; override if you want a different silhouette.</summary>
     [Parameter] public ChartSkeletonKind SkeletonKind { get; set; } = ChartSkeletonKind.Scatter;
+    /// <summary>Phantom (default) renders the real chart with placeholder data and morphs to real data via ECharts' option-change animation. Silhouette falls back to the legacy SVG skeleton overlay.</summary>
+    [Parameter] public ChartSkeletonStyle SkeletonStyle { get; set; } = ChartSkeletonStyle.Phantom;
 
     [Parameter] public bool ShowDataLabels { get; set; }
     [Parameter] public string LabelPosition { get; set; } = "top";

--- a/src/Lumeo/UI/Chart/Charts/ScatterChart.razor
+++ b/src/Lumeo/UI/Chart/Charts/ScatterChart.razor
@@ -1,6 +1,6 @@
 @namespace Lumeo
 
-<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" IsLoading="@IsLoading" ShowLoadingSkeleton="@ShowLoadingSkeleton" SkeletonKind="@SkeletonKind" SkeletonStyle="@SkeletonStyle" @attributes="AdditionalAttributes" />
+<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" IsLoading="@IsLoading" ShowLoadingSkeleton="@ShowLoadingSkeleton" SkeletonKind="@SkeletonKind" SkeletonStyle="@SkeletonStyle" PhantomCycleMs="@PhantomCycleMs" @attributes="AdditionalAttributes" />
 
 @code {
     [Parameter] public List<ScatterSeriesData> Series { get; set; } = new();
@@ -21,6 +21,8 @@
     [Parameter] public ChartSkeletonKind SkeletonKind { get; set; } = ChartSkeletonKind.Scatter;
     /// <summary>Phantom (default) renders the real chart with placeholder data and morphs to real data via ECharts' option-change animation. Silhouette falls back to the legacy SVG skeleton overlay.</summary>
     [Parameter] public ChartSkeletonStyle SkeletonStyle { get; set; } = ChartSkeletonStyle.Phantom;
+    /// <summary>Phantom-mode refresh interval in milliseconds. Lower = faster data cycling while loading. Defaults to 1400.</summary>
+    [Parameter] public int PhantomCycleMs { get; set; } = 1400;
 
     [Parameter] public bool ShowDataLabels { get; set; }
     [Parameter] public string LabelPosition { get; set; } = "top";

--- a/src/Lumeo/UI/Chart/Charts/SunburstChart.razor
+++ b/src/Lumeo/UI/Chart/Charts/SunburstChart.razor
@@ -1,6 +1,6 @@
 @namespace Lumeo
 
-<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" IsLoading="@IsLoading" ShowLoadingSkeleton="@ShowLoadingSkeleton" SkeletonKind="@SkeletonKind" @attributes="AdditionalAttributes" />
+<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" IsLoading="@IsLoading" ShowLoadingSkeleton="@ShowLoadingSkeleton" SkeletonKind="@SkeletonKind" SkeletonStyle="@SkeletonStyle" @attributes="AdditionalAttributes" />
 
 @code {
     [Parameter] public List<SunburstData> Data { get; set; } = new();
@@ -18,6 +18,8 @@
     [Parameter] public bool ShowLoadingSkeleton { get; set; } = true;
     /// <summary>Shape family for the loading skeleton. Defaults to <c>ChartSkeletonKind.Pie</c> for this chart type; override if you want a different silhouette.</summary>
     [Parameter] public ChartSkeletonKind SkeletonKind { get; set; } = ChartSkeletonKind.Pie;
+    /// <summary>Phantom (default) renders the real chart with placeholder data and morphs to real data via ECharts' option-change animation. Silhouette falls back to the legacy SVG skeleton overlay.</summary>
+    [Parameter] public ChartSkeletonStyle SkeletonStyle { get; set; } = ChartSkeletonStyle.Phantom;
 
     [Parameter] public bool ShowDataLabels { get; set; }
     [Parameter] public string LabelPosition { get; set; } = "inside";

--- a/src/Lumeo/UI/Chart/Charts/SunburstChart.razor
+++ b/src/Lumeo/UI/Chart/Charts/SunburstChart.razor
@@ -1,6 +1,6 @@
 @namespace Lumeo
 
-<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" @attributes="AdditionalAttributes" />
+<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" IsLoading="@IsLoading" ShowLoadingSkeleton="@ShowLoadingSkeleton" SkeletonKind="@SkeletonKind" @attributes="AdditionalAttributes" />
 
 @code {
     [Parameter] public List<SunburstData> Data { get; set; } = new();
@@ -12,6 +12,12 @@
     [Parameter] public string? Theme { get; set; }
     [Parameter] public string? Class { get; set; }
     [Parameter(CaptureUnmatchedValues = true)] public Dictionary<string, object>? AdditionalAttributes { get; set; }
+    /// <summary>When true, overlays a shape-aware loading skeleton on top of the chart (consumer is fetching data). Flips back to the real chart once set to false.</summary>
+    [Parameter] public bool IsLoading { get; set; }
+    /// <summary>When true (default), renders a shape-aware skeleton while the chart has not yet mounted and whenever <see cref="IsLoading"/> is true. Set to <c>false</c> to opt out.</summary>
+    [Parameter] public bool ShowLoadingSkeleton { get; set; } = true;
+    /// <summary>Shape family for the loading skeleton. Defaults to <c>ChartSkeletonKind.Pie</c> for this chart type; override if you want a different silhouette.</summary>
+    [Parameter] public ChartSkeletonKind SkeletonKind { get; set; } = ChartSkeletonKind.Pie;
 
     [Parameter] public bool ShowDataLabels { get; set; }
     [Parameter] public string LabelPosition { get; set; } = "inside";

--- a/src/Lumeo/UI/Chart/Charts/SunburstChart.razor
+++ b/src/Lumeo/UI/Chart/Charts/SunburstChart.razor
@@ -1,6 +1,6 @@
 @namespace Lumeo
 
-<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" IsLoading="@IsLoading" ShowLoadingSkeleton="@ShowLoadingSkeleton" SkeletonKind="@SkeletonKind" SkeletonStyle="@SkeletonStyle" @attributes="AdditionalAttributes" />
+<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" IsLoading="@IsLoading" ShowLoadingSkeleton="@ShowLoadingSkeleton" SkeletonKind="@SkeletonKind" SkeletonStyle="@SkeletonStyle" PhantomCycleMs="@PhantomCycleMs" @attributes="AdditionalAttributes" />
 
 @code {
     [Parameter] public List<SunburstData> Data { get; set; } = new();
@@ -20,6 +20,8 @@
     [Parameter] public ChartSkeletonKind SkeletonKind { get; set; } = ChartSkeletonKind.Pie;
     /// <summary>Phantom (default) renders the real chart with placeholder data and morphs to real data via ECharts' option-change animation. Silhouette falls back to the legacy SVG skeleton overlay.</summary>
     [Parameter] public ChartSkeletonStyle SkeletonStyle { get; set; } = ChartSkeletonStyle.Phantom;
+    /// <summary>Phantom-mode refresh interval in milliseconds. Lower = faster data cycling while loading. Defaults to 1400.</summary>
+    [Parameter] public int PhantomCycleMs { get; set; } = 1400;
 
     [Parameter] public bool ShowDataLabels { get; set; }
     [Parameter] public string LabelPosition { get; set; } = "inside";

--- a/src/Lumeo/UI/Chart/Charts/ThemeRiverChart.razor
+++ b/src/Lumeo/UI/Chart/Charts/ThemeRiverChart.razor
@@ -1,6 +1,6 @@
 @namespace Lumeo
 
-<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" IsLoading="@IsLoading" ShowLoadingSkeleton="@ShowLoadingSkeleton" SkeletonKind="@SkeletonKind" @attributes="AdditionalAttributes" />
+<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" IsLoading="@IsLoading" ShowLoadingSkeleton="@ShowLoadingSkeleton" SkeletonKind="@SkeletonKind" SkeletonStyle="@SkeletonStyle" @attributes="AdditionalAttributes" />
 
 @code {
     [Parameter] public List<string[]> Data { get; set; } = new();
@@ -18,6 +18,8 @@
     [Parameter] public bool ShowLoadingSkeleton { get; set; } = true;
     /// <summary>Shape family for the loading skeleton. Defaults to <c>ChartSkeletonKind.Generic</c> for this chart type; override if you want a different silhouette.</summary>
     [Parameter] public ChartSkeletonKind SkeletonKind { get; set; } = ChartSkeletonKind.Generic;
+    /// <summary>Phantom (default) renders the real chart with placeholder data and morphs to real data via ECharts' option-change animation. Silhouette falls back to the legacy SVG skeleton overlay.</summary>
+    [Parameter] public ChartSkeletonStyle SkeletonStyle { get; set; } = ChartSkeletonStyle.Phantom;
 
     [Parameter] public bool ShowDataLabels { get; set; }
     [Parameter] public string LabelPosition { get; set; } = "top";

--- a/src/Lumeo/UI/Chart/Charts/ThemeRiverChart.razor
+++ b/src/Lumeo/UI/Chart/Charts/ThemeRiverChart.razor
@@ -1,6 +1,6 @@
 @namespace Lumeo
 
-<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" @attributes="AdditionalAttributes" />
+<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" IsLoading="@IsLoading" ShowLoadingSkeleton="@ShowLoadingSkeleton" SkeletonKind="@SkeletonKind" @attributes="AdditionalAttributes" />
 
 @code {
     [Parameter] public List<string[]> Data { get; set; } = new();
@@ -12,6 +12,12 @@
     [Parameter] public string? Theme { get; set; }
     [Parameter] public string? Class { get; set; }
     [Parameter(CaptureUnmatchedValues = true)] public Dictionary<string, object>? AdditionalAttributes { get; set; }
+    /// <summary>When true, overlays a shape-aware loading skeleton on top of the chart (consumer is fetching data). Flips back to the real chart once set to false.</summary>
+    [Parameter] public bool IsLoading { get; set; }
+    /// <summary>When true (default), renders a shape-aware skeleton while the chart has not yet mounted and whenever <see cref="IsLoading"/> is true. Set to <c>false</c> to opt out.</summary>
+    [Parameter] public bool ShowLoadingSkeleton { get; set; } = true;
+    /// <summary>Shape family for the loading skeleton. Defaults to <c>ChartSkeletonKind.Generic</c> for this chart type; override if you want a different silhouette.</summary>
+    [Parameter] public ChartSkeletonKind SkeletonKind { get; set; } = ChartSkeletonKind.Generic;
 
     [Parameter] public bool ShowDataLabels { get; set; }
     [Parameter] public string LabelPosition { get; set; } = "top";

--- a/src/Lumeo/UI/Chart/Charts/ThemeRiverChart.razor
+++ b/src/Lumeo/UI/Chart/Charts/ThemeRiverChart.razor
@@ -1,6 +1,6 @@
 @namespace Lumeo
 
-<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" IsLoading="@IsLoading" ShowLoadingSkeleton="@ShowLoadingSkeleton" SkeletonKind="@SkeletonKind" SkeletonStyle="@SkeletonStyle" @attributes="AdditionalAttributes" />
+<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" IsLoading="@IsLoading" ShowLoadingSkeleton="@ShowLoadingSkeleton" SkeletonKind="@SkeletonKind" SkeletonStyle="@SkeletonStyle" PhantomCycleMs="@PhantomCycleMs" @attributes="AdditionalAttributes" />
 
 @code {
     [Parameter] public List<string[]> Data { get; set; } = new();
@@ -20,6 +20,8 @@
     [Parameter] public ChartSkeletonKind SkeletonKind { get; set; } = ChartSkeletonKind.Generic;
     /// <summary>Phantom (default) renders the real chart with placeholder data and morphs to real data via ECharts' option-change animation. Silhouette falls back to the legacy SVG skeleton overlay.</summary>
     [Parameter] public ChartSkeletonStyle SkeletonStyle { get; set; } = ChartSkeletonStyle.Phantom;
+    /// <summary>Phantom-mode refresh interval in milliseconds. Lower = faster data cycling while loading. Defaults to 1400.</summary>
+    [Parameter] public int PhantomCycleMs { get; set; } = 1400;
 
     [Parameter] public bool ShowDataLabels { get; set; }
     [Parameter] public string LabelPosition { get; set; } = "top";

--- a/src/Lumeo/UI/Chart/Charts/TreeChart.razor
+++ b/src/Lumeo/UI/Chart/Charts/TreeChart.razor
@@ -1,6 +1,6 @@
 @namespace Lumeo
 
-<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" @attributes="AdditionalAttributes" />
+<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" IsLoading="@IsLoading" ShowLoadingSkeleton="@ShowLoadingSkeleton" SkeletonKind="@SkeletonKind" @attributes="AdditionalAttributes" />
 
 @code {
     [Parameter] public TreeData? Data { get; set; }
@@ -13,6 +13,12 @@
     [Parameter] public string? Theme { get; set; }
     [Parameter] public string? Class { get; set; }
     [Parameter(CaptureUnmatchedValues = true)] public Dictionary<string, object>? AdditionalAttributes { get; set; }
+    /// <summary>When true, overlays a shape-aware loading skeleton on top of the chart (consumer is fetching data). Flips back to the real chart once set to false.</summary>
+    [Parameter] public bool IsLoading { get; set; }
+    /// <summary>When true (default), renders a shape-aware skeleton while the chart has not yet mounted and whenever <see cref="IsLoading"/> is true. Set to <c>false</c> to opt out.</summary>
+    [Parameter] public bool ShowLoadingSkeleton { get; set; } = true;
+    /// <summary>Shape family for the loading skeleton. Defaults to <c>ChartSkeletonKind.Generic</c> for this chart type; override if you want a different silhouette.</summary>
+    [Parameter] public ChartSkeletonKind SkeletonKind { get; set; } = ChartSkeletonKind.Generic;
 
     [Parameter] public bool ShowDataLabels { get; set; }
     [Parameter] public string LabelPosition { get; set; } = "right";

--- a/src/Lumeo/UI/Chart/Charts/TreeChart.razor
+++ b/src/Lumeo/UI/Chart/Charts/TreeChart.razor
@@ -1,6 +1,6 @@
 @namespace Lumeo
 
-<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" IsLoading="@IsLoading" ShowLoadingSkeleton="@ShowLoadingSkeleton" SkeletonKind="@SkeletonKind" @attributes="AdditionalAttributes" />
+<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" IsLoading="@IsLoading" ShowLoadingSkeleton="@ShowLoadingSkeleton" SkeletonKind="@SkeletonKind" SkeletonStyle="@SkeletonStyle" @attributes="AdditionalAttributes" />
 
 @code {
     [Parameter] public TreeData? Data { get; set; }
@@ -19,6 +19,8 @@
     [Parameter] public bool ShowLoadingSkeleton { get; set; } = true;
     /// <summary>Shape family for the loading skeleton. Defaults to <c>ChartSkeletonKind.Generic</c> for this chart type; override if you want a different silhouette.</summary>
     [Parameter] public ChartSkeletonKind SkeletonKind { get; set; } = ChartSkeletonKind.Generic;
+    /// <summary>Phantom (default) renders the real chart with placeholder data and morphs to real data via ECharts' option-change animation. Silhouette falls back to the legacy SVG skeleton overlay.</summary>
+    [Parameter] public ChartSkeletonStyle SkeletonStyle { get; set; } = ChartSkeletonStyle.Phantom;
 
     [Parameter] public bool ShowDataLabels { get; set; }
     [Parameter] public string LabelPosition { get; set; } = "right";

--- a/src/Lumeo/UI/Chart/Charts/TreeChart.razor
+++ b/src/Lumeo/UI/Chart/Charts/TreeChart.razor
@@ -1,6 +1,6 @@
 @namespace Lumeo
 
-<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" IsLoading="@IsLoading" ShowLoadingSkeleton="@ShowLoadingSkeleton" SkeletonKind="@SkeletonKind" SkeletonStyle="@SkeletonStyle" @attributes="AdditionalAttributes" />
+<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" IsLoading="@IsLoading" ShowLoadingSkeleton="@ShowLoadingSkeleton" SkeletonKind="@SkeletonKind" SkeletonStyle="@SkeletonStyle" PhantomCycleMs="@PhantomCycleMs" @attributes="AdditionalAttributes" />
 
 @code {
     [Parameter] public TreeData? Data { get; set; }
@@ -21,6 +21,8 @@
     [Parameter] public ChartSkeletonKind SkeletonKind { get; set; } = ChartSkeletonKind.Generic;
     /// <summary>Phantom (default) renders the real chart with placeholder data and morphs to real data via ECharts' option-change animation. Silhouette falls back to the legacy SVG skeleton overlay.</summary>
     [Parameter] public ChartSkeletonStyle SkeletonStyle { get; set; } = ChartSkeletonStyle.Phantom;
+    /// <summary>Phantom-mode refresh interval in milliseconds. Lower = faster data cycling while loading. Defaults to 1400.</summary>
+    [Parameter] public int PhantomCycleMs { get; set; } = 1400;
 
     [Parameter] public bool ShowDataLabels { get; set; }
     [Parameter] public string LabelPosition { get; set; } = "right";

--- a/src/Lumeo/UI/Chart/Charts/TreeChart.razor
+++ b/src/Lumeo/UI/Chart/Charts/TreeChart.razor
@@ -17,8 +17,8 @@
     [Parameter] public bool IsLoading { get; set; }
     /// <summary>When true (default), renders a shape-aware skeleton while the chart has not yet mounted and whenever <see cref="IsLoading"/> is true. Set to <c>false</c> to opt out.</summary>
     [Parameter] public bool ShowLoadingSkeleton { get; set; } = true;
-    /// <summary>Shape family for the loading skeleton. Defaults to <c>ChartSkeletonKind.Generic</c> for this chart type; override if you want a different silhouette.</summary>
-    [Parameter] public ChartSkeletonKind SkeletonKind { get; set; } = ChartSkeletonKind.Generic;
+    /// <summary>Shape family for the loading skeleton. Defaults to <c>ChartSkeletonKind.Tree</c> for this chart type; override if you want a different silhouette.</summary>
+    [Parameter] public ChartSkeletonKind SkeletonKind { get; set; } = ChartSkeletonKind.Tree;
     /// <summary>Phantom (default) renders the real chart with placeholder data and morphs to real data via ECharts' option-change animation. Silhouette falls back to the legacy SVG skeleton overlay.</summary>
     [Parameter] public ChartSkeletonStyle SkeletonStyle { get; set; } = ChartSkeletonStyle.Phantom;
     /// <summary>Phantom-mode refresh interval in milliseconds. Lower = faster data cycling while loading. Defaults to 1400.</summary>

--- a/src/Lumeo/UI/Chart/Charts/TreemapChart.razor
+++ b/src/Lumeo/UI/Chart/Charts/TreemapChart.razor
@@ -1,6 +1,6 @@
 @namespace Lumeo
 
-<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" IsLoading="@IsLoading" ShowLoadingSkeleton="@ShowLoadingSkeleton" SkeletonKind="@SkeletonKind" SkeletonStyle="@SkeletonStyle" @attributes="AdditionalAttributes" />
+<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" IsLoading="@IsLoading" ShowLoadingSkeleton="@ShowLoadingSkeleton" SkeletonKind="@SkeletonKind" SkeletonStyle="@SkeletonStyle" PhantomCycleMs="@PhantomCycleMs" @attributes="AdditionalAttributes" />
 
 @code {
     [Parameter] public List<TreemapData> Data { get; set; } = new();
@@ -20,6 +20,8 @@
     [Parameter] public ChartSkeletonKind SkeletonKind { get; set; } = ChartSkeletonKind.Grid;
     /// <summary>Phantom (default) renders the real chart with placeholder data and morphs to real data via ECharts' option-change animation. Silhouette falls back to the legacy SVG skeleton overlay.</summary>
     [Parameter] public ChartSkeletonStyle SkeletonStyle { get; set; } = ChartSkeletonStyle.Phantom;
+    /// <summary>Phantom-mode refresh interval in milliseconds. Lower = faster data cycling while loading. Defaults to 1400.</summary>
+    [Parameter] public int PhantomCycleMs { get; set; } = 1400;
 
     [Parameter] public bool ShowDataLabels { get; set; }
     [Parameter] public string LabelPosition { get; set; } = "inside";

--- a/src/Lumeo/UI/Chart/Charts/TreemapChart.razor
+++ b/src/Lumeo/UI/Chart/Charts/TreemapChart.razor
@@ -1,6 +1,6 @@
 @namespace Lumeo
 
-<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" IsLoading="@IsLoading" ShowLoadingSkeleton="@ShowLoadingSkeleton" SkeletonKind="@SkeletonKind" @attributes="AdditionalAttributes" />
+<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" IsLoading="@IsLoading" ShowLoadingSkeleton="@ShowLoadingSkeleton" SkeletonKind="@SkeletonKind" SkeletonStyle="@SkeletonStyle" @attributes="AdditionalAttributes" />
 
 @code {
     [Parameter] public List<TreemapData> Data { get; set; } = new();
@@ -18,6 +18,8 @@
     [Parameter] public bool ShowLoadingSkeleton { get; set; } = true;
     /// <summary>Shape family for the loading skeleton. Defaults to <c>ChartSkeletonKind.Grid</c> for this chart type; override if you want a different silhouette.</summary>
     [Parameter] public ChartSkeletonKind SkeletonKind { get; set; } = ChartSkeletonKind.Grid;
+    /// <summary>Phantom (default) renders the real chart with placeholder data and morphs to real data via ECharts' option-change animation. Silhouette falls back to the legacy SVG skeleton overlay.</summary>
+    [Parameter] public ChartSkeletonStyle SkeletonStyle { get; set; } = ChartSkeletonStyle.Phantom;
 
     [Parameter] public bool ShowDataLabels { get; set; }
     [Parameter] public string LabelPosition { get; set; } = "inside";

--- a/src/Lumeo/UI/Chart/Charts/TreemapChart.razor
+++ b/src/Lumeo/UI/Chart/Charts/TreemapChart.razor
@@ -1,6 +1,6 @@
 @namespace Lumeo
 
-<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" @attributes="AdditionalAttributes" />
+<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" IsLoading="@IsLoading" ShowLoadingSkeleton="@ShowLoadingSkeleton" SkeletonKind="@SkeletonKind" @attributes="AdditionalAttributes" />
 
 @code {
     [Parameter] public List<TreemapData> Data { get; set; } = new();
@@ -12,6 +12,12 @@
     [Parameter] public string? Theme { get; set; }
     [Parameter] public string? Class { get; set; }
     [Parameter(CaptureUnmatchedValues = true)] public Dictionary<string, object>? AdditionalAttributes { get; set; }
+    /// <summary>When true, overlays a shape-aware loading skeleton on top of the chart (consumer is fetching data). Flips back to the real chart once set to false.</summary>
+    [Parameter] public bool IsLoading { get; set; }
+    /// <summary>When true (default), renders a shape-aware skeleton while the chart has not yet mounted and whenever <see cref="IsLoading"/> is true. Set to <c>false</c> to opt out.</summary>
+    [Parameter] public bool ShowLoadingSkeleton { get; set; } = true;
+    /// <summary>Shape family for the loading skeleton. Defaults to <c>ChartSkeletonKind.Grid</c> for this chart type; override if you want a different silhouette.</summary>
+    [Parameter] public ChartSkeletonKind SkeletonKind { get; set; } = ChartSkeletonKind.Grid;
 
     [Parameter] public bool ShowDataLabels { get; set; }
     [Parameter] public string LabelPosition { get; set; } = "inside";

--- a/src/Lumeo/UI/Chart/Charts/WaterfallChart.razor
+++ b/src/Lumeo/UI/Chart/Charts/WaterfallChart.razor
@@ -1,6 +1,6 @@
 @namespace Lumeo
 
-<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" @attributes="AdditionalAttributes" />
+<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" IsLoading="@IsLoading" ShowLoadingSkeleton="@ShowLoadingSkeleton" SkeletonKind="@SkeletonKind" @attributes="AdditionalAttributes" />
 
 @code {
     [Parameter] public List<string> Categories { get; set; } = new();
@@ -15,6 +15,12 @@
     [Parameter] public string? Theme { get; set; }
     [Parameter] public string? Class { get; set; }
     [Parameter(CaptureUnmatchedValues = true)] public Dictionary<string, object>? AdditionalAttributes { get; set; }
+    /// <summary>When true, overlays a shape-aware loading skeleton on top of the chart (consumer is fetching data). Flips back to the real chart once set to false.</summary>
+    [Parameter] public bool IsLoading { get; set; }
+    /// <summary>When true (default), renders a shape-aware skeleton while the chart has not yet mounted and whenever <see cref="IsLoading"/> is true. Set to <c>false</c> to opt out.</summary>
+    [Parameter] public bool ShowLoadingSkeleton { get; set; } = true;
+    /// <summary>Shape family for the loading skeleton. Defaults to <c>ChartSkeletonKind.Bars</c> for this chart type; override if you want a different silhouette.</summary>
+    [Parameter] public ChartSkeletonKind SkeletonKind { get; set; } = ChartSkeletonKind.Bars;
 
     [Parameter] public bool ShowDataLabels { get; set; }
     [Parameter] public string LabelPosition { get; set; } = "top";

--- a/src/Lumeo/UI/Chart/Charts/WaterfallChart.razor
+++ b/src/Lumeo/UI/Chart/Charts/WaterfallChart.razor
@@ -1,6 +1,6 @@
 @namespace Lumeo
 
-<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" IsLoading="@IsLoading" ShowLoadingSkeleton="@ShowLoadingSkeleton" SkeletonKind="@SkeletonKind" @attributes="AdditionalAttributes" />
+<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" IsLoading="@IsLoading" ShowLoadingSkeleton="@ShowLoadingSkeleton" SkeletonKind="@SkeletonKind" SkeletonStyle="@SkeletonStyle" @attributes="AdditionalAttributes" />
 
 @code {
     [Parameter] public List<string> Categories { get; set; } = new();
@@ -21,6 +21,8 @@
     [Parameter] public bool ShowLoadingSkeleton { get; set; } = true;
     /// <summary>Shape family for the loading skeleton. Defaults to <c>ChartSkeletonKind.Bars</c> for this chart type; override if you want a different silhouette.</summary>
     [Parameter] public ChartSkeletonKind SkeletonKind { get; set; } = ChartSkeletonKind.Bars;
+    /// <summary>Phantom (default) renders the real chart with placeholder data and morphs to real data via ECharts' option-change animation. Silhouette falls back to the legacy SVG skeleton overlay.</summary>
+    [Parameter] public ChartSkeletonStyle SkeletonStyle { get; set; } = ChartSkeletonStyle.Phantom;
 
     [Parameter] public bool ShowDataLabels { get; set; }
     [Parameter] public string LabelPosition { get; set; } = "top";

--- a/src/Lumeo/UI/Chart/Charts/WaterfallChart.razor
+++ b/src/Lumeo/UI/Chart/Charts/WaterfallChart.razor
@@ -1,6 +1,6 @@
 @namespace Lumeo
 
-<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" IsLoading="@IsLoading" ShowLoadingSkeleton="@ShowLoadingSkeleton" SkeletonKind="@SkeletonKind" SkeletonStyle="@SkeletonStyle" @attributes="AdditionalAttributes" />
+<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" IsLoading="@IsLoading" ShowLoadingSkeleton="@ShowLoadingSkeleton" SkeletonKind="@SkeletonKind" SkeletonStyle="@SkeletonStyle" PhantomCycleMs="@PhantomCycleMs" @attributes="AdditionalAttributes" />
 
 @code {
     [Parameter] public List<string> Categories { get; set; } = new();
@@ -23,6 +23,8 @@
     [Parameter] public ChartSkeletonKind SkeletonKind { get; set; } = ChartSkeletonKind.Bars;
     /// <summary>Phantom (default) renders the real chart with placeholder data and morphs to real data via ECharts' option-change animation. Silhouette falls back to the legacy SVG skeleton overlay.</summary>
     [Parameter] public ChartSkeletonStyle SkeletonStyle { get; set; } = ChartSkeletonStyle.Phantom;
+    /// <summary>Phantom-mode refresh interval in milliseconds. Lower = faster data cycling while loading. Defaults to 1400.</summary>
+    [Parameter] public int PhantomCycleMs { get; set; } = 1400;
 
     [Parameter] public bool ShowDataLabels { get; set; }
     [Parameter] public string LabelPosition { get; set; } = "top";

--- a/src/Lumeo/UI/Chart/Charts/WordCloudChart.razor
+++ b/src/Lumeo/UI/Chart/Charts/WordCloudChart.razor
@@ -4,7 +4,7 @@
 @if (_extensionLoaded)
 {
     <Chart OptionJson="@_optionJson" Width="@Width" Height="@Height" Theme="@Theme"
-           EChartsSource="@EChartsSource" Class="@Class" IsLoading="@IsLoading" ShowLoadingSkeleton="@ShowLoadingSkeleton" SkeletonKind="@SkeletonKind" SkeletonStyle="@SkeletonStyle" @attributes="AdditionalAttributes" />
+           EChartsSource="@EChartsSource" Class="@Class" IsLoading="@IsLoading" ShowLoadingSkeleton="@ShowLoadingSkeleton" SkeletonKind="@SkeletonKind" SkeletonStyle="@SkeletonStyle" PhantomCycleMs="@PhantomCycleMs" @attributes="AdditionalAttributes" />
 }
 else
 {
@@ -33,6 +33,8 @@ else
     [Parameter] public ChartSkeletonKind SkeletonKind { get; set; } = ChartSkeletonKind.Generic;
     /// <summary>Phantom (default) renders the real chart with placeholder data and morphs to real data via ECharts' option-change animation. Silhouette falls back to the legacy SVG skeleton overlay.</summary>
     [Parameter] public ChartSkeletonStyle SkeletonStyle { get; set; } = ChartSkeletonStyle.Phantom;
+    /// <summary>Phantom-mode refresh interval in milliseconds. Lower = faster data cycling while loading. Defaults to 1400.</summary>
+    [Parameter] public int PhantomCycleMs { get; set; } = 1400;
 
     [Parameter] public bool ShowDataLabels { get; set; }
     [Parameter] public string LabelPosition { get; set; } = "center";

--- a/src/Lumeo/UI/Chart/Charts/WordCloudChart.razor
+++ b/src/Lumeo/UI/Chart/Charts/WordCloudChart.razor
@@ -4,7 +4,7 @@
 @if (_extensionLoaded)
 {
     <Chart OptionJson="@_optionJson" Width="@Width" Height="@Height" Theme="@Theme"
-           EChartsSource="@EChartsSource" Class="@Class" IsLoading="@IsLoading" ShowLoadingSkeleton="@ShowLoadingSkeleton" SkeletonKind="@SkeletonKind" @attributes="AdditionalAttributes" />
+           EChartsSource="@EChartsSource" Class="@Class" IsLoading="@IsLoading" ShowLoadingSkeleton="@ShowLoadingSkeleton" SkeletonKind="@SkeletonKind" SkeletonStyle="@SkeletonStyle" @attributes="AdditionalAttributes" />
 }
 else
 {
@@ -31,6 +31,8 @@ else
     [Parameter] public bool ShowLoadingSkeleton { get; set; } = true;
     /// <summary>Shape family for the loading skeleton. Defaults to <c>ChartSkeletonKind.Generic</c> for this chart type; override if you want a different silhouette.</summary>
     [Parameter] public ChartSkeletonKind SkeletonKind { get; set; } = ChartSkeletonKind.Generic;
+    /// <summary>Phantom (default) renders the real chart with placeholder data and morphs to real data via ECharts' option-change animation. Silhouette falls back to the legacy SVG skeleton overlay.</summary>
+    [Parameter] public ChartSkeletonStyle SkeletonStyle { get; set; } = ChartSkeletonStyle.Phantom;
 
     [Parameter] public bool ShowDataLabels { get; set; }
     [Parameter] public string LabelPosition { get; set; } = "center";

--- a/src/Lumeo/UI/Chart/Charts/WordCloudChart.razor
+++ b/src/Lumeo/UI/Chart/Charts/WordCloudChart.razor
@@ -4,7 +4,7 @@
 @if (_extensionLoaded)
 {
     <Chart OptionJson="@_optionJson" Width="@Width" Height="@Height" Theme="@Theme"
-           EChartsSource="@EChartsSource" Class="@Class" @attributes="AdditionalAttributes" />
+           EChartsSource="@EChartsSource" Class="@Class" IsLoading="@IsLoading" ShowLoadingSkeleton="@ShowLoadingSkeleton" SkeletonKind="@SkeletonKind" @attributes="AdditionalAttributes" />
 }
 else
 {
@@ -25,6 +25,12 @@ else
     [Parameter] public string? Theme { get; set; }
     [Parameter] public string? Class { get; set; }
     [Parameter(CaptureUnmatchedValues = true)] public Dictionary<string, object>? AdditionalAttributes { get; set; }
+    /// <summary>When true, overlays a shape-aware loading skeleton on top of the chart (consumer is fetching data). Flips back to the real chart once set to false.</summary>
+    [Parameter] public bool IsLoading { get; set; }
+    /// <summary>When true (default), renders a shape-aware skeleton while the chart has not yet mounted and whenever <see cref="IsLoading"/> is true. Set to <c>false</c> to opt out.</summary>
+    [Parameter] public bool ShowLoadingSkeleton { get; set; } = true;
+    /// <summary>Shape family for the loading skeleton. Defaults to <c>ChartSkeletonKind.Generic</c> for this chart type; override if you want a different silhouette.</summary>
+    [Parameter] public ChartSkeletonKind SkeletonKind { get; set; } = ChartSkeletonKind.Generic;
 
     [Parameter] public bool ShowDataLabels { get; set; }
     [Parameter] public string LabelPosition { get; set; } = "center";

--- a/src/Lumeo/UI/Chart/EChartOption.cs
+++ b/src/Lumeo/UI/Chart/EChartOption.cs
@@ -142,6 +142,22 @@ public class EChartTextStyle
 
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? FontFamily { get; set; }
+
+    /// <summary>Background fill behind legend/text — used for phantom skeleton-box rendering.</summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? BackgroundColor { get; set; }
+
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public int[]? Padding { get; set; }
+
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public int? BorderRadius { get; set; }
+
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public int? Width { get; set; }
+
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public int? Height { get; set; }
 }
 
 public class EChartTooltip
@@ -273,6 +289,29 @@ public class EChartAxisLabel
     /// Leave null for ECharts' default auto-thinning (hides overlapping labels).</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public int? Interval { get; set; }
+
+    /// <summary>Background fill behind the label text — used by phantom-mode skeleton boxes
+    /// where we want label rectangles to show while the real text is transparent.</summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? BackgroundColor { get; set; }
+
+    /// <summary>Padding inside the label background — [top, right, bottom, left].</summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public int[]? Padding { get; set; }
+
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public int? BorderRadius { get; set; }
+
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public int? Width { get; set; }
+
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public int? Height { get; set; }
+
+    /// <summary>When true (and a category label formatter returns the raw value), forces the
+    /// label to render as a formatted string — mainly a knob for phantom-box rendering.</summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Formatter { get; set; }
 }
 
 public class EChartLineStyle

--- a/src/Lumeo/UI/DataGrid/DataGrid.razor
+++ b/src/Lumeo/UI/DataGrid/DataGrid.razor
@@ -98,7 +98,8 @@
                              ShowSearch="ShowSearch"
                              ShowColumnChooser="ShowColumnChooser"
                              ShowExport="ShowExport"
-                             ExportFormats="ExportFormats" />
+                             ExportFormats="ExportFormats"
+                             ToolbarContentClass="@ToolbarContentClass" />
         }
 
         @if (_contextMenuVisible)
@@ -273,6 +274,10 @@
     // --- Templates ---
     [Parameter] public RenderFragment? ChildContent { get; set; }
     [Parameter] public RenderFragment? ToolbarContent { get; set; }
+
+    /// <summary>Custom CSS classes applied to the toolbar content wrapper
+    /// (the flex row holding <see cref="ToolbarContent"/> + filter chips).</summary>
+    [Parameter] public string? ToolbarContentClass { get; set; }
     [Parameter] public RenderFragment<TItem>? DetailTemplate { get; set; }
     [Parameter] public RenderFragment? EmptyContent { get; set; }
     [Parameter] public RenderFragment<TItem>? RowContextMenu { get; set; }

--- a/src/Lumeo/UI/DataGrid/DataGrid.razor
+++ b/src/Lumeo/UI/DataGrid/DataGrid.razor
@@ -359,8 +359,16 @@
 
     internal void RegisterToolbarContent(ToolbarContent<TItem> tc)
     {
-        RegisteredToolbarContent = tc;
-        InvokeAsync(StateHasChanged);
+        // Re-registration from the child's OnParametersSet happens on every render;
+        // only flag a re-render when the instance actually changed, otherwise we'd
+        // loop (StateHasChanged → child re-renders → re-registers → StateHasChanged).
+        // Class/ChildContent updates on the SAME instance are already read by the
+        // next natural parent render (we dereference them at render time).
+        if (!ReferenceEquals(RegisteredToolbarContent, tc))
+        {
+            RegisteredToolbarContent = tc;
+            InvokeAsync(StateHasChanged);
+        }
     }
 
     internal void UnregisterToolbarContent(ToolbarContent<TItem> tc)

--- a/src/Lumeo/UI/DataGrid/DataGrid.razor
+++ b/src/Lumeo/UI/DataGrid/DataGrid.razor
@@ -1,5 +1,6 @@
 @namespace Lumeo
 @typeparam TItem
+@attribute [CascadingTypeParameter(nameof(TItem))]
 @implements IAsyncDisposable
 @inject Lumeo.Services.Localization.ILumeoLocalizer L
 @inject Lumeo.Services.ToastService Toast
@@ -75,7 +76,7 @@
             <DataGridToolbar TItem="TItem"
                              SearchText="@_globalSearch"
                              SearchTextChanged="HandleGlobalSearch"
-                             ToolbarContent="ToolbarContent"
+                             RegisteredContent="@RegisteredToolbarContent"
                              OnColumnToggle="HandleColumnVisibilityChanged"
                              OnColumnReorder="HandleColumnReorder"
                              OnExport="HandleExport"
@@ -98,8 +99,7 @@
                              ShowSearch="ShowSearch"
                              ShowColumnChooser="ShowColumnChooser"
                              ShowExport="ShowExport"
-                             ExportFormats="ExportFormats"
-                             ToolbarContentClass="@ToolbarContentClass" />
+                             ExportFormats="ExportFormats" />
         }
 
         @if (_contextMenuVisible)
@@ -150,6 +150,7 @@
 
 <CascadingValue Value="this" IsFixed="true">
 <CascadingValue Value="context" IsFixed="false">
+<CascadingValue Value="_toolbarContext" IsFixed="false">
     @if (_isExpanded)
     {
         <div class="fixed inset-0 lumeo-datagrid-fullscreen-backdrop"
@@ -182,6 +183,7 @@
     {
         @gridRoot
     }
+</CascadingValue>
 </CascadingValue>
 </CascadingValue>
 
@@ -273,11 +275,6 @@
 
     // --- Templates ---
     [Parameter] public RenderFragment? ChildContent { get; set; }
-    [Parameter] public RenderFragment? ToolbarContent { get; set; }
-
-    /// <summary>Custom CSS classes applied to the toolbar content wrapper
-    /// (the flex row holding <see cref="ToolbarContent"/> + filter chips).</summary>
-    [Parameter] public string? ToolbarContentClass { get; set; }
     [Parameter] public RenderFragment<TItem>? DetailTemplate { get; set; }
     [Parameter] public RenderFragment? EmptyContent { get; set; }
     [Parameter] public RenderFragment<TItem>? RowContextMenu { get; set; }
@@ -349,6 +346,31 @@
     private bool _savedLayoutApplied; // tracks whether the SavedLayout parameter has been applied
     private DataGridLayoutService? _layoutService;
     private DataGridServerService? _serverService;
+    private DataGridToolbarContext<TItem> _toolbarContext = new();
+
+    // --- ToolbarContent component registration ---
+
+    /// <summary>
+    /// The <see cref="ToolbarContent{TItem}"/> component currently registered inside
+    /// this grid (at most one). Forwarded to <see cref="DataGridToolbar"/> so it can
+    /// render the custom ChildContent + Class in the toolbar's left-hand slot.
+    /// </summary>
+    internal ToolbarContent<TItem>? RegisteredToolbarContent { get; private set; }
+
+    internal void RegisterToolbarContent(ToolbarContent<TItem> tc)
+    {
+        RegisteredToolbarContent = tc;
+        InvokeAsync(StateHasChanged);
+    }
+
+    internal void UnregisterToolbarContent(ToolbarContent<TItem> tc)
+    {
+        if (RegisteredToolbarContent == tc)
+        {
+            RegisteredToolbarContent = null;
+            InvokeAsync(StateHasChanged);
+        }
+    }
 
     private List<DataGridColumn<TItem>> SourceColumns =>
         Columns is not null && Columns.Count > 0 ? Columns : _columnDefs;
@@ -587,6 +609,42 @@
             _selectedItems = SelectedItems.ToList();
             _selectedSet = new HashSet<TItem>(_selectedItems);
         }
+
+        PopulateToolbarContext();
+    }
+
+    /// <summary>
+    /// Rebuilds the cascading <see cref="DataGridToolbarContext{TItem}"/> used by the
+    /// extracted toolbar tool components (Fullscreen, CopySelected, Columns, Export,
+    /// Layouts) as well as any custom tools placed inside <see cref="ToolbarContent{TItem}"/>.
+    /// Called from OnParametersSetAsync so dependent values reflect the latest parameters.
+    /// </summary>
+    private void PopulateToolbarContext()
+    {
+        _toolbarContext.IsExpanded = _isExpanded;
+        _toolbarContext.Expandable = Expandable;
+        _toolbarContext.OnToggleExpanded = EventCallback.Factory.Create(this, ToggleExpanded);
+
+        _toolbarContext.SelectedItems = _selectedItems;
+        _toolbarContext.EffectiveColumns = EffectiveColumns.AsReadOnly();
+        _toolbarContext.OnColumnToggle = EventCallback.Factory.Create<DataGridColumn<TItem>>(this, HandleColumnVisibilityChanged);
+        _toolbarContext.OnColumnReorder = EventCallback.Factory.Create<ColumnReorderEventArgs>(this, HandleColumnReorder);
+
+        _toolbarContext.ExportFormats = ExportFormats;
+        _toolbarContext.OnExport = EventCallback.Factory.Create<string>(this, HandleExport);
+
+        _toolbarContext.EnableLayoutPersistence = EnableLayoutPersistence;
+        _toolbarContext.GlobalLayouts = GlobalLayouts;
+        _toolbarContext.OnSaveLayout = EventCallback.Factory.Create(this, HandleSaveLayout);
+        _toolbarContext.OnResetLayout = EventCallback.Factory.Create(this, HandleResetLayout);
+        _toolbarContext.OnSaveNamedLayout = EventCallback.Factory.Create<DataGridNamedLayout>(this, HandleSaveNamedLayout);
+        _toolbarContext.OnDeleteNamedLayout = OnDeleteNamedLayout;
+        _toolbarContext.OnApplyNamedLayout = EventCallback.Factory.Create<DataGridNamedLayout>(this, HandleApplyNamedLayout);
+        _toolbarContext.LayoutStorageKey = LayoutStorageKey;
+        _toolbarContext.OnError = OnError;
+
+        _toolbarContext.Interop = Interop;
+        _toolbarContext.Localizer = L;
     }
 
     protected override async Task OnAfterRenderAsync(bool firstRender)

--- a/src/Lumeo/UI/DataGrid/DataGridHeaderCell.razor
+++ b/src/Lumeo/UI/DataGrid/DataGridHeaderCell.razor
@@ -108,7 +108,6 @@
             : Context.Filters.FirstOrDefault(f => f.Field == Column.Field);
 
     private string _resizeHandleId = $"dg-resize-{Guid.NewGuid():N}";
-    private double _startWidth;
     private bool _resizeRegistered;
     private bool _isDragOver;
     private string? _dropSide; // "left" or "right" — where the drop indicator is rendered
@@ -188,26 +187,18 @@
     {
         if (!Column.Resizable) return;
 
-        _startWidth = Column.Width ?? 150;
-
         if (!_resizeRegistered)
         {
+            // Register once, pass the column's min/max constraints up-front. JS drags the
+            // header + body cells in the DOM directly (smooth, no Blazor round-trips per
+            // pixel) and invokes the commit callback with the final width on mouseup.
             await Interop.RegisterColumnResize(
                 _resizeHandleId,
-                async delta =>
+                Column.MinWidth ?? 50,
+                Column.MaxWidth,
+                async finalWidth =>
                 {
-                    // delta is incremental (per mouse move), so accumulate it
-                    var currentWidth = Column.Width ?? 150;
-                    var newWidth = currentWidth + delta;
-                    if (Column.MinWidth.HasValue) newWidth = Math.Max(Column.MinWidth.Value, newWidth);
-                    else newWidth = Math.Max(50, newWidth);
-                    if (Column.MaxWidth.HasValue) newWidth = Math.Min(Column.MaxWidth.Value, newWidth);
-
-                    ParentGrid?.UpdateColumnWidth(Column.Id, newWidth);
-                },
-                async () =>
-                {
-                    _startWidth = Column.Width ?? 150;
+                    ParentGrid?.UpdateColumnWidth(Column.Id, finalWidth);
                     await InvokeAsync(StateHasChanged);
                 });
             _resizeRegistered = true;

--- a/src/Lumeo/UI/DataGrid/DataGridToolbar.razor
+++ b/src/Lumeo/UI/DataGrid/DataGridToolbar.razor
@@ -39,37 +39,43 @@
         }
     </div>
 
-    <div class="flex items-center gap-2">
-        @* Expand to fullscreen *@
-        @if (Expandable)
-        {
-            <DataGridToolbarFullscreen TItem="TItem" />
-        }
+    @* When the consumer supplies a <ToolbarContent>, they take full control of the
+       tools — the default right-hand stack is suppressed to avoid duplicates. Each
+       tool inside ToolbarContent renders wherever the consumer places it. *@
+    @if (RegisteredContent is null)
+    {
+        <div class="flex items-center gap-2">
+            @* Expand to fullscreen *@
+            @if (Expandable)
+            {
+                <DataGridToolbarFullscreen TItem="TItem" />
+            }
 
-        @* Copy selected rows to clipboard *@
-        @if (SelectedItems is not null && SelectedItems.Count > 0 && EffectiveColumns is not null)
-        {
-            <DataGridToolbarCopySelected TItem="TItem" />
-        }
+            @* Copy selected rows to clipboard *@
+            @if (SelectedItems is not null && SelectedItems.Count > 0 && EffectiveColumns is not null)
+            {
+                <DataGridToolbarCopySelected TItem="TItem" />
+            }
 
-        @* Column visibility dropdown *@
-        @if (ShowColumnChooser)
-        {
-            <DataGridToolbarColumns TItem="TItem" />
-        }
+            @* Column visibility dropdown *@
+            @if (ShowColumnChooser)
+            {
+                <DataGridToolbarColumns TItem="TItem" />
+            }
 
-        @* Export dropdown — hidden when ShowExport=false OR ExportFormats has no flags set. *@
-        @if (ShowExport && ExportFormats != DataGridExportFormat.None)
-        {
-            <DataGridToolbarExport TItem="TItem" />
-        }
+            @* Export dropdown — hidden when ShowExport=false OR ExportFormats has no flags set. *@
+            @if (ShowExport && ExportFormats != DataGridExportFormat.None)
+            {
+                <DataGridToolbarExport TItem="TItem" />
+            }
 
-        @* Layouts dropdown *@
-        @if (EnableLayoutPersistence)
-        {
-            <DataGridToolbarLayouts TItem="TItem" />
-        }
-    </div>
+            @* Layouts dropdown *@
+            @if (EnableLayoutPersistence)
+            {
+                <DataGridToolbarLayouts TItem="TItem" />
+            }
+        </div>
+    }
 </div>
 
 @code {

--- a/src/Lumeo/UI/DataGrid/DataGridToolbar.razor
+++ b/src/Lumeo/UI/DataGrid/DataGridToolbar.razor
@@ -16,6 +16,11 @@
             </div>
         }
 
+        @if (RegisteredContent?.ChildContent is not null)
+        {
+            @RegisteredContent.ChildContent
+        }
+
         @if (Context is not null)
         {
             @foreach (var filter in Context.Filters)
@@ -34,53 +39,50 @@
         }
     </div>
 
-    <CascadingValue Value="_toolbarContext" IsFixed="false">
-        <div class="flex items-center gap-2">
-            @if (ToolbarContent is not null)
-            {
-                @ToolbarContent
-            }
+    <div class="flex items-center gap-2">
+        @* Expand to fullscreen *@
+        @if (Expandable)
+        {
+            <DataGridToolbarFullscreen TItem="TItem" />
+        }
 
-            @* Expand to fullscreen *@
-            @if (Expandable)
-            {
-                <DataGridToolbarFullscreen TItem="TItem" />
-            }
+        @* Copy selected rows to clipboard *@
+        @if (SelectedItems is not null && SelectedItems.Count > 0 && EffectiveColumns is not null)
+        {
+            <DataGridToolbarCopySelected TItem="TItem" />
+        }
 
-            @* Copy selected rows to clipboard *@
-            @if (SelectedItems is not null && SelectedItems.Count > 0 && EffectiveColumns is not null)
-            {
-                <DataGridToolbarCopySelected TItem="TItem" />
-            }
+        @* Column visibility dropdown *@
+        @if (ShowColumnChooser)
+        {
+            <DataGridToolbarColumns TItem="TItem" />
+        }
 
-            @* Column visibility dropdown *@
-            @if (ShowColumnChooser)
-            {
-                <DataGridToolbarColumns TItem="TItem" />
-            }
+        @* Export dropdown — hidden when ShowExport=false OR ExportFormats has no flags set. *@
+        @if (ShowExport && ExportFormats != DataGridExportFormat.None)
+        {
+            <DataGridToolbarExport TItem="TItem" />
+        }
 
-            @* Export dropdown — hidden when ShowExport=false OR ExportFormats has no flags set. *@
-            @if (ShowExport && ExportFormats != DataGridExportFormat.None)
-            {
-                <DataGridToolbarExport TItem="TItem" />
-            }
-
-            @* Layouts dropdown *@
-            @if (EnableLayoutPersistence)
-            {
-                <DataGridToolbarLayouts TItem="TItem" />
-            }
-        </div>
-    </CascadingValue>
+        @* Layouts dropdown *@
+        @if (EnableLayoutPersistence)
+        {
+            <DataGridToolbarLayouts TItem="TItem" />
+        }
+    </div>
 </div>
 
 @code {
     [CascadingParameter] private DataGridContext<TItem>? Context { get; set; }
-    [Inject] private ComponentInteropService Interop { get; set; } = default!;
 
     [Parameter] public string? SearchText { get; set; }
     [Parameter] public EventCallback<string> SearchTextChanged { get; set; }
-    [Parameter] public RenderFragment? ToolbarContent { get; set; }
+
+    /// <summary>The <see cref="ToolbarContent{TItem}"/> component the consumer placed
+    /// inside the DataGrid, forwarded by the parent grid. When null, the toolbar's left
+    /// slot renders just the search + filter chips; when non-null, its Class styles the
+    /// wrapper and its ChildContent renders alongside the chips.</summary>
+    [Parameter] public ToolbarContent<TItem>? RegisteredContent { get; set; }
     [Parameter] public EventCallback OnColumnVisibilityToggle { get; set; }
     [Parameter] public EventCallback<DataGridColumn<TItem>> OnColumnToggle { get; set; }
     [Parameter] public EventCallback<ColumnReorderEventArgs> OnColumnReorder { get; set; }
@@ -114,44 +116,11 @@
     /// <summary>Which export formats to include in the dropdown. Default <see cref="DataGridExportFormat.All"/>.</summary>
     [Parameter] public DataGridExportFormat ExportFormats { get; set; } = DataGridExportFormat.All;
 
-    /// <summary>Custom CSS classes applied to the toolbar content wrapper
-    /// (the flex row holding <see cref="ToolbarContent"/> + filter chips).</summary>
-    [Parameter] public string? ToolbarContentClass { get; set; }
-
     [Parameter] public string? Class { get; set; }
     [Parameter(CaptureUnmatchedValues = true)] public Dictionary<string, object>? AdditionalAttributes { get; set; }
 
-    private DataGridToolbarContext<TItem> _toolbarContext = new();
     private string CssClass => $"flex items-center gap-2 px-4 py-3 border-b border-border/40 {Class}".Trim();
-    private string ContentWrapperClass => $"flex items-center gap-2 flex-1 {ToolbarContentClass}".Trim();
-
-    protected override void OnParametersSet()
-    {
-        _toolbarContext.IsExpanded = IsExpanded;
-        _toolbarContext.Expandable = Expandable;
-        _toolbarContext.OnToggleExpanded = OnToggleExpanded;
-
-        _toolbarContext.SelectedItems = SelectedItems;
-        _toolbarContext.EffectiveColumns = EffectiveColumns;
-        _toolbarContext.OnColumnToggle = OnColumnToggle;
-        _toolbarContext.OnColumnReorder = OnColumnReorder;
-
-        _toolbarContext.ExportFormats = ExportFormats;
-        _toolbarContext.OnExport = OnExport;
-
-        _toolbarContext.EnableLayoutPersistence = EnableLayoutPersistence;
-        _toolbarContext.GlobalLayouts = GlobalLayouts;
-        _toolbarContext.OnSaveLayout = OnSaveLayout;
-        _toolbarContext.OnResetLayout = OnResetLayout;
-        _toolbarContext.OnSaveNamedLayout = OnSaveNamedLayout;
-        _toolbarContext.OnDeleteNamedLayout = OnDeleteNamedLayout;
-        _toolbarContext.OnApplyNamedLayout = OnApplyNamedLayout;
-        _toolbarContext.LayoutStorageKey = LayoutStorageKey;
-        _toolbarContext.OnError = OnError;
-
-        _toolbarContext.Interop = Interop;
-        _toolbarContext.Localizer = L;
-    }
+    private string ContentWrapperClass => $"flex items-center gap-2 flex-1 {RegisteredContent?.Class}".Trim();
 
     private async Task OnSearchInput(ChangeEventArgs e)
     {

--- a/src/Lumeo/UI/DataGrid/DataGridToolbar.razor
+++ b/src/Lumeo/UI/DataGrid/DataGridToolbar.razor
@@ -3,7 +3,7 @@
 @inject Lumeo.Services.Localization.ILumeoLocalizer L
 
 <div data-slot="datagrid-toolbar" class="@CssClass" @attributes="AdditionalAttributes">
-    <div class="flex items-center gap-2 flex-1">
+    <div class="@ContentWrapperClass">
         @if (ShowSearch)
         {
             <div class="relative">
@@ -34,251 +34,44 @@
         }
     </div>
 
-    <div class="flex items-center gap-2">
-        @if (ToolbarContent is not null)
-        {
-            @ToolbarContent
-        }
+    <CascadingValue Value="_toolbarContext" IsFixed="false">
+        <div class="flex items-center gap-2">
+            @if (ToolbarContent is not null)
+            {
+                @ToolbarContent
+            }
 
-        @* Expand to fullscreen *@
-        @if (Expandable)
-        {
-            <Button Variant="Button.ButtonVariant.Ghost" Size="Button.ButtonSize.Icon"
-                    OnClick="@(() => OnToggleExpanded.InvokeAsync())"
-                    title="@(IsExpanded ? L["DataGrid.ExitFullscreen"] : L["DataGrid.ExpandFullscreen"])"
-                    aria-label="@(IsExpanded ? L["DataGrid.ExitFullscreen"] : L["DataGrid.ExpandFullscreen"])">
-                @if (IsExpanded)
-                {
-                    <Blazicon Svg="Lucide.Minimize2" class="h-4 w-4" />
-                }
-                else
-                {
-                    <Blazicon Svg="Lucide.Maximize2" class="h-4 w-4" />
-                }
-            </Button>
-        }
+            @* Expand to fullscreen *@
+            @if (Expandable)
+            {
+                <DataGridToolbarFullscreen TItem="TItem" />
+            }
 
-        @* Copy selected rows to clipboard *@
-        @if (SelectedItems is not null && SelectedItems.Count > 0 && EffectiveColumns is not null)
-        {
-            <button type="button"
-                    class="inline-flex items-center justify-center h-8 px-3 rounded-md text-sm border border-input bg-background hover:bg-accent hover:text-accent-foreground transition-colors"
-                    title="@L["DataGrid.CopySelected", SelectedItems.Count]"
-                    @onclick="CopySelected">
-                <Blazicon Svg="Lucide.Clipboard" class="h-4 w-4 mr-1.5" />
-                <span>@L["DataGrid.CopySelected", SelectedItems.Count]</span>
-            </button>
-        }
+            @* Copy selected rows to clipboard *@
+            @if (SelectedItems is not null && SelectedItems.Count > 0 && EffectiveColumns is not null)
+            {
+                <DataGridToolbarCopySelected TItem="TItem" />
+            }
 
-        @* Column visibility dropdown *@
-        @if (ShowColumnChooser)
-        {
-            <div class="relative">
-                <button type="button"
-                        class="inline-flex items-center justify-center h-8 px-3 rounded-md text-sm border border-input bg-background hover:bg-accent hover:text-accent-foreground transition-colors"
-                        @onclick="ToggleColumnPanel">
-                    <Blazicon Svg="Lucide.Columns3" class="h-4 w-4 mr-1.5" />
-                    <span>@L["DataGrid.Columns"]</span>
-                </button>
+            @* Column visibility dropdown *@
+            @if (ShowColumnChooser)
+            {
+                <DataGridToolbarColumns TItem="TItem" />
+            }
 
-                @if (_columnPanelOpen && EffectiveColumns is not null)
-                {
-                    <div class="absolute right-0 top-full mt-1 z-50">
-                        <DataGridColumnVisibility TItem="TItem"
-                                                  Columns="EffectiveColumns"
-                                                  OnColumnToggle="OnColumnToggle"
-                                                  OnColumnReorder="OnColumnReorder" />
-                    </div>
-                }
-            </div>
-        }
+            @* Export dropdown — hidden when ShowExport=false OR ExportFormats has no flags set. *@
+            @if (ShowExport && ExportFormats != DataGridExportFormat.None)
+            {
+                <DataGridToolbarExport TItem="TItem" />
+            }
 
-        @* Export dropdown — hidden when ShowExport=false OR ExportFormats has no flags set. *@
-        @if (ShowExport && ExportFormats != DataGridExportFormat.None)
-        {
-            <div class="relative">
-                <button type="button"
-                        class="inline-flex items-center justify-center h-8 px-3 rounded-md text-sm border border-input bg-background hover:bg-accent hover:text-accent-foreground transition-colors"
-                        @onclick="ToggleExportMenu">
-                    <Blazicon Svg="Lucide.Download" class="h-4 w-4 mr-1.5" />
-                    <span>@L["DataGrid.Export"]</span>
-                    <Blazicon Svg="Lucide.ChevronDown" class="h-3.5 w-3.5 ml-1" />
-                </button>
-
-                @if (_exportMenuOpen)
-                {
-                    <div class="absolute right-0 top-full mt-1 z-50 min-w-[140px] rounded-md border border-border/40 bg-popover p-1 shadow-md">
-                        @if (ExportFormats.HasFlag(DataGridExportFormat.Csv))
-                        {
-                            <button type="button"
-                                    data-export-format="csv"
-                                    class="w-full flex items-center gap-2 rounded px-3 py-1.5 text-sm hover:bg-accent hover:text-accent-foreground"
-                                    @onclick="@(() => Export("csv"))">
-                                <Blazicon Svg="Lucide.FileText" class="h-4 w-4" />
-                                <span>CSV</span>
-                            </button>
-                        }
-                        @if (ExportFormats.HasFlag(DataGridExportFormat.Excel))
-                        {
-                            <button type="button"
-                                    data-export-format="excel"
-                                    class="w-full flex items-center gap-2 rounded px-3 py-1.5 text-sm hover:bg-accent hover:text-accent-foreground"
-                                    @onclick="@(() => Export("excel"))">
-                                <Blazicon Svg="Lucide.Sheet" class="h-4 w-4" />
-                                <span>Excel</span>
-                            </button>
-                        }
-                        @if (ExportFormats.HasFlag(DataGridExportFormat.Pdf))
-                        {
-                            <button type="button"
-                                    data-export-format="pdf"
-                                    class="w-full flex items-center gap-2 rounded px-3 py-1.5 text-sm hover:bg-accent hover:text-accent-foreground"
-                                    @onclick="@(() => Export("pdf"))">
-                                <Blazicon Svg="Lucide.FileDown" class="h-4 w-4" />
-                                <span>PDF</span>
-                            </button>
-                        }
-                    </div>
-                }
-            </div>
-        }
-
-        @* Layouts dropdown *@
-        @if (EnableLayoutPersistence)
-        {
-            <div class="relative">
-                <button type="button"
-                        class="inline-flex items-center justify-center h-8 px-3 rounded-md text-sm border border-input bg-background hover:bg-accent hover:text-accent-foreground transition-colors"
-                        @onclick="ToggleLayoutsPanel">
-                    <Blazicon Svg="Lucide.LayoutTemplate" class="h-4 w-4 mr-1.5" />
-                    <span>@L["DataGrid.Layouts"]</span>
-                    <Blazicon Svg="Lucide.ChevronDown" class="h-3.5 w-3.5 ml-1" />
-                </button>
-
-                @if (_layoutsPanelOpen)
-                {
-                    <div class="absolute right-0 top-full mt-1 z-50 w-72 rounded-md border border-border/40 bg-popover shadow-md overflow-hidden">
-
-                        @* Personal layouts *@
-                        <div class="px-3 py-2 text-xs font-semibold text-muted-foreground uppercase tracking-wider border-b border-border/40 bg-muted/30">
-                            @L["DataGrid.Personal"]
-                        </div>
-                        <div class="p-1">
-                            @if (_personalLayouts.Count == 0)
-                            {
-                                <div class="px-3 py-1.5 text-xs text-muted-foreground italic">@L["DataGrid.NoSavedLayouts"]</div>
-                            }
-                            else
-                            {
-                                @foreach (var layout in _personalLayouts)
-                                {
-                                    var l = layout;
-                                    <div class="flex items-center gap-1 rounded px-2 py-1 hover:bg-accent group">
-                                        <span class="flex-1 text-sm truncate">@l.Name</span>
-                                        <button type="button"
-                                                class="inline-flex items-center justify-center h-6 w-6 rounded text-muted-foreground hover:text-foreground hover:bg-accent-foreground/10 opacity-0 group-hover:opacity-100 transition-opacity"
-                                                title="@L["DataGrid.ApplyLayout"]"
-                                                @onclick="@(async () => await ApplyLayout(l))">
-                                            <Blazicon Svg="Lucide.Check" class="h-3.5 w-3.5" />
-                                        </button>
-                                        <button type="button"
-                                                class="inline-flex items-center justify-center h-6 w-6 rounded text-muted-foreground hover:text-destructive hover:bg-destructive/10 opacity-0 group-hover:opacity-100 transition-opacity"
-                                                title="@L["DataGrid.Delete"]"
-                                                @onclick="@(async () => await DeletePersonalLayout(l.Id))">
-                                            <Blazicon Svg="Lucide.X" class="h-3.5 w-3.5" />
-                                        </button>
-                                    </div>
-                                }
-                            }
-
-                            @* Save current layout *@
-                            @if (_showSaveInput)
-                            {
-                                <div class="flex items-center gap-1 px-2 py-1 mt-0.5">
-                                    <input type="text"
-                                           class="flex-1 h-7 rounded border border-input bg-background px-2 text-xs focus-visible:outline-none focus-visible:ring-[1.5px] focus-visible:ring-ring"
-                                           placeholder="@L["DataGrid.LayoutName"]"
-                                           @bind="_newLayoutName"
-                                           @bind:event="oninput"
-                                           @onkeydown="HandleSaveKeyDown" />
-                                    <button type="button"
-                                            class="inline-flex items-center justify-center h-7 w-7 rounded border border-input bg-background hover:bg-accent transition-colors"
-                                            title="@L["DataGrid.Save"]"
-                                            @onclick="CommitSavePersonal">
-                                        <Blazicon Svg="Lucide.Check" class="h-3.5 w-3.5" />
-                                    </button>
-                                    <button type="button"
-                                            class="inline-flex items-center justify-center h-7 w-7 rounded border border-input bg-background hover:bg-accent transition-colors"
-                                            title="@L["DataGrid.Cancel"]"
-                                            @onclick="@(() => { _showSaveInput = false; _newLayoutName = ""; })">
-                                        <Blazicon Svg="Lucide.X" class="h-3.5 w-3.5" />
-                                    </button>
-                                </div>
-                            }
-                            else
-                            {
-                                <button type="button"
-                                        class="w-full flex items-center gap-2 rounded px-3 py-1.5 mt-0.5 text-sm text-muted-foreground hover:bg-accent hover:text-accent-foreground transition-colors"
-                                        @onclick="@(() => _showSaveInput = true)">
-                                    <Blazicon Svg="Lucide.Plus" class="h-3.5 w-3.5" />
-                                    <span>@L["DataGrid.SaveCurrentLayout"]</span>
-                                </button>
-                            }
-                        </div>
-
-                        @* Global layouts *@
-                        @if (GlobalLayouts is not null && GlobalLayouts.Count > 0)
-                        {
-                            <div class="px-3 py-2 text-xs font-semibold text-muted-foreground uppercase tracking-wider border-t border-b border-border/40 bg-muted/30">
-                                @L["DataGrid.Global"]
-                            </div>
-                            <div class="p-1">
-                                @foreach (var layout in GlobalLayouts.Where(l => l.Scope == "Global"))
-                                {
-                                    var l = layout;
-                                    <div class="flex items-center gap-1 rounded px-2 py-1 hover:bg-accent group">
-                                        <span class="flex-1 text-sm truncate">@l.Name</span>
-                                        <button type="button"
-                                                class="inline-flex items-center justify-center h-6 w-6 rounded text-muted-foreground hover:text-foreground hover:bg-accent-foreground/10 opacity-0 group-hover:opacity-100 transition-opacity"
-                                                title="@L["DataGrid.ApplyLayout"]"
-                                                @onclick="@(async () => await ApplyLayout(l))">
-                                            <Blazicon Svg="Lucide.Check" class="h-3.5 w-3.5" />
-                                        </button>
-                                        @if (OnDeleteNamedLayout.HasDelegate)
-                                        {
-                                            <button type="button"
-                                                    class="inline-flex items-center justify-center h-6 w-6 rounded text-muted-foreground hover:text-destructive hover:bg-destructive/10 opacity-0 group-hover:opacity-100 transition-opacity"
-                                                    title="@L["DataGrid.Delete"]"
-                                                    @onclick="@(async () => { _layoutsPanelOpen = false; await OnDeleteNamedLayout.InvokeAsync(l.Id); })">
-                                                <Blazicon Svg="Lucide.X" class="h-3.5 w-3.5" />
-                                            </button>
-                                        }
-                                    </div>
-                                }
-                            </div>
-                        }
-
-                        @* System Default *@
-                        <div class="px-3 py-2 text-xs font-semibold text-muted-foreground uppercase tracking-wider border-t border-b border-border/40 bg-muted/30">
-                            @L["DataGrid.SystemDefault"]
-                        </div>
-                        <div class="p-1">
-                            <div class="flex items-center gap-1 rounded px-2 py-1 hover:bg-accent group">
-                                <span class="flex-1 text-sm truncate">@L["DataGrid.Default"]</span>
-                                <button type="button"
-                                        class="inline-flex items-center justify-center h-6 w-6 rounded text-muted-foreground hover:text-foreground hover:bg-accent-foreground/10 opacity-0 group-hover:opacity-100 transition-opacity"
-                                        title="@L["DataGrid.ResetLayout"]"
-                                        @onclick="ResetLayout">
-                                    <Blazicon Svg="Lucide.Check" class="h-3.5 w-3.5" />
-                                </button>
-                            </div>
-                        </div>
-
-                    </div>
-                }
-            </div>
-        }
-    </div>
+            @* Layouts dropdown *@
+            @if (EnableLayoutPersistence)
+            {
+                <DataGridToolbarLayouts TItem="TItem" />
+            }
+        </div>
+    </CascadingValue>
 </div>
 
 @code {
@@ -321,23 +114,43 @@
     /// <summary>Which export formats to include in the dropdown. Default <see cref="DataGridExportFormat.All"/>.</summary>
     [Parameter] public DataGridExportFormat ExportFormats { get; set; } = DataGridExportFormat.All;
 
+    /// <summary>Custom CSS classes applied to the toolbar content wrapper
+    /// (the flex row holding <see cref="ToolbarContent"/> + filter chips).</summary>
+    [Parameter] public string? ToolbarContentClass { get; set; }
+
     [Parameter] public string? Class { get; set; }
     [Parameter(CaptureUnmatchedValues = true)] public Dictionary<string, object>? AdditionalAttributes { get; set; }
 
-    private bool _exportMenuOpen;
-    private bool _columnPanelOpen;
-    private bool _layoutsPanelOpen;
-    private bool _showSaveInput;
-    private string _newLayoutName = "";
-    private List<DataGridNamedLayout> _personalLayouts = new();
+    private DataGridToolbarContext<TItem> _toolbarContext = new();
     private string CssClass => $"flex items-center gap-2 px-4 py-3 border-b border-border/40 {Class}".Trim();
+    private string ContentWrapperClass => $"flex items-center gap-2 flex-1 {ToolbarContentClass}".Trim();
 
-    protected override async Task OnParametersSetAsync()
+    protected override void OnParametersSet()
     {
-        if (EnableLayoutPersistence && _layoutsPanelOpen)
-        {
-            await LoadPersonalLayouts();
-        }
+        _toolbarContext.IsExpanded = IsExpanded;
+        _toolbarContext.Expandable = Expandable;
+        _toolbarContext.OnToggleExpanded = OnToggleExpanded;
+
+        _toolbarContext.SelectedItems = SelectedItems;
+        _toolbarContext.EffectiveColumns = EffectiveColumns;
+        _toolbarContext.OnColumnToggle = OnColumnToggle;
+        _toolbarContext.OnColumnReorder = OnColumnReorder;
+
+        _toolbarContext.ExportFormats = ExportFormats;
+        _toolbarContext.OnExport = OnExport;
+
+        _toolbarContext.EnableLayoutPersistence = EnableLayoutPersistence;
+        _toolbarContext.GlobalLayouts = GlobalLayouts;
+        _toolbarContext.OnSaveLayout = OnSaveLayout;
+        _toolbarContext.OnResetLayout = OnResetLayout;
+        _toolbarContext.OnSaveNamedLayout = OnSaveNamedLayout;
+        _toolbarContext.OnDeleteNamedLayout = OnDeleteNamedLayout;
+        _toolbarContext.OnApplyNamedLayout = OnApplyNamedLayout;
+        _toolbarContext.LayoutStorageKey = LayoutStorageKey;
+        _toolbarContext.OnError = OnError;
+
+        _toolbarContext.Interop = Interop;
+        _toolbarContext.Localizer = L;
     }
 
     private async Task OnSearchInput(ChangeEventArgs e)
@@ -349,141 +162,6 @@
     private async Task RemoveFilter(FilterDescriptor filter)
     {
         await OnRemoveFilter.InvokeAsync(filter);
-    }
-
-    private void ToggleColumnPanel()
-    {
-        _columnPanelOpen = !_columnPanelOpen;
-        _exportMenuOpen = false;
-        _layoutsPanelOpen = false;
-    }
-
-    private void ToggleExportMenu()
-    {
-        _exportMenuOpen = !_exportMenuOpen;
-        _layoutsPanelOpen = false;
-        _columnPanelOpen = false;
-    }
-
-    private async Task Export(string format)
-    {
-        _exportMenuOpen = false;
-        await OnExport.InvokeAsync(format);
-    }
-
-    private async Task ToggleLayoutsPanel()
-    {
-        _exportMenuOpen = false;
-        _columnPanelOpen = false;
-        _layoutsPanelOpen = !_layoutsPanelOpen;
-        if (_layoutsPanelOpen)
-        {
-            await LoadPersonalLayouts();
-        }
-        else
-        {
-            _showSaveInput = false;
-            _newLayoutName = "";
-        }
-    }
-
-    private async Task LoadPersonalLayouts()
-    {
-        if (!EnableLayoutPersistence) return;
-        var key = (LayoutStorageKey ?? "datagrid") + "-named";
-        try
-        {
-            var json = await Interop.LoadFromLocalStorage(key);
-            if (!string.IsNullOrEmpty(json))
-                _personalLayouts = System.Text.Json.JsonSerializer.Deserialize<List<DataGridNamedLayout>>(json) ?? new();
-            else
-                _personalLayouts = new();
-        }
-        catch (Exception ex)
-        {
-            Console.Error.WriteLine($"[Lumeo DataGrid] Failed to load personal layouts: {ex.Message}");
-            _personalLayouts = new();
-            if (OnError.HasDelegate) await OnError.InvokeAsync(ex);
-        }
-    }
-
-    private async Task CommitSavePersonal()
-    {
-        var name = _newLayoutName.Trim();
-        if (string.IsNullOrEmpty(name)) return;
-
-        _showSaveInput = false;
-        _newLayoutName = "";
-
-        await OnSaveNamedLayout.InvokeAsync(new DataGridNamedLayout(Guid.NewGuid().ToString("N"), name, "Personal", new DataGridLayout()));
-        await LoadPersonalLayouts();
-        StateHasChanged();
-    }
-
-    private async Task HandleSaveKeyDown(KeyboardEventArgs e)
-    {
-        if (e.Key == "Enter") await CommitSavePersonal();
-        else if (e.Key == "Escape") { _showSaveInput = false; _newLayoutName = ""; }
-    }
-
-    private async Task ApplyLayout(DataGridNamedLayout layout)
-    {
-        _layoutsPanelOpen = false;
-        _showSaveInput = false;
-        await OnApplyNamedLayout.InvokeAsync(layout);
-    }
-
-    private async Task DeletePersonalLayout(string id)
-    {
-        _personalLayouts.RemoveAll(l => l.Id == id);
-        var key = (LayoutStorageKey ?? "datagrid") + "-named";
-        try
-        {
-            var json = System.Text.Json.JsonSerializer.Serialize(_personalLayouts);
-            await Interop.SaveToLocalStorage(key, json);
-        }
-        catch (Exception ex)
-        {
-            Console.Error.WriteLine($"[Lumeo DataGrid] Failed to save personal layouts: {ex.Message}");
-            if (OnError.HasDelegate) await OnError.InvokeAsync(ex);
-        }
-
-        if (OnDeleteNamedLayout.HasDelegate)
-            await OnDeleteNamedLayout.InvokeAsync(id);
-
-        StateHasChanged();
-    }
-
-    private async Task SaveLayout()
-    {
-        _layoutsPanelOpen = false;
-        await OnSaveLayout.InvokeAsync();
-    }
-
-    private async Task ResetLayout()
-    {
-        _layoutsPanelOpen = false;
-        await OnResetLayout.InvokeAsync();
-    }
-
-    private async Task CopySelected()
-    {
-        if (SelectedItems is null || SelectedItems.Count == 0 || EffectiveColumns is null) return;
-
-        var visibleColumns = EffectiveColumns.Where(c => c.Visible).ToList();
-        var lines = new List<string>();
-
-        // Header row
-        lines.Add(string.Join("\t", visibleColumns.Select(c => c.Title ?? c.Field ?? "")));
-
-        // Data rows
-        foreach (var item in SelectedItems)
-        {
-            lines.Add(string.Join("\t", visibleColumns.Select(c => c.GetFormattedValue(item))));
-        }
-
-        var text = string.Join("\n", lines);
-        await Interop.CopyToClipboard(text);
     }
 
     private string GetOperatorLabel(FilterOperator op) => op switch

--- a/src/Lumeo/UI/DataGrid/DataGridToolbarColumns.razor
+++ b/src/Lumeo/UI/DataGrid/DataGridToolbarColumns.razor
@@ -1,0 +1,35 @@
+@namespace Lumeo
+@typeparam TItem
+
+@if (Context is not null && Context.EffectiveColumns is not null)
+{
+    <div class="relative">
+        <button type="button"
+                class="inline-flex items-center justify-center h-8 px-3 rounded-md text-sm border border-input bg-background hover:bg-accent hover:text-accent-foreground transition-colors"
+                @onclick="ToggleColumnPanel">
+            <Blazicon Svg="Lucide.Columns3" class="h-4 w-4 mr-1.5" />
+            <span>@Context.Localizer["DataGrid.Columns"]</span>
+        </button>
+
+        @if (_columnPanelOpen)
+        {
+            <div class="absolute right-0 top-full mt-1 z-50">
+                <DataGridColumnVisibility TItem="TItem"
+                                          Columns="Context.EffectiveColumns"
+                                          OnColumnToggle="Context.OnColumnToggle"
+                                          OnColumnReorder="Context.OnColumnReorder" />
+            </div>
+        }
+    </div>
+}
+
+@code {
+    [CascadingParameter] public DataGridToolbarContext<TItem>? Context { get; set; }
+
+    private bool _columnPanelOpen;
+
+    private void ToggleColumnPanel()
+    {
+        _columnPanelOpen = !_columnPanelOpen;
+    }
+}

--- a/src/Lumeo/UI/DataGrid/DataGridToolbarContext.cs
+++ b/src/Lumeo/UI/DataGrid/DataGridToolbarContext.cs
@@ -1,0 +1,36 @@
+using Microsoft.AspNetCore.Components;
+using Lumeo.Services;
+
+namespace Lumeo;
+
+/// <summary>State + callbacks shared with the extracted toolbar tool components
+/// (<see cref="DataGridToolbarFullscreen{TItem}"/>, <see cref="DataGridToolbarExport{TItem}"/>, etc.)
+/// via <see cref="CascadingValue{T}"/>. The generic
+/// parameter matches the grid's row type so column/selection tools stay type-safe.</summary>
+public sealed class DataGridToolbarContext<TItem>
+{
+    public bool IsExpanded { get; set; }
+    public bool Expandable { get; set; }
+    public EventCallback OnToggleExpanded { get; set; }
+
+    public List<TItem>? SelectedItems { get; set; }
+    public IReadOnlyList<DataGridColumn<TItem>>? EffectiveColumns { get; set; }
+    public EventCallback<DataGridColumn<TItem>> OnColumnToggle { get; set; }
+    public EventCallback<ColumnReorderEventArgs> OnColumnReorder { get; set; }
+
+    public DataGridExportFormat ExportFormats { get; set; } = DataGridExportFormat.All;
+    public EventCallback<string> OnExport { get; set; }
+
+    public bool EnableLayoutPersistence { get; set; }
+    public List<DataGridNamedLayout>? GlobalLayouts { get; set; }
+    public EventCallback OnSaveLayout { get; set; }
+    public EventCallback OnResetLayout { get; set; }
+    public EventCallback<DataGridNamedLayout> OnSaveNamedLayout { get; set; }
+    public EventCallback<string> OnDeleteNamedLayout { get; set; }
+    public EventCallback<DataGridNamedLayout> OnApplyNamedLayout { get; set; }
+    public string? LayoutStorageKey { get; set; }
+    public EventCallback<Exception> OnError { get; set; }
+
+    public ComponentInteropService Interop { get; set; } = default!;
+    public Services.Localization.ILumeoLocalizer Localizer { get; set; } = default!;
+}

--- a/src/Lumeo/UI/DataGrid/DataGridToolbarCopySelected.razor
+++ b/src/Lumeo/UI/DataGrid/DataGridToolbarCopySelected.razor
@@ -1,0 +1,38 @@
+@namespace Lumeo
+@typeparam TItem
+
+@if (Context is not null && Context.SelectedItems is { Count: > 0 } selected && Context.EffectiveColumns is not null)
+{
+    <button type="button"
+            class="inline-flex items-center justify-center h-8 px-3 rounded-md text-sm border border-input bg-background hover:bg-accent hover:text-accent-foreground transition-colors"
+            title="@Context.Localizer["DataGrid.CopySelected", selected.Count]"
+            @onclick="CopySelected">
+        <Blazicon Svg="Lucide.Clipboard" class="h-4 w-4 mr-1.5" />
+        <span>@Context.Localizer["DataGrid.CopySelected", selected.Count]</span>
+    </button>
+}
+
+@code {
+    [CascadingParameter] public DataGridToolbarContext<TItem>? Context { get; set; }
+
+    private async Task CopySelected()
+    {
+        if (Context is null) return;
+        if (Context.SelectedItems is null || Context.SelectedItems.Count == 0 || Context.EffectiveColumns is null) return;
+
+        var visibleColumns = Context.EffectiveColumns.Where(c => c.Visible).ToList();
+        var lines = new List<string>();
+
+        // Header row
+        lines.Add(string.Join("\t", visibleColumns.Select(c => c.Title ?? c.Field ?? "")));
+
+        // Data rows
+        foreach (var item in Context.SelectedItems)
+        {
+            lines.Add(string.Join("\t", visibleColumns.Select(c => c.GetFormattedValue(item))));
+        }
+
+        var text = string.Join("\n", lines);
+        await Context.Interop.CopyToClipboard(text);
+    }
+}

--- a/src/Lumeo/UI/DataGrid/DataGridToolbarExport.razor
+++ b/src/Lumeo/UI/DataGrid/DataGridToolbarExport.razor
@@ -1,0 +1,69 @@
+@namespace Lumeo
+@typeparam TItem
+
+@if (Context is not null && Context.ExportFormats != DataGridExportFormat.None)
+{
+    <div class="relative">
+        <button type="button"
+                class="inline-flex items-center justify-center h-8 px-3 rounded-md text-sm border border-input bg-background hover:bg-accent hover:text-accent-foreground transition-colors"
+                @onclick="ToggleExportMenu">
+            <Blazicon Svg="Lucide.Download" class="h-4 w-4 mr-1.5" />
+            <span>@Context.Localizer["DataGrid.Export"]</span>
+            <Blazicon Svg="Lucide.ChevronDown" class="h-3.5 w-3.5 ml-1" />
+        </button>
+
+        @if (_exportMenuOpen)
+        {
+            <div class="absolute right-0 top-full mt-1 z-50 min-w-[140px] rounded-md border border-border/40 bg-popover p-1 shadow-md">
+                @if (Context.ExportFormats.HasFlag(DataGridExportFormat.Csv))
+                {
+                    <button type="button"
+                            data-export-format="csv"
+                            class="w-full flex items-center gap-2 rounded px-3 py-1.5 text-sm hover:bg-accent hover:text-accent-foreground"
+                            @onclick="@(() => Export("csv"))">
+                        <Blazicon Svg="Lucide.FileText" class="h-4 w-4" />
+                        <span>CSV</span>
+                    </button>
+                }
+                @if (Context.ExportFormats.HasFlag(DataGridExportFormat.Excel))
+                {
+                    <button type="button"
+                            data-export-format="excel"
+                            class="w-full flex items-center gap-2 rounded px-3 py-1.5 text-sm hover:bg-accent hover:text-accent-foreground"
+                            @onclick="@(() => Export("excel"))">
+                        <Blazicon Svg="Lucide.Sheet" class="h-4 w-4" />
+                        <span>Excel</span>
+                    </button>
+                }
+                @if (Context.ExportFormats.HasFlag(DataGridExportFormat.Pdf))
+                {
+                    <button type="button"
+                            data-export-format="pdf"
+                            class="w-full flex items-center gap-2 rounded px-3 py-1.5 text-sm hover:bg-accent hover:text-accent-foreground"
+                            @onclick="@(() => Export("pdf"))">
+                        <Blazicon Svg="Lucide.FileDown" class="h-4 w-4" />
+                        <span>PDF</span>
+                    </button>
+                }
+            </div>
+        }
+    </div>
+}
+
+@code {
+    [CascadingParameter] public DataGridToolbarContext<TItem>? Context { get; set; }
+
+    private bool _exportMenuOpen;
+
+    private void ToggleExportMenu()
+    {
+        _exportMenuOpen = !_exportMenuOpen;
+    }
+
+    private async Task Export(string format)
+    {
+        if (Context is null) return;
+        _exportMenuOpen = false;
+        await Context.OnExport.InvokeAsync(format);
+    }
+}

--- a/src/Lumeo/UI/DataGrid/DataGridToolbarFullscreen.razor
+++ b/src/Lumeo/UI/DataGrid/DataGridToolbarFullscreen.razor
@@ -1,7 +1,9 @@
 @namespace Lumeo
 @typeparam TItem
 
-@if (Context is not null && Context.Expandable)
+@* No Expandable gate here — when consumers place this component inside <ToolbarContent>
+   they've already opted in; the Expandable flag on DataGrid only gates the default auto-render. *@
+@if (Context is not null)
 {
     <Button Variant="Button.ButtonVariant.Ghost" Size="Button.ButtonSize.Icon"
             OnClick="@(() => Context.OnToggleExpanded.InvokeAsync())"

--- a/src/Lumeo/UI/DataGrid/DataGridToolbarFullscreen.razor
+++ b/src/Lumeo/UI/DataGrid/DataGridToolbarFullscreen.razor
@@ -1,0 +1,23 @@
+@namespace Lumeo
+@typeparam TItem
+
+@if (Context is not null && Context.Expandable)
+{
+    <Button Variant="Button.ButtonVariant.Ghost" Size="Button.ButtonSize.Icon"
+            OnClick="@(() => Context.OnToggleExpanded.InvokeAsync())"
+            title="@(Context.IsExpanded ? Context.Localizer["DataGrid.ExitFullscreen"] : Context.Localizer["DataGrid.ExpandFullscreen"])"
+            aria-label="@(Context.IsExpanded ? Context.Localizer["DataGrid.ExitFullscreen"] : Context.Localizer["DataGrid.ExpandFullscreen"])">
+        @if (Context.IsExpanded)
+        {
+            <Blazicon Svg="Lucide.Minimize2" class="h-4 w-4" />
+        }
+        else
+        {
+            <Blazicon Svg="Lucide.Maximize2" class="h-4 w-4" />
+        }
+    </Button>
+}
+
+@code {
+    [CascadingParameter] public DataGridToolbarContext<TItem>? Context { get; set; }
+}

--- a/src/Lumeo/UI/DataGrid/DataGridToolbarLayouts.razor
+++ b/src/Lumeo/UI/DataGrid/DataGridToolbarLayouts.razor
@@ -1,7 +1,8 @@
 @namespace Lumeo
 @typeparam TItem
 
-@if (Context is not null && Context.EnableLayoutPersistence)
+@* No EnableLayoutPersistence gate — consumers place this component explicitly when they want it. *@
+@if (Context is not null)
 {
     <div class="relative">
         <button type="button"

--- a/src/Lumeo/UI/DataGrid/DataGridToolbarLayouts.razor
+++ b/src/Lumeo/UI/DataGrid/DataGridToolbarLayouts.razor
@@ -1,0 +1,252 @@
+@namespace Lumeo
+@typeparam TItem
+
+@if (Context is not null && Context.EnableLayoutPersistence)
+{
+    <div class="relative">
+        <button type="button"
+                class="inline-flex items-center justify-center h-8 px-3 rounded-md text-sm border border-input bg-background hover:bg-accent hover:text-accent-foreground transition-colors"
+                @onclick="ToggleLayoutsPanel">
+            <Blazicon Svg="Lucide.LayoutTemplate" class="h-4 w-4 mr-1.5" />
+            <span>@Context.Localizer["DataGrid.Layouts"]</span>
+            <Blazicon Svg="Lucide.ChevronDown" class="h-3.5 w-3.5 ml-1" />
+        </button>
+
+        @if (_layoutsPanelOpen)
+        {
+            <div class="absolute right-0 top-full mt-1 z-50 w-72 rounded-md border border-border/40 bg-popover shadow-md overflow-hidden">
+
+                @* Personal layouts *@
+                <div class="px-3 py-2 text-xs font-semibold text-muted-foreground uppercase tracking-wider border-b border-border/40 bg-muted/30">
+                    @Context.Localizer["DataGrid.Personal"]
+                </div>
+                <div class="p-1">
+                    @if (_personalLayouts.Count == 0)
+                    {
+                        <div class="px-3 py-1.5 text-xs text-muted-foreground italic">@Context.Localizer["DataGrid.NoSavedLayouts"]</div>
+                    }
+                    else
+                    {
+                        @foreach (var layout in _personalLayouts)
+                        {
+                            var l = layout;
+                            <div class="flex items-center gap-1 rounded px-2 py-1 hover:bg-accent group">
+                                <span class="flex-1 text-sm truncate">@l.Name</span>
+                                <button type="button"
+                                        class="inline-flex items-center justify-center h-6 w-6 rounded text-muted-foreground hover:text-foreground hover:bg-accent-foreground/10 opacity-0 group-hover:opacity-100 transition-opacity"
+                                        title="@Context.Localizer["DataGrid.ApplyLayout"]"
+                                        @onclick="@(async () => await ApplyLayout(l))">
+                                    <Blazicon Svg="Lucide.Check" class="h-3.5 w-3.5" />
+                                </button>
+                                <button type="button"
+                                        class="inline-flex items-center justify-center h-6 w-6 rounded text-muted-foreground hover:text-destructive hover:bg-destructive/10 opacity-0 group-hover:opacity-100 transition-opacity"
+                                        title="@Context.Localizer["DataGrid.Delete"]"
+                                        @onclick="@(async () => await DeletePersonalLayout(l.Id))">
+                                    <Blazicon Svg="Lucide.X" class="h-3.5 w-3.5" />
+                                </button>
+                            </div>
+                        }
+                    }
+
+                    @* Save current layout *@
+                    @if (_showSaveInput)
+                    {
+                        <div class="flex items-center gap-1 px-2 py-1 mt-0.5">
+                            <input type="text"
+                                   class="flex-1 h-7 rounded border border-input bg-background px-2 text-xs focus-visible:outline-none focus-visible:ring-[1.5px] focus-visible:ring-ring"
+                                   placeholder="@Context.Localizer["DataGrid.LayoutName"]"
+                                   @bind="_newLayoutName"
+                                   @bind:event="oninput"
+                                   @onkeydown="HandleSaveKeyDown" />
+                            <button type="button"
+                                    class="inline-flex items-center justify-center h-7 w-7 rounded border border-input bg-background hover:bg-accent transition-colors"
+                                    title="@Context.Localizer["DataGrid.Save"]"
+                                    @onclick="CommitSavePersonal">
+                                <Blazicon Svg="Lucide.Check" class="h-3.5 w-3.5" />
+                            </button>
+                            <button type="button"
+                                    class="inline-flex items-center justify-center h-7 w-7 rounded border border-input bg-background hover:bg-accent transition-colors"
+                                    title="@Context.Localizer["DataGrid.Cancel"]"
+                                    @onclick="@(() => { _showSaveInput = false; _newLayoutName = ""; })">
+                                <Blazicon Svg="Lucide.X" class="h-3.5 w-3.5" />
+                            </button>
+                        </div>
+                    }
+                    else
+                    {
+                        <button type="button"
+                                class="w-full flex items-center gap-2 rounded px-3 py-1.5 mt-0.5 text-sm text-muted-foreground hover:bg-accent hover:text-accent-foreground transition-colors"
+                                @onclick="@(() => _showSaveInput = true)">
+                            <Blazicon Svg="Lucide.Plus" class="h-3.5 w-3.5" />
+                            <span>@Context.Localizer["DataGrid.SaveCurrentLayout"]</span>
+                        </button>
+                    }
+                </div>
+
+                @* Global layouts *@
+                @if (Context.GlobalLayouts is not null && Context.GlobalLayouts.Count > 0)
+                {
+                    <div class="px-3 py-2 text-xs font-semibold text-muted-foreground uppercase tracking-wider border-t border-b border-border/40 bg-muted/30">
+                        @Context.Localizer["DataGrid.Global"]
+                    </div>
+                    <div class="p-1">
+                        @foreach (var layout in Context.GlobalLayouts.Where(l => l.Scope == "Global"))
+                        {
+                            var l = layout;
+                            <div class="flex items-center gap-1 rounded px-2 py-1 hover:bg-accent group">
+                                <span class="flex-1 text-sm truncate">@l.Name</span>
+                                <button type="button"
+                                        class="inline-flex items-center justify-center h-6 w-6 rounded text-muted-foreground hover:text-foreground hover:bg-accent-foreground/10 opacity-0 group-hover:opacity-100 transition-opacity"
+                                        title="@Context.Localizer["DataGrid.ApplyLayout"]"
+                                        @onclick="@(async () => await ApplyLayout(l))">
+                                    <Blazicon Svg="Lucide.Check" class="h-3.5 w-3.5" />
+                                </button>
+                                @if (Context.OnDeleteNamedLayout.HasDelegate)
+                                {
+                                    <button type="button"
+                                            class="inline-flex items-center justify-center h-6 w-6 rounded text-muted-foreground hover:text-destructive hover:bg-destructive/10 opacity-0 group-hover:opacity-100 transition-opacity"
+                                            title="@Context.Localizer["DataGrid.Delete"]"
+                                            @onclick="@(async () => { _layoutsPanelOpen = false; await Context.OnDeleteNamedLayout.InvokeAsync(l.Id); })">
+                                        <Blazicon Svg="Lucide.X" class="h-3.5 w-3.5" />
+                                    </button>
+                                }
+                            </div>
+                        }
+                    </div>
+                }
+
+                @* System Default *@
+                <div class="px-3 py-2 text-xs font-semibold text-muted-foreground uppercase tracking-wider border-t border-b border-border/40 bg-muted/30">
+                    @Context.Localizer["DataGrid.SystemDefault"]
+                </div>
+                <div class="p-1">
+                    <div class="flex items-center gap-1 rounded px-2 py-1 hover:bg-accent group">
+                        <span class="flex-1 text-sm truncate">@Context.Localizer["DataGrid.Default"]</span>
+                        <button type="button"
+                                class="inline-flex items-center justify-center h-6 w-6 rounded text-muted-foreground hover:text-foreground hover:bg-accent-foreground/10 opacity-0 group-hover:opacity-100 transition-opacity"
+                                title="@Context.Localizer["DataGrid.ResetLayout"]"
+                                @onclick="ResetLayout">
+                            <Blazicon Svg="Lucide.Check" class="h-3.5 w-3.5" />
+                        </button>
+                    </div>
+                </div>
+
+            </div>
+        }
+    </div>
+}
+
+@code {
+    [CascadingParameter] public DataGridToolbarContext<TItem>? Context { get; set; }
+
+    private bool _layoutsPanelOpen;
+    private bool _showSaveInput;
+    private string _newLayoutName = "";
+    private List<DataGridNamedLayout> _personalLayouts = new();
+
+    protected override async Task OnParametersSetAsync()
+    {
+        if (Context is not null && Context.EnableLayoutPersistence && _layoutsPanelOpen)
+        {
+            await LoadPersonalLayouts();
+        }
+    }
+
+    private async Task ToggleLayoutsPanel()
+    {
+        _layoutsPanelOpen = !_layoutsPanelOpen;
+        if (_layoutsPanelOpen)
+        {
+            await LoadPersonalLayouts();
+        }
+        else
+        {
+            _showSaveInput = false;
+            _newLayoutName = "";
+        }
+    }
+
+    private async Task LoadPersonalLayouts()
+    {
+        if (Context is null || !Context.EnableLayoutPersistence) return;
+        var key = (Context.LayoutStorageKey ?? "datagrid") + "-named";
+        try
+        {
+            var json = await Context.Interop.LoadFromLocalStorage(key);
+            if (!string.IsNullOrEmpty(json))
+                _personalLayouts = System.Text.Json.JsonSerializer.Deserialize<List<DataGridNamedLayout>>(json) ?? new();
+            else
+                _personalLayouts = new();
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"[Lumeo DataGrid] Failed to load personal layouts: {ex.Message}");
+            _personalLayouts = new();
+            if (Context.OnError.HasDelegate) await Context.OnError.InvokeAsync(ex);
+        }
+    }
+
+    private async Task CommitSavePersonal()
+    {
+        if (Context is null) return;
+        var name = _newLayoutName.Trim();
+        if (string.IsNullOrEmpty(name)) return;
+
+        _showSaveInput = false;
+        _newLayoutName = "";
+
+        await Context.OnSaveNamedLayout.InvokeAsync(new DataGridNamedLayout(Guid.NewGuid().ToString("N"), name, "Personal", new DataGridLayout()));
+        await LoadPersonalLayouts();
+        StateHasChanged();
+    }
+
+    private async Task HandleSaveKeyDown(KeyboardEventArgs e)
+    {
+        if (e.Key == "Enter") await CommitSavePersonal();
+        else if (e.Key == "Escape") { _showSaveInput = false; _newLayoutName = ""; }
+    }
+
+    private async Task ApplyLayout(DataGridNamedLayout layout)
+    {
+        if (Context is null) return;
+        _layoutsPanelOpen = false;
+        _showSaveInput = false;
+        await Context.OnApplyNamedLayout.InvokeAsync(layout);
+    }
+
+    private async Task DeletePersonalLayout(string id)
+    {
+        if (Context is null) return;
+        _personalLayouts.RemoveAll(l => l.Id == id);
+        var key = (Context.LayoutStorageKey ?? "datagrid") + "-named";
+        try
+        {
+            var json = System.Text.Json.JsonSerializer.Serialize(_personalLayouts);
+            await Context.Interop.SaveToLocalStorage(key, json);
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"[Lumeo DataGrid] Failed to save personal layouts: {ex.Message}");
+            if (Context.OnError.HasDelegate) await Context.OnError.InvokeAsync(ex);
+        }
+
+        if (Context.OnDeleteNamedLayout.HasDelegate)
+            await Context.OnDeleteNamedLayout.InvokeAsync(id);
+
+        StateHasChanged();
+    }
+
+    private async Task SaveLayout()
+    {
+        if (Context is null) return;
+        _layoutsPanelOpen = false;
+        await Context.OnSaveLayout.InvokeAsync();
+    }
+
+    private async Task ResetLayout()
+    {
+        if (Context is null) return;
+        _layoutsPanelOpen = false;
+        await Context.OnResetLayout.InvokeAsync();
+    }
+}

--- a/src/Lumeo/UI/DataGrid/ToolbarContent.razor
+++ b/src/Lumeo/UI/DataGrid/ToolbarContent.razor
@@ -1,0 +1,30 @@
+@namespace Lumeo
+@typeparam TItem
+@implements IDisposable
+
+@* Renders nothing directly — the parent DataGrid reads Class + ChildContent
+   through the registration below and renders them in the toolbar slot. *@
+
+@code {
+    [CascadingParameter] public DataGrid<TItem>? Parent { get; set; }
+
+    /// <summary>Custom CSS classes applied to the wrapper around the toolbar content
+    /// (the flex row holding your custom buttons + the filter chips).</summary>
+    [Parameter] public string? Class { get; set; }
+
+    [Parameter] public RenderFragment? ChildContent { get; set; }
+
+    protected override void OnInitialized()
+    {
+        Parent?.RegisterToolbarContent(this);
+    }
+
+    protected override void OnParametersSet()
+    {
+        // Re-register on each render in case Class or ChildContent changed — the
+        // parent treats re-registration as an update.
+        Parent?.RegisterToolbarContent(this);
+    }
+
+    public void Dispose() => Parent?.UnregisterToolbarContent(this);
+}

--- a/src/Lumeo/wwwroot/css/lumeo.css
+++ b/src/Lumeo/wwwroot/css/lumeo.css
@@ -1300,9 +1300,65 @@ input[type="range"]::-moz-range-thumb {
   0%, 100% { opacity: 0.3; }
   50%      { opacity: 0.7; }
 }
+
+/* Bars — grow/shrink in height from the bottom, keeping the opacity pulse. */
+.lumeo-chart-skel-svg [data-skel-shape="bar"] {
+  transform-origin: center bottom;
+  transform-box: fill-box;
+  animation:
+    lumeo-chart-skel-pulse 1.4s ease-in-out infinite,
+    lumeo-chart-skel-bar-grow 1.8s ease-in-out infinite;
+}
+@keyframes lumeo-chart-skel-bar-grow {
+  0%, 100% { transform: scaleY(0.35); }
+  50%      { transform: scaleY(1); }
+}
+
+/* Line / Area — stroke 'draws itself' across the path with stroke-dasharray.
+   We use a generous dasharray so the effect reads regardless of exact path length. */
+.lumeo-chart-skel-svg [data-skel-shape="line"] {
+  stroke-dasharray: 220;
+  animation: lumeo-chart-skel-line-draw 2.4s ease-in-out infinite;
+  opacity: 0.6;
+}
+@keyframes lumeo-chart-skel-line-draw {
+  0%       { stroke-dashoffset: 220; opacity: 0.3; }
+  40%      { stroke-dashoffset: 0;   opacity: 0.7; }
+  60%      { stroke-dashoffset: 0;   opacity: 0.7; }
+  100%     { stroke-dashoffset: -220; opacity: 0.3; }
+}
+
+/* Pie ring — stroke fills around the circle like a circular progress. */
+.lumeo-chart-skel-svg [data-skel-shape="pie-ring"] {
+  stroke-dasharray: 188.5; /* 2π * r (r=30) ≈ 188.5 */
+  transform-origin: 50px 50px;
+  transform-box: view-box;
+  animation: lumeo-chart-skel-pie-fill 2.2s ease-in-out infinite;
+  opacity: 0.6;
+}
+@keyframes lumeo-chart-skel-pie-fill {
+  0%   { stroke-dashoffset: 188.5; opacity: 0.35; transform: rotate(-90deg); }
+  50%  { stroke-dashoffset: 47;    opacity: 0.75; transform: rotate(180deg); }
+  100% { stroke-dashoffset: 188.5; opacity: 0.35; transform: rotate(270deg); }
+}
+
+/* Scatter dots — different pace, slight travel to feel alive. */
+.lumeo-chart-skel-svg [data-skel-shape="dot"] {
+  animation:
+    lumeo-chart-skel-pulse 1.4s ease-in-out infinite,
+    lumeo-chart-skel-dot-breath 2s ease-in-out infinite;
+}
+@keyframes lumeo-chart-skel-dot-breath {
+  0%, 100% { transform: scale(0.8); }
+  50%      { transform: scale(1.15); }
+}
+
 @media (prefers-reduced-motion: reduce) {
-  .lumeo-chart-skel-shape {
+  .lumeo-chart-skel-shape,
+  .lumeo-chart-skel-svg [data-skel-shape] {
     animation: none !important;
     opacity: 0.4 !important;
+    transform: none !important;
+    stroke-dashoffset: 0 !important;
   }
 }

--- a/src/Lumeo/wwwroot/css/lumeo.css
+++ b/src/Lumeo/wwwroot/css/lumeo.css
@@ -1320,18 +1320,11 @@ input[type="range"]::-moz-range-thumb {
   100% { stroke-dashoffset: -240; }
 }
 
-/* Pie slices — scale each wedge in and out from the pie center. Staggered
-   per slice (via inline animation-delay) so the whole pie reads as wedges
-   pushing in/out, not a static ring. */
+/* Pie slices — scale + translate handled via SVG native <animateTransform>
+   in the markup (reliable across browsers, anchored to the pie centre). We
+   still pulse opacity here so slices shimmer in/out as they breathe. */
 .lumeo-chart-skel-svg [data-skel-shape="pie-slice"] {
-  transform-box: view-box;
-  animation:
-    lumeo-chart-skel-pulse 1.6s ease-in-out infinite,
-    lumeo-chart-skel-pie-slice 1.6s cubic-bezier(0.4, 0, 0.2, 1) infinite;
-}
-@keyframes lumeo-chart-skel-pie-slice {
-  0%, 100% { transform: scale(0.82); }
-  50%      { transform: scale(1.05); }
+  animation: lumeo-chart-skel-pulse 1.6s ease-in-out infinite;
 }
 
 /* Scatter dots — different pace, slight travel to feel alive. */

--- a/src/Lumeo/wwwroot/css/lumeo.css
+++ b/src/Lumeo/wwwroot/css/lumeo.css
@@ -1301,45 +1301,37 @@ input[type="range"]::-moz-range-thumb {
   50%      { opacity: 0.7; }
 }
 
-/* Bars — grow/shrink in height from the bottom, keeping the opacity pulse. */
+/* Bars — height/y animated via SVG <animate> elements in the markup, so
+   we only pulse opacity here (the height animation is browser-native SVG). */
 .lumeo-chart-skel-svg [data-skel-shape="bar"] {
-  transform-origin: center bottom;
-  transform-box: fill-box;
-  animation:
-    lumeo-chart-skel-pulse 1.4s ease-in-out infinite,
-    lumeo-chart-skel-bar-grow 1.8s ease-in-out infinite;
-}
-@keyframes lumeo-chart-skel-bar-grow {
-  0%, 100% { transform: scaleY(0.35); }
-  50%      { transform: scaleY(1); }
+  animation: lumeo-chart-skel-pulse 1.6s ease-in-out infinite;
 }
 
-/* Line / Area — stroke 'draws itself' across the path with stroke-dasharray.
-   We use a generous dasharray so the effect reads regardless of exact path length. */
+/* Line / Area — stroke 'draws itself' across the path with stroke-dasharray. */
 .lumeo-chart-skel-svg [data-skel-shape="line"] {
-  stroke-dasharray: 220;
-  animation: lumeo-chart-skel-line-draw 2.4s ease-in-out infinite;
-  opacity: 0.6;
+  stroke-dasharray: 240;
+  stroke-dashoffset: 240;
+  animation: lumeo-chart-skel-line-draw 2.2s ease-in-out infinite;
+  opacity: 0.75;
 }
 @keyframes lumeo-chart-skel-line-draw {
-  0%       { stroke-dashoffset: 220; opacity: 0.3; }
-  40%      { stroke-dashoffset: 0;   opacity: 0.7; }
-  60%      { stroke-dashoffset: 0;   opacity: 0.7; }
-  100%     { stroke-dashoffset: -220; opacity: 0.3; }
+  0%   { stroke-dashoffset:  240; }
+  50%  { stroke-dashoffset:    0; }
+  100% { stroke-dashoffset: -240; }
 }
 
-/* Pie ring — stroke fills around the circle like a circular progress. */
-.lumeo-chart-skel-svg [data-skel-shape="pie-ring"] {
-  stroke-dasharray: 188.5; /* 2π * r (r=30) ≈ 188.5 */
-  transform-origin: 50px 50px;
+/* Pie slices — scale each wedge in and out from the pie center. Staggered
+   per slice (via inline animation-delay) so the whole pie reads as wedges
+   pushing in/out, not a static ring. */
+.lumeo-chart-skel-svg [data-skel-shape="pie-slice"] {
   transform-box: view-box;
-  animation: lumeo-chart-skel-pie-fill 2.2s ease-in-out infinite;
-  opacity: 0.6;
+  animation:
+    lumeo-chart-skel-pulse 1.6s ease-in-out infinite,
+    lumeo-chart-skel-pie-slice 1.6s cubic-bezier(0.4, 0, 0.2, 1) infinite;
 }
-@keyframes lumeo-chart-skel-pie-fill {
-  0%   { stroke-dashoffset: 188.5; opacity: 0.35; transform: rotate(-90deg); }
-  50%  { stroke-dashoffset: 47;    opacity: 0.75; transform: rotate(180deg); }
-  100% { stroke-dashoffset: 188.5; opacity: 0.35; transform: rotate(270deg); }
+@keyframes lumeo-chart-skel-pie-slice {
+  0%, 100% { transform: scale(0.82); }
+  50%      { transform: scale(1.05); }
 }
 
 /* Scatter dots — different pace, slight travel to feel alive. */

--- a/src/Lumeo/wwwroot/css/lumeo.css
+++ b/src/Lumeo/wwwroot/css/lumeo.css
@@ -1274,3 +1274,35 @@ input[type="range"]::-moz-range-thumb {
   from { opacity: 1; transform: scale(1); }
   to   { opacity: 0; transform: scale(0.96); }
 }
+
+/* =================================================================
+ * ChartSkeleton — shape-aware loading placeholder for Chart.
+ * Each <ChartSkeleton Kind="..."/> renders SVG primitives with the
+ * class `.lumeo-chart-skel-shape`; we animate opacity with a gentle
+ * ripple. Staggered delays come from inline `animation-delay` set
+ * by the Blazor render fragments.
+ * Respects `prefers-reduced-motion`.
+ * ============================================================= */
+.lumeo-chart-skeleton {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.lumeo-chart-skel-svg {
+  display: block;
+}
+.lumeo-chart-skel-shape {
+  animation: lumeo-chart-skel-pulse 1.4s ease-in-out infinite;
+  transform-origin: center;
+  transform-box: fill-box;
+}
+@keyframes lumeo-chart-skel-pulse {
+  0%, 100% { opacity: 0.3; }
+  50%      { opacity: 0.7; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .lumeo-chart-skel-shape {
+    animation: none !important;
+    opacity: 0.4 !important;
+  }
+}

--- a/src/Lumeo/wwwroot/js/components.js
+++ b/src/Lumeo/wwwroot/js/components.js
@@ -805,15 +805,56 @@ export function unregisterOtpPaste(baseId, length) {
 
 const columnResizeHandlers = new Map();
 
-export function registerColumnResize(handleId, dotnetRef) {
+export function registerColumnResize(handleId, dotnetRef, minWidth, maxWidth) {
     const handle = document.getElementById(handleId);
     if (!handle) return;
+    const th = handle.closest('th');
+    if (!th) return;
+
     let startX = 0;
+    let startWidth = 0;
+    let currentWidth = 0;
     let isDragging = false;
+    let colBodyCells = [];
+
+    const min = Math.max(1, Number(minWidth) || 50);
+    const max = Number(maxWidth) > 0 ? Number(maxWidth) : Number.POSITIVE_INFINITY;
+
+    // Apply the width to the header + every body cell in the same column — using
+    // direct style writes so we can drag smoothly without a Blazor round-trip on
+    // every mouse move. We commit the final width ONCE on mouseup.
+    const applyWidth = (w) => {
+        const wpx = w + 'px';
+        th.style.width = wpx;
+        th.style.minWidth = wpx;
+        for (const cell of colBodyCells) {
+            cell.style.width = wpx;
+            cell.style.minWidth = wpx;
+        }
+    };
+
+    const gatherBodyCells = () => {
+        const table = th.closest('table');
+        if (!table) return [];
+        const headerRow = th.parentElement;
+        if (!headerRow) return [];
+        const colIndex = Array.prototype.indexOf.call(headerRow.children, th);
+        if (colIndex < 0) return [];
+        const tbody = table.querySelector('tbody');
+        if (!tbody) return [];
+        const cells = [];
+        for (const row of tbody.rows) {
+            if (row.children[colIndex]) cells.push(row.children[colIndex]);
+        }
+        return cells;
+    };
 
     const onMouseDown = (e) => {
         isDragging = true;
         startX = e.clientX;
+        startWidth = th.getBoundingClientRect().width;
+        currentWidth = startWidth;
+        colBodyCells = gatherBodyCells();
         document.body.style.cursor = 'col-resize';
         document.body.style.userSelect = 'none';
         e.preventDefault();
@@ -822,15 +863,19 @@ export function registerColumnResize(handleId, dotnetRef) {
     const onMouseMove = (e) => {
         if (!isDragging) return;
         const delta = e.clientX - startX;
-        startX = e.clientX;
-        dotnetRef.invokeMethodAsync('OnColumnResize', handleId, delta);
+        let w = startWidth + delta;
+        if (w < min) w = min;
+        else if (w > max) w = max;
+        if (w === currentWidth) return;
+        currentWidth = w;
+        applyWidth(w);
     };
     const onMouseUp = () => {
         if (!isDragging) return;
         isDragging = false;
         document.body.style.cursor = '';
         document.body.style.userSelect = '';
-        dotnetRef.invokeMethodAsync('OnColumnResizeEnd', handleId);
+        dotnetRef.invokeMethodAsync('OnColumnResizeCommit', handleId, currentWidth);
     };
     handle.addEventListener('mousedown', onMouseDown);
     document.addEventListener('mousemove', onMouseMove);

--- a/src/Lumeo/wwwroot/js/echarts-interop.js
+++ b/src/Lumeo/wwwroot/js/echarts-interop.js
@@ -375,12 +375,21 @@ export async function initChart(elementId, optionsJson, theme, echartsSource) {
     chart._lumeoObserver = observer;
 }
 
-export function updateChart(elementId, optionsJson, notMerge) {
+export function updateChart(elementId, optionsJson, notMerge, replaceMergeJson) {
     const chart = charts.get(elementId);
     if (!chart) return;
     const options = JSON.parse(optionsJson);
     resolveCssVars(options);
-    chart.setOption(options, { notMerge: notMerge || false });
+    const opts = { notMerge: notMerge || false };
+    if (replaceMergeJson) {
+        try {
+            const replaceMerge = JSON.parse(replaceMergeJson);
+            if (Array.isArray(replaceMerge) && replaceMerge.length > 0) {
+                opts.replaceMerge = replaceMerge;
+            }
+        } catch { /* ignore bad input */ }
+    }
+    chart.setOption(options, opts);
 }
 
 export function resizeChart(elementId) {

--- a/templates/Lumeo.Templates/Lumeo.Templates.csproj
+++ b/templates/Lumeo.Templates/Lumeo.Templates.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <PackageType>Template</PackageType>
     <PackageId>Lumeo.Templates</PackageId>
-    <Version>2.0.0-rc.2</Version>
+    <Version>2.0.0-rc.3</Version>
     <Title>Lumeo item templates</Title>
     <Authors>bemi</Authors>
     <Description>Scaffolding templates for Lumeo Blazor projects: pages, forms, and components.</Description>

--- a/tests/Lumeo.Tests/Components/Chart/ChartLoadingStateTests.cs
+++ b/tests/Lumeo.Tests/Components/Chart/ChartLoadingStateTests.cs
@@ -1,0 +1,153 @@
+using Bunit;
+using Xunit;
+using Lumeo.Tests.Helpers;
+using L = Lumeo;
+
+namespace Lumeo.Tests.Components.Chart;
+
+/// <summary>Covers the Chart loading-skeleton hook — <c>IsLoading</c>, <c>ShowLoadingSkeleton</c>,
+/// and <c>SkeletonKind</c>. The skeleton renders as an absolute-positioned child of the chart
+/// root so ECharts still has its host div available for mounting; we assert both concerns.</summary>
+public class ChartLoadingStateTests : IAsyncLifetime
+{
+    private readonly BunitContext _ctx = new();
+
+    public Task InitializeAsync()
+    {
+        _ctx.AddLumeoServices();
+        var module = _ctx.JSInterop.SetupModule("./_content/Lumeo/js/echarts-interop.js");
+        module.Mode = Bunit.JSRuntimeMode.Loose;
+        return Task.CompletedTask;
+    }
+
+    public async Task DisposeAsync() => await _ctx.DisposeAsync();
+
+    [Fact]
+    public void Chart_Host_Div_Always_Present_Even_When_Loading()
+    {
+        // The host div must always exist in the DOM so ECharts has a mount target;
+        // the skeleton overlays it rather than replacing it.
+        var cut = _ctx.Render<L.Chart>(p => p.Add(x => x.IsLoading, true));
+
+        var host = cut.Find("div.lumeo-chart-host");
+        Assert.StartsWith("lumeo-chart-", host.GetAttribute("id") ?? "");
+    }
+
+    [Fact]
+    public void IsLoading_True_Renders_Skeleton_Overlay()
+    {
+        var cut = _ctx.Render<L.Chart>(p => p.Add(x => x.IsLoading, true));
+
+        Assert.NotEmpty(cut.FindAll("div.lumeo-chart-skeleton"));
+    }
+
+    [Fact]
+    public void IsLoading_False_And_Rendered_Hides_Skeleton()
+    {
+        // After the first render completes the skeleton should retract because
+        // IsLoading is false and _hasFirstRendered is flipped true by OnAfterRenderAsync.
+        var cut = _ctx.Render<L.Chart>();
+
+        Assert.Empty(cut.FindAll("div.lumeo-chart-skeleton"));
+    }
+
+    [Fact]
+    public void ShowLoadingSkeleton_False_Skips_Skeleton_Even_When_Loading()
+    {
+        var cut = _ctx.Render<L.Chart>(p => p
+            .Add(x => x.IsLoading, true)
+            .Add(x => x.ShowLoadingSkeleton, false));
+
+        Assert.Empty(cut.FindAll("div.lumeo-chart-skeleton"));
+    }
+
+    [Fact]
+    public void SkeletonKind_Bars_Forwards_To_Skeleton()
+    {
+        var cut = _ctx.Render<L.Chart>(p => p
+            .Add(x => x.IsLoading, true)
+            .Add(x => x.SkeletonKind, L.ChartSkeletonKind.Bars));
+
+        var root = cut.Find("div.lumeo-chart-skeleton");
+        Assert.Equal("bars", root.GetAttribute("data-lumeo-chart-skeleton"));
+    }
+
+    [Fact]
+    public void SkeletonKind_Pie_Forwards_To_Skeleton()
+    {
+        var cut = _ctx.Render<L.Chart>(p => p
+            .Add(x => x.IsLoading, true)
+            .Add(x => x.SkeletonKind, L.ChartSkeletonKind.Pie));
+
+        var root = cut.Find("div.lumeo-chart-skeleton");
+        Assert.Equal("pie", root.GetAttribute("data-lumeo-chart-skeleton"));
+    }
+
+    [Fact]
+    public void IsLoading_Toggled_Back_On_After_First_Render_Shows_Skeleton_Again()
+    {
+        // Simulates a consumer refetch cycle: chart mounts, data loads, user clicks refresh.
+        var cut = _ctx.Render<L.Chart>();
+        Assert.Empty(cut.FindAll("div.lumeo-chart-skeleton"));
+
+        cut.Render(p => p.Add(x => x.IsLoading, true));
+
+        Assert.NotEmpty(cut.FindAll("div.lumeo-chart-skeleton"));
+    }
+
+    [Fact]
+    public void BarChart_Wrapper_Defaults_SkeletonKind_To_Bars()
+    {
+        var cut = _ctx.Render<L.BarChart>(p => p.Add(x => x.IsLoading, true));
+
+        var root = cut.Find("div.lumeo-chart-skeleton");
+        Assert.Equal("bars", root.GetAttribute("data-lumeo-chart-skeleton"));
+    }
+
+    [Fact]
+    public void LineChart_Wrapper_Defaults_SkeletonKind_To_Line()
+    {
+        var cut = _ctx.Render<L.LineChart>(p => p.Add(x => x.IsLoading, true));
+
+        var root = cut.Find("div.lumeo-chart-skeleton");
+        Assert.Equal("line", root.GetAttribute("data-lumeo-chart-skeleton"));
+    }
+
+    [Fact]
+    public void PieChart_Wrapper_Defaults_SkeletonKind_To_Pie()
+    {
+        var cut = _ctx.Render<L.PieChart>(p => p.Add(x => x.IsLoading, true));
+
+        var root = cut.Find("div.lumeo-chart-skeleton");
+        Assert.Equal("pie", root.GetAttribute("data-lumeo-chart-skeleton"));
+    }
+
+    [Fact]
+    public void ScatterChart_Wrapper_Defaults_SkeletonKind_To_Scatter()
+    {
+        var cut = _ctx.Render<L.ScatterChart>(p => p.Add(x => x.IsLoading, true));
+
+        var root = cut.Find("div.lumeo-chart-skeleton");
+        Assert.Equal("scatter", root.GetAttribute("data-lumeo-chart-skeleton"));
+    }
+
+    [Fact]
+    public void HeatmapChart_Wrapper_Defaults_SkeletonKind_To_Grid()
+    {
+        var cut = _ctx.Render<L.HeatmapChart>(p => p.Add(x => x.IsLoading, true));
+
+        var root = cut.Find("div.lumeo-chart-skeleton");
+        Assert.Equal("grid", root.GetAttribute("data-lumeo-chart-skeleton"));
+    }
+
+    [Fact]
+    public void Consumer_Can_Override_Wrapper_Default_SkeletonKind()
+    {
+        var cut = _ctx.Render<L.BarChart>(p => p
+            .Add(x => x.IsLoading, true)
+            .Add(x => x.SkeletonKind, L.ChartSkeletonKind.Generic));
+
+        var root = cut.Find("div.lumeo-chart-skeleton");
+        Assert.Equal("generic", root.GetAttribute("data-lumeo-chart-skeleton"));
+    }
+}

--- a/tests/Lumeo.Tests/Components/Chart/ChartLoadingStateTests.cs
+++ b/tests/Lumeo.Tests/Components/Chart/ChartLoadingStateTests.cs
@@ -5,9 +5,10 @@ using L = Lumeo;
 
 namespace Lumeo.Tests.Components.Chart;
 
-/// <summary>Covers the Chart loading-skeleton hook — <c>IsLoading</c>, <c>ShowLoadingSkeleton</c>,
-/// and <c>SkeletonKind</c>. The skeleton renders as an absolute-positioned child of the chart
-/// root so ECharts still has its host div available for mounting; we assert both concerns.</summary>
+/// <summary>Covers the Chart loading-state hook — <c>IsLoading</c>, <c>ShowLoadingSkeleton</c>,
+/// <c>SkeletonKind</c>, and <c>SkeletonStyle</c>. The default <c>Phantom</c> style renders the
+/// real ECharts with placeholder data (no SVG overlay), so SVG-overlay assertions are gated
+/// on <c>SkeletonStyle.Silhouette</c>. Phantom-specific behavior has its own section below.</summary>
 public class ChartLoadingStateTests : IAsyncLifetime
 {
     private readonly BunitContext _ctx = new();
@@ -25,8 +26,6 @@ public class ChartLoadingStateTests : IAsyncLifetime
     [Fact]
     public void Chart_Host_Div_Always_Present_Even_When_Loading()
     {
-        // The host div must always exist in the DOM so ECharts has a mount target;
-        // the skeleton overlays it rather than replacing it.
         var cut = _ctx.Render<L.Chart>(p => p.Add(x => x.IsLoading, true));
 
         var host = cut.Find("div.lumeo-chart-host");
@@ -34,9 +33,11 @@ public class ChartLoadingStateTests : IAsyncLifetime
     }
 
     [Fact]
-    public void IsLoading_True_Renders_Skeleton_Overlay()
+    public void IsLoading_True_Silhouette_Renders_Skeleton_Overlay()
     {
-        var cut = _ctx.Render<L.Chart>(p => p.Add(x => x.IsLoading, true));
+        var cut = _ctx.Render<L.Chart>(p => p
+            .Add(x => x.IsLoading, true)
+            .Add(x => x.SkeletonStyle, L.ChartSkeletonStyle.Silhouette));
 
         Assert.NotEmpty(cut.FindAll("div.lumeo-chart-skeleton"));
     }
@@ -44,8 +45,6 @@ public class ChartLoadingStateTests : IAsyncLifetime
     [Fact]
     public void IsLoading_False_And_Rendered_Hides_Skeleton()
     {
-        // After the first render completes the skeleton should retract because
-        // IsLoading is false and _hasFirstRendered is flipped true by OnAfterRenderAsync.
         var cut = _ctx.Render<L.Chart>();
 
         Assert.Empty(cut.FindAll("div.lumeo-chart-skeleton"));
@@ -56,7 +55,8 @@ public class ChartLoadingStateTests : IAsyncLifetime
     {
         var cut = _ctx.Render<L.Chart>(p => p
             .Add(x => x.IsLoading, true)
-            .Add(x => x.ShowLoadingSkeleton, false));
+            .Add(x => x.ShowLoadingSkeleton, false)
+            .Add(x => x.SkeletonStyle, L.ChartSkeletonStyle.Silhouette));
 
         Assert.Empty(cut.FindAll("div.lumeo-chart-skeleton"));
     }
@@ -66,6 +66,7 @@ public class ChartLoadingStateTests : IAsyncLifetime
     {
         var cut = _ctx.Render<L.Chart>(p => p
             .Add(x => x.IsLoading, true)
+            .Add(x => x.SkeletonStyle, L.ChartSkeletonStyle.Silhouette)
             .Add(x => x.SkeletonKind, L.ChartSkeletonKind.Bars));
 
         var root = cut.Find("div.lumeo-chart-skeleton");
@@ -77,6 +78,7 @@ public class ChartLoadingStateTests : IAsyncLifetime
     {
         var cut = _ctx.Render<L.Chart>(p => p
             .Add(x => x.IsLoading, true)
+            .Add(x => x.SkeletonStyle, L.ChartSkeletonStyle.Silhouette)
             .Add(x => x.SkeletonKind, L.ChartSkeletonKind.Pie));
 
         var root = cut.Find("div.lumeo-chart-skeleton");
@@ -86,11 +88,13 @@ public class ChartLoadingStateTests : IAsyncLifetime
     [Fact]
     public void IsLoading_Toggled_Back_On_After_First_Render_Shows_Skeleton_Again()
     {
-        // Simulates a consumer refetch cycle: chart mounts, data loads, user clicks refresh.
-        var cut = _ctx.Render<L.Chart>();
+        var cut = _ctx.Render<L.Chart>(p => p
+            .Add(x => x.SkeletonStyle, L.ChartSkeletonStyle.Silhouette));
         Assert.Empty(cut.FindAll("div.lumeo-chart-skeleton"));
 
-        cut.Render(p => p.Add(x => x.IsLoading, true));
+        cut.Render(p => p
+            .Add(x => x.SkeletonStyle, L.ChartSkeletonStyle.Silhouette)
+            .Add(x => x.IsLoading, true));
 
         Assert.NotEmpty(cut.FindAll("div.lumeo-chart-skeleton"));
     }
@@ -98,7 +102,9 @@ public class ChartLoadingStateTests : IAsyncLifetime
     [Fact]
     public void BarChart_Wrapper_Defaults_SkeletonKind_To_Bars()
     {
-        var cut = _ctx.Render<L.BarChart>(p => p.Add(x => x.IsLoading, true));
+        var cut = _ctx.Render<L.BarChart>(p => p
+            .Add(x => x.IsLoading, true)
+            .Add(x => x.SkeletonStyle, L.ChartSkeletonStyle.Silhouette));
 
         var root = cut.Find("div.lumeo-chart-skeleton");
         Assert.Equal("bars", root.GetAttribute("data-lumeo-chart-skeleton"));
@@ -107,7 +113,9 @@ public class ChartLoadingStateTests : IAsyncLifetime
     [Fact]
     public void LineChart_Wrapper_Defaults_SkeletonKind_To_Line()
     {
-        var cut = _ctx.Render<L.LineChart>(p => p.Add(x => x.IsLoading, true));
+        var cut = _ctx.Render<L.LineChart>(p => p
+            .Add(x => x.IsLoading, true)
+            .Add(x => x.SkeletonStyle, L.ChartSkeletonStyle.Silhouette));
 
         var root = cut.Find("div.lumeo-chart-skeleton");
         Assert.Equal("line", root.GetAttribute("data-lumeo-chart-skeleton"));
@@ -116,7 +124,9 @@ public class ChartLoadingStateTests : IAsyncLifetime
     [Fact]
     public void PieChart_Wrapper_Defaults_SkeletonKind_To_Pie()
     {
-        var cut = _ctx.Render<L.PieChart>(p => p.Add(x => x.IsLoading, true));
+        var cut = _ctx.Render<L.PieChart>(p => p
+            .Add(x => x.IsLoading, true)
+            .Add(x => x.SkeletonStyle, L.ChartSkeletonStyle.Silhouette));
 
         var root = cut.Find("div.lumeo-chart-skeleton");
         Assert.Equal("pie", root.GetAttribute("data-lumeo-chart-skeleton"));
@@ -125,7 +135,9 @@ public class ChartLoadingStateTests : IAsyncLifetime
     [Fact]
     public void ScatterChart_Wrapper_Defaults_SkeletonKind_To_Scatter()
     {
-        var cut = _ctx.Render<L.ScatterChart>(p => p.Add(x => x.IsLoading, true));
+        var cut = _ctx.Render<L.ScatterChart>(p => p
+            .Add(x => x.IsLoading, true)
+            .Add(x => x.SkeletonStyle, L.ChartSkeletonStyle.Silhouette));
 
         var root = cut.Find("div.lumeo-chart-skeleton");
         Assert.Equal("scatter", root.GetAttribute("data-lumeo-chart-skeleton"));
@@ -134,7 +146,9 @@ public class ChartLoadingStateTests : IAsyncLifetime
     [Fact]
     public void HeatmapChart_Wrapper_Defaults_SkeletonKind_To_Grid()
     {
-        var cut = _ctx.Render<L.HeatmapChart>(p => p.Add(x => x.IsLoading, true));
+        var cut = _ctx.Render<L.HeatmapChart>(p => p
+            .Add(x => x.IsLoading, true)
+            .Add(x => x.SkeletonStyle, L.ChartSkeletonStyle.Silhouette));
 
         var root = cut.Find("div.lumeo-chart-skeleton");
         Assert.Equal("grid", root.GetAttribute("data-lumeo-chart-skeleton"));
@@ -145,9 +159,31 @@ public class ChartLoadingStateTests : IAsyncLifetime
     {
         var cut = _ctx.Render<L.BarChart>(p => p
             .Add(x => x.IsLoading, true)
+            .Add(x => x.SkeletonStyle, L.ChartSkeletonStyle.Silhouette)
             .Add(x => x.SkeletonKind, L.ChartSkeletonKind.Generic));
 
         var root = cut.Find("div.lumeo-chart-skeleton");
         Assert.Equal("generic", root.GetAttribute("data-lumeo-chart-skeleton"));
+    }
+
+    // ---- Phantom mode (default) ----
+
+    [Fact]
+    public void Phantom_Is_The_Default_SkeletonStyle()
+    {
+        var cut = _ctx.Render<L.Chart>(p => p.Add(x => x.IsLoading, true));
+
+        // Phantom mode renders no SVG overlay — the chart host carries the phantom data.
+        Assert.Empty(cut.FindAll("div.lumeo-chart-skeleton"));
+        Assert.NotEmpty(cut.FindAll("div.lumeo-chart-host"));
+    }
+
+    [Fact]
+    public void Phantom_IsLoading_False_Still_Renders_Chart_Host()
+    {
+        var cut = _ctx.Render<L.Chart>();
+
+        Assert.NotEmpty(cut.FindAll("div.lumeo-chart-host"));
+        Assert.Empty(cut.FindAll("div.lumeo-chart-skeleton"));
     }
 }

--- a/tests/Lumeo.Tests/Components/Chart/ChartSkeletonTests.cs
+++ b/tests/Lumeo.Tests/Components/Chart/ChartSkeletonTests.cs
@@ -84,11 +84,12 @@ public class ChartSkeletonTests : IAsyncLifetime
     }
 
     [Fact]
-    public void Pie_Kind_Renders_Single_Donut_Circle()
+    public void Pie_Kind_Renders_Four_Slices()
     {
         var cut = _ctx.Render<L.ChartSkeleton>(p => p.Add(b => b.Kind, L.ChartSkeletonKind.Pie));
 
-        Assert.Single(cut.FindAll("circle.lumeo-chart-skel-shape"));
+        // Pie renders 4 <path> wedges — one per 90° slice — each tagged as a pie-slice.
+        Assert.Equal(4, cut.FindAll("path[data-skel-shape='pie-slice']").Count);
     }
 
     [Fact]

--- a/tests/Lumeo.Tests/Components/Chart/ChartSkeletonTests.cs
+++ b/tests/Lumeo.Tests/Components/Chart/ChartSkeletonTests.cs
@@ -65,21 +65,22 @@ public class ChartSkeletonTests : IAsyncLifetime
     }
 
     [Fact]
-    public void Line_Kind_Renders_Polyline_Only()
+    public void Line_Kind_Renders_Multi_Line_Polylines()
     {
         var cut = _ctx.Render<L.ChartSkeleton>(p => p.Add(b => b.Kind, L.ChartSkeletonKind.Line));
 
-        Assert.Single(cut.FindAll("polyline.lumeo-chart-skel-shape"));
+        // Three overlapping polylines give the skeleton a multi-series look.
+        Assert.Equal(3, cut.FindAll("polyline.lumeo-chart-skel-shape").Count);
         // Line variant has no filled area polygon.
         Assert.Empty(cut.FindAll("polygon.lumeo-chart-skel-shape"));
     }
 
     [Fact]
-    public void Area_Kind_Renders_Polyline_And_Polygon()
+    public void Area_Kind_Renders_Polylines_And_Polygon()
     {
         var cut = _ctx.Render<L.ChartSkeleton>(p => p.Add(b => b.Kind, L.ChartSkeletonKind.Area));
 
-        Assert.Single(cut.FindAll("polyline.lumeo-chart-skel-shape"));
+        Assert.Equal(3, cut.FindAll("polyline.lumeo-chart-skel-shape").Count);
         Assert.Single(cut.FindAll("polygon.lumeo-chart-skel-shape"));
     }
 

--- a/tests/Lumeo.Tests/Components/Chart/ChartSkeletonTests.cs
+++ b/tests/Lumeo.Tests/Components/Chart/ChartSkeletonTests.cs
@@ -1,0 +1,153 @@
+using Bunit;
+using Xunit;
+using Lumeo.Tests.Helpers;
+using L = Lumeo;
+
+namespace Lumeo.Tests.Components.Chart;
+
+/// <summary>Covers <see cref="L.ChartSkeleton"/> — the SVG placeholder that renders
+/// during chart load. Each <see cref="L.ChartSkeletonKind"/> produces a different
+/// silhouette; tests verify the element count / shape per kind and confirm the
+/// animatable class is always applied (the `prefers-reduced-motion` gate is a pure
+/// CSS media query, so we assert the structure, not the runtime computed style).</summary>
+public class ChartSkeletonTests : IAsyncLifetime
+{
+    private readonly BunitContext _ctx = new();
+
+    public Task InitializeAsync()
+    {
+        _ctx.AddLumeoServices();
+        return Task.CompletedTask;
+    }
+
+    public async Task DisposeAsync() => await _ctx.DisposeAsync();
+
+    [Fact]
+    public void Renders_Root_With_Status_Role_And_AriaLabel()
+    {
+        var cut = _ctx.Render<L.ChartSkeleton>();
+        var root = cut.Find("div.lumeo-chart-skeleton");
+
+        Assert.Equal("status", root.GetAttribute("role"));
+        Assert.Equal("Loading chart", root.GetAttribute("aria-label"));
+        Assert.Equal("polite", root.GetAttribute("aria-live"));
+    }
+
+    [Fact]
+    public void Default_Height_Matches_Chart_Default()
+    {
+        var cut = _ctx.Render<L.ChartSkeleton>();
+        var root = cut.Find("div.lumeo-chart-skeleton");
+
+        Assert.Contains("height: 350px", root.GetAttribute("style"));
+    }
+
+    [Fact]
+    public void Custom_Height_And_Width_Applied()
+    {
+        var cut = _ctx.Render<L.ChartSkeleton>(p => p
+            .Add(b => b.Height, "220px")
+            .Add(b => b.Width, "480px"));
+        var root = cut.Find("div.lumeo-chart-skeleton");
+
+        Assert.Contains("height: 220px", root.GetAttribute("style"));
+        Assert.Contains("width: 480px", root.GetAttribute("style"));
+    }
+
+    [Fact]
+    public void Bars_Kind_Renders_Eight_Rects()
+    {
+        var cut = _ctx.Render<L.ChartSkeleton>(p => p.Add(b => b.Kind, L.ChartSkeletonKind.Bars));
+        var rects = cut.FindAll("rect.lumeo-chart-skel-shape");
+
+        // 8 staggered bars — matches the BarHeights array in ChartSkeleton.
+        Assert.Equal(8, rects.Count);
+    }
+
+    [Fact]
+    public void Line_Kind_Renders_Polyline_Only()
+    {
+        var cut = _ctx.Render<L.ChartSkeleton>(p => p.Add(b => b.Kind, L.ChartSkeletonKind.Line));
+
+        Assert.Single(cut.FindAll("polyline.lumeo-chart-skel-shape"));
+        // Line variant has no filled area polygon.
+        Assert.Empty(cut.FindAll("polygon.lumeo-chart-skel-shape"));
+    }
+
+    [Fact]
+    public void Area_Kind_Renders_Polyline_And_Polygon()
+    {
+        var cut = _ctx.Render<L.ChartSkeleton>(p => p.Add(b => b.Kind, L.ChartSkeletonKind.Area));
+
+        Assert.Single(cut.FindAll("polyline.lumeo-chart-skel-shape"));
+        Assert.Single(cut.FindAll("polygon.lumeo-chart-skel-shape"));
+    }
+
+    [Fact]
+    public void Pie_Kind_Renders_Single_Donut_Circle()
+    {
+        var cut = _ctx.Render<L.ChartSkeleton>(p => p.Add(b => b.Kind, L.ChartSkeletonKind.Pie));
+
+        Assert.Single(cut.FindAll("circle.lumeo-chart-skel-shape"));
+    }
+
+    [Fact]
+    public void Scatter_Kind_Renders_Fifteen_Dots()
+    {
+        var cut = _ctx.Render<L.ChartSkeleton>(p => p.Add(b => b.Kind, L.ChartSkeletonKind.Scatter));
+
+        // 15 seeded scatter positions — stable across renders.
+        Assert.Equal(15, cut.FindAll("circle.lumeo-chart-skel-shape").Count);
+    }
+
+    [Fact]
+    public void Grid_Kind_Renders_TwentyFive_Cells()
+    {
+        var cut = _ctx.Render<L.ChartSkeleton>(p => p.Add(b => b.Kind, L.ChartSkeletonKind.Grid));
+
+        // 5x5 heatmap-style layout.
+        Assert.Equal(25, cut.FindAll("rect.lumeo-chart-skel-shape").Count);
+    }
+
+    [Fact]
+    public void Generic_Kind_Renders_Rect_And_Ring()
+    {
+        var cut = _ctx.Render<L.ChartSkeleton>(p => p.Add(b => b.Kind, L.ChartSkeletonKind.Generic));
+
+        Assert.Single(cut.FindAll("rect.lumeo-chart-skel-shape"));
+        Assert.Single(cut.FindAll("circle.lumeo-chart-skel-shape"));
+    }
+
+    [Fact]
+    public void Shapes_Carry_Animation_Class_For_Pulse()
+    {
+        // The `.lumeo-chart-skel-shape` class is the sole hook for both the pulse
+        // animation and the reduced-motion override. Missing class = no animation
+        // AND no reduced-motion safeguard — hence guarding it with a test.
+        var cut = _ctx.Render<L.ChartSkeleton>(p => p.Add(b => b.Kind, L.ChartSkeletonKind.Bars));
+
+        foreach (var rect in cut.FindAll("rect"))
+        {
+            Assert.Contains("lumeo-chart-skel-shape", rect.GetAttribute("class") ?? "");
+        }
+    }
+
+    [Fact]
+    public void Custom_Class_Is_Merged_With_Base()
+    {
+        var cut = _ctx.Render<L.ChartSkeleton>(p => p.Add(b => b.Class, "my-skel"));
+        var root = cut.Find("div.lumeo-chart-skeleton");
+
+        Assert.Contains("my-skel", root.GetAttribute("class"));
+        Assert.Contains("lumeo-chart-skeleton", root.GetAttribute("class"));
+    }
+
+    [Fact]
+    public void Kind_Attribute_Reflects_Selected_Variant()
+    {
+        var cut = _ctx.Render<L.ChartSkeleton>(p => p.Add(b => b.Kind, L.ChartSkeletonKind.Scatter));
+        var root = cut.Find("div.lumeo-chart-skeleton");
+
+        Assert.Equal("scatter", root.GetAttribute("data-lumeo-chart-skeleton"));
+    }
+}

--- a/tests/Lumeo.Tests/Components/Chart/ChartSkeletonTests.cs
+++ b/tests/Lumeo.Tests/Components/Chart/ChartSkeletonTests.cs
@@ -126,9 +126,15 @@ public class ChartSkeletonTests : IAsyncLifetime
         // The `.lumeo-chart-skel-shape` class is the sole hook for both the pulse
         // animation and the reduced-motion override. Missing class = no animation
         // AND no reduced-motion safeguard — hence guarding it with a test.
+        //
+        // Scoped to `rect.lumeo-chart-skel-shape` because the skeleton also renders
+        // static axis/legend hint rects (tagged via `data-skel-axis`) that intentionally
+        // do NOT animate — they're background structure, not the pulsing shapes.
         var cut = _ctx.Render<L.ChartSkeleton>(p => p.Add(b => b.Kind, L.ChartSkeletonKind.Bars));
 
-        foreach (var rect in cut.FindAll("rect"))
+        var shapeRects = cut.FindAll("rect.lumeo-chart-skel-shape");
+        Assert.NotEmpty(shapeRects);
+        foreach (var rect in shapeRects)
         {
             Assert.Contains("lumeo-chart-skel-shape", rect.GetAttribute("class") ?? "");
         }
@@ -142,6 +148,40 @@ public class ChartSkeletonTests : IAsyncLifetime
 
         Assert.Contains("my-skel", root.GetAttribute("class"));
         Assert.Contains("lumeo-chart-skeleton", root.GetAttribute("class"));
+    }
+
+    [Fact]
+    public void Cartesian_Kinds_Render_Axis_And_Legend_Hints()
+    {
+        // Top 14%: 3 legend pills. Left 10%: 4 y-tick labels. Bottom 12%: 6 x-tick labels.
+        // These reserve plot-area space so the real chart can swap in without a layout jump.
+        var cut = _ctx.Render<L.ChartSkeleton>(p => p.Add(b => b.Kind, L.ChartSkeletonKind.Bars));
+
+        Assert.Equal(3, cut.FindAll("rect[data-skel-axis='legend']").Count);
+        Assert.Equal(4, cut.FindAll("rect[data-skel-axis='y']").Count);
+        Assert.Equal(6, cut.FindAll("rect[data-skel-axis='x']").Count);
+    }
+
+    [Fact]
+    public void Pie_Kind_Renders_Legend_And_External_Label_Anchors()
+    {
+        // Pie reserves a top-strip legend and 4 external label anchor lines (one per quadrant).
+        var cut = _ctx.Render<L.ChartSkeleton>(p => p.Add(b => b.Kind, L.ChartSkeletonKind.Pie));
+
+        Assert.Equal(3, cut.FindAll("rect[data-skel-axis='legend']").Count);
+        Assert.Equal(4, cut.FindAll("line[data-skel-axis='pie-label']").Count);
+    }
+
+    [Fact]
+    public void Generic_Kind_Has_No_Axis_Or_Legend_Hints()
+    {
+        // Generic shapes fill the box; no reserved axis/legend space — keeps the skeleton
+        // minimal for kinds where the real chart has no cartesian grid (Radar, Sankey, Tree, etc.).
+        var cut = _ctx.Render<L.ChartSkeleton>(p => p.Add(b => b.Kind, L.ChartSkeletonKind.Generic));
+
+        Assert.Empty(cut.FindAll("rect[data-skel-axis='legend']"));
+        Assert.Empty(cut.FindAll("rect[data-skel-axis='x']"));
+        Assert.Empty(cut.FindAll("rect[data-skel-axis='y']"));
     }
 
     [Fact]

--- a/tests/Lumeo.Tests/Components/Chart/ChartTests.cs
+++ b/tests/Lumeo.Tests/Components/Chart/ChartTests.cs
@@ -72,8 +72,10 @@ public class ChartTests : IAsyncLifetime
     {
         var cut = _ctx.Render<L.Chart>();
 
-        var div = cut.Find("div");
-        var id = div.GetAttribute("id");
+        // Chart host is the nested div carrying the ECharts id; the outer wrapper
+        // owns styling so the skeleton overlay can pin absolute inside it.
+        var host = cut.Find("div.lumeo-chart-host");
+        var id = host.GetAttribute("id");
         Assert.NotNull(id);
         Assert.StartsWith("lumeo-chart-", id);
     }
@@ -84,8 +86,8 @@ public class ChartTests : IAsyncLifetime
         var cut1 = _ctx.Render<L.Chart>();
         var cut2 = _ctx.Render<L.Chart>();
 
-        var id1 = cut1.Find("div").GetAttribute("id");
-        var id2 = cut2.Find("div").GetAttribute("id");
+        var id1 = cut1.Find("div.lumeo-chart-host").GetAttribute("id");
+        var id2 = cut2.Find("div.lumeo-chart-host").GetAttribute("id");
         Assert.NotEqual(id1, id2);
     }
 

--- a/tests/Lumeo.Tests/Services/ComponentInteropServiceTests.cs
+++ b/tests/Lumeo.Tests/Services/ComponentInteropServiceTests.cs
@@ -506,38 +506,18 @@ public class ComponentInteropServiceTests : IAsyncLifetime
     // --- ColumnResize ---
 
     [Fact]
-    public async Task OnColumnResize_Calls_Only_Matching_Handler()
+    public async Task OnColumnResizeCommit_Calls_Only_Matching_Handler()
     {
-        double receivedDelta = 0;
+        double receivedWidth = 0;
         bool otherCalled = false;
-        await _service.RegisterColumnResize("col-1",
-            delta => { receivedDelta = delta; return Task.CompletedTask; },
-            () => Task.CompletedTask);
-        await _service.RegisterColumnResize("col-2",
-            _ => { otherCalled = true; return Task.CompletedTask; },
-            () => Task.CompletedTask);
+        await _service.RegisterColumnResize("col-1", 50, null,
+            w => { receivedWidth = w; return Task.CompletedTask; });
+        await _service.RegisterColumnResize("col-2", 50, null,
+            _ => { otherCalled = true; return Task.CompletedTask; });
 
-        await _service.OnColumnResize("col-1", 15.0);
+        await _service.OnColumnResizeCommit("col-1", 180.0);
 
-        Assert.Equal(15.0, receivedDelta);
-        Assert.False(otherCalled);
-    }
-
-    [Fact]
-    public async Task OnColumnResizeEnd_Calls_Only_Matching_Handler()
-    {
-        bool called = false;
-        bool otherCalled = false;
-        await _service.RegisterColumnResize("col-3",
-            _ => Task.CompletedTask,
-            () => { called = true; return Task.CompletedTask; });
-        await _service.RegisterColumnResize("col-4",
-            _ => Task.CompletedTask,
-            () => { otherCalled = true; return Task.CompletedTask; });
-
-        await _service.OnColumnResizeEnd("col-3");
-
-        Assert.True(called);
+        Assert.Equal(180.0, receivedWidth);
         Assert.False(otherCalled);
     }
 

--- a/tests/Lumeo.Tests/Services/StrictInteropTests.cs
+++ b/tests/Lumeo.Tests/Services/StrictInteropTests.cs
@@ -349,8 +349,8 @@ public class StrictInteropTests : IAsyncLifetime
     [Fact]
     public async Task RegisterColumnResize_Invokes_JS_With_HandleId()
     {
-        // JS call: registerColumnResize(handleId, selfRef) — no direction
-        await _service.RegisterColumnResize("handle-1", _ => Task.CompletedTask, () => Task.CompletedTask);
+        // JS call: registerColumnResize(handleId, selfRef, minWidth, maxWidth)
+        await _service.RegisterColumnResize("handle-1", 50, null, _ => Task.CompletedTask);
 
         var inv = _module.VerifyInvoke("registerColumnResize");
         Assert.Equal("handle-1", inv.Arguments[0]);
@@ -360,7 +360,7 @@ public class StrictInteropTests : IAsyncLifetime
     [Fact]
     public async Task UnregisterColumnResize_Invokes_JS_With_HandleId()
     {
-        await _service.RegisterColumnResize("handle-1", _ => Task.CompletedTask, () => Task.CompletedTask);
+        await _service.RegisterColumnResize("handle-1", 50, null, _ => Task.CompletedTask);
         await _service.UnregisterColumnResize("handle-1");
 
         var inv = _module.VerifyInvoke("unregisterColumnResize");

--- a/tools/Lumeo.Cli/Lumeo.Cli.csproj
+++ b/tools/Lumeo.Cli/Lumeo.Cli.csproj
@@ -9,7 +9,7 @@
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>lumeo</ToolCommandName>
     <PackageId>Lumeo.Cli</PackageId>
-    <Version>2.0.0-rc.2</Version>
+    <Version>2.0.0-rc.3</Version>
     <Description>Vendorize Lumeo components directly into your project.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <Authors>bemi</Authors>


### PR DESCRIPTION
## Summary

Shape-aware loading skeletons for every chart type. Solves three UX problems:
1. First-paint flicker (ECharts mount delay shows empty whitespace)
2. Layout shift (no height reservation while data loads)
3. Async loading states (consumers had no clean `IsLoading` pattern today)

## What's new
- `ChartSkeleton` component with 7 shape kinds (Bars / Line / Area / Pie / Scatter / Grid / Generic)
- `IsLoading` + `ShowLoadingSkeleton` + `SkeletonKind` parameters on every chart wrapper (30 charts)
- Per-type `SkeletonKind` defaults so consumers don't have to specify
- `prefers-reduced-motion` gates the pulse animation
- Docs demo on `/components/charts/bar` — "Loading state" section with a Simulate-loading button and a Hold-skeleton switch

## Test plan
- [x] `dotnet build src/Lumeo` — 0 errors
- [x] `dotnet build docs/Lumeo.Docs` — 0 errors
- [x] `dotnet test` — 1,723 / 1,723 passing (+26 from 2.0.0-rc.2)
- [ ] Merge + create GitHub Release `v2.0.0-rc.3` to trigger all 4 publish jobs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Global chart loading states with shape-aware skeletons and animated "phantom" placeholders; per-chart controls to toggle and tune loading/animation.
  * New composable DataGrid toolbar model plus dedicated toolbar tools (columns, export, fullscreen, layouts, copy-selected).

* **Documentation**
  * Added interactive "Loading state" demos and updated API docs for charts and toolbar usage.

* **Tests**
  * New unit tests covering chart skeleton rendering and loading-state behavior.

* **Chores**
  * Bumped package version to 2.0.0-rc.3.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->