### PR TITLE
fix(cli): default registry URL uses jsDelivr CDN + flexible file URL …

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"1aac31f1-ef8e-49da-a5cd-dfeef9e27d6a","pid":17128,"acquiredAt":1776797036511}

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -2,7 +2,7 @@ name: Deploy Docs to GitHub Pages
 
 on:
   push:
-    branches: [master]
+    branches: [master, v2.0-dev]
   workflow_dispatch:
 
 permissions:
@@ -36,6 +36,15 @@ jobs:
 
       - name: Add CNAME for custom domain
         run: echo 'lumeo.nativ.sh' > release/wwwroot/CNAME
+
+      - name: Copy registry to site root (for CLI --registry access at <site>/registry/*)
+        run: |
+          mkdir -p release/wwwroot/registry
+          cp -r src/Lumeo/wwwroot/registry/* release/wwwroot/registry/ || true
+          mkdir -p release/wwwroot/raw
+          # The CLI's default scheme resolves component files under <site>/raw/<relpath>.
+          # Copy src/Lumeo/* (sans wwwroot duplicates) so CLI file fetches work once Pages is live.
+          rsync -a --exclude='wwwroot/_content' --exclude='obj' --exclude='bin' src/Lumeo/ release/wwwroot/raw/
 
       - name: Copy index.html to 404.html for SPA routing
         run: cp release/wwwroot/index.html release/wwwroot/404.html

--- a/docs/Lumeo.Docs/Pages/Docs/Changelog.razor
+++ b/docs/Lumeo.Docs/Pages/Docs/Changelog.razor
@@ -103,6 +103,29 @@
 
     <Separator Class="my-4" />
 
+    <!-- v2.0.0-rc.6 -->
+    <Stack Gap="4">
+        <div class="flex items-center gap-3">
+            <Badge>v2.0.0-rc.6</Badge>
+            <Lumeo.Text Size="sm" Color="muted">April 2026</Lumeo.Text>
+        </div>
+
+        <Lumeo.Text Size="base" Color="muted" Leading="relaxed">
+            Default registry URL now points at jsDelivr's GitHub CDN, so the CLI works out of the box without any self-hosted registry. Enables <code class="rounded bg-muted px-1.5 py-0.5 text-xs font-mono text-foreground">lumeo init</code> / <code class="rounded bg-muted px-1.5 py-0.5 text-xs font-mono text-foreground">lumeo add</code> on fresh projects immediately after <code class="rounded bg-muted px-1.5 py-0.5 text-xs font-mono text-foreground">dotnet tool install</code>.
+        </Lumeo.Text>
+
+        <Stack Gap="3">
+            <Heading Level="3" Size="sm" Class="font-semibold">Fixed</Heading>
+            <ul class="space-y-1.5 text-sm list-disc list-inside text-muted-foreground">
+                <li>Default registry URL <code class="rounded bg-muted px-1.5 py-0.5 text-xs font-mono text-foreground">lumeo.nativ.sh</code> wasn't live, so fresh installs of the CLI failed with a 404 on <code class="rounded bg-muted px-1.5 py-0.5 text-xs font-mono text-foreground">lumeo add &lt;component&gt;</code>. Now defaults to <code class="rounded bg-muted px-1.5 py-0.5 text-xs font-mono text-foreground">cdn.jsdelivr.net/gh/Brain2k-0005/Lumeo@v2.0.0-rc.6/src/Lumeo/wwwroot/registry/registry.json</code> — pinned to the release tag so schema stays consistent.</li>
+                <li>File-fetch URL derivation now recognizes three patterns: (1) jsDelivr / raw.githubusercontent.com layouts where the registry lives under <code class="rounded bg-muted px-1.5 py-0.5 text-xs font-mono text-foreground">.../wwwroot/registry/registry.json</code>, (2) legacy self-hosted <code class="rounded bg-muted px-1.5 py-0.5 text-xs font-mono text-foreground">/registry.json</code> → <code class="rounded bg-muted px-1.5 py-0.5 text-xs font-mono text-foreground">/raw/</code>, (3) bare base URLs.</li>
+                <li>GitHub Pages deploy workflow now also triggers on <code class="rounded bg-muted px-1.5 py-0.5 text-xs font-mono text-foreground">v2.0-dev</code> branch and copies the registry + source files under the published site's <code class="rounded bg-muted px-1.5 py-0.5 text-xs font-mono text-foreground">/registry/</code> + <code class="rounded bg-muted px-1.5 py-0.5 text-xs font-mono text-foreground">/raw/</code> paths.</li>
+            </ul>
+        </Stack>
+    </Stack>
+
+    <Separator Class="my-4" />
+
     <!-- v2.0.0-rc.5 -->
     <Stack Gap="4">
         <div class="flex items-center gap-3">

--- a/src/Lumeo/Lumeo.csproj
+++ b/src/Lumeo/Lumeo.csproj
@@ -8,7 +8,7 @@
 
     <!-- NuGet Package Metadata -->
     <PackageId>Lumeo</PackageId>
-    <Version>2.0.0-rc.5</Version>
+    <Version>2.0.0-rc.6</Version>
     <Title>Lumeo</Title>
     <Authors>bemi</Authors>
     <Description>Lumeo is a modern, accessible Blazor component library with 135+ production-ready components. Built on Tailwind CSS v4 with 8 color themes, dark mode, and 14 locales. Features AI chat primitives (PromptInput, StreamingText, AgentMessage), motion primitives, Scheduler (FullCalendar), Gantt (Frappe), RichTextEditor (TipTap), 30+ ECharts, enterprise DataGrid with Excel/PDF/CSV export, programmatic overlay service, [LumeoForm] Roslyn source generator, RTL support, and 1,564 unit tests. Inspired by shadcn/ui and Radix.</Description>

--- a/templates/Lumeo.Templates/Lumeo.Templates.csproj
+++ b/templates/Lumeo.Templates/Lumeo.Templates.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <PackageType>Template</PackageType>
     <PackageId>Lumeo.Templates</PackageId>
-    <Version>2.0.0-rc.5</Version>
+    <Version>2.0.0-rc.6</Version>
     <Title>Lumeo item templates</Title>
     <Authors>bemi</Authors>
     <Description>Scaffolding templates for Lumeo Blazor projects: pages, forms, and components.</Description>

--- a/tools/Lumeo.Cli/Commands.cs
+++ b/tools/Lumeo.Cli/Commands.cs
@@ -50,7 +50,7 @@ internal static class Commands
             path = opts.Yes ? defaultPath : Prompts.Ask("Components path", defaultPath);
 
         var registry = opts.Registry;
-        var defaultRegistry = "https://lumeo.nativ.sh/registry/registry.json";
+        var defaultRegistry = RegistryLoader.DefaultRegistryUrl;
         if (registry is null)
             registry = opts.Yes ? defaultRegistry : Prompts.Ask("Registry URL", defaultRegistry);
 
@@ -850,7 +850,7 @@ internal static class Commands
     public static async Task List(bool local, string? category, bool json)
     {
         var cfg = ConfigIO.TryLoad();
-        var registryUrl = cfg?.Registry ?? "https://lumeo.nativ.sh/registry/registry.json";
+        var registryUrl = cfg?.Registry ?? RegistryLoader.DefaultRegistryUrl;
         var registry = await RegistryLoader.LoadAsync(local, registryUrl);
 
         var filtered = registry.Components

--- a/tools/Lumeo.Cli/Lumeo.Cli.csproj
+++ b/tools/Lumeo.Cli/Lumeo.Cli.csproj
@@ -9,7 +9,7 @@
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>lumeo</ToolCommandName>
     <PackageId>Lumeo.Cli</PackageId>
-    <Version>2.0.0-rc.5</Version>
+    <Version>2.0.0-rc.6</Version>
     <Description>Vendorize Lumeo components directly into your project.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <Authors>bemi</Authors>

--- a/tools/Lumeo.Cli/Program.cs
+++ b/tools/Lumeo.Cli/Program.cs
@@ -14,7 +14,7 @@ var root = new RootCommand("Lumeo CLI — vendorize Lumeo components into your p
 // --- init ---
 var initNamespaceOpt = new Option<string?>("--namespace", "Target namespace for generated components (e.g. MyApp.Components).");
 var initPathOpt = new Option<string?>("--path", "Components folder relative to the current directory. Default: Components/Ui");
-var initRegistryOpt = new Option<string?>("--registry", "Registry URL. Default: https://lumeo.nativ.sh/registry/registry.json");
+var initRegistryOpt = new Option<string?>("--registry", "Registry URL. Default: jsDelivr CDN at cdn.jsdelivr.net/gh/Brain2k-0005/Lumeo@<version>/src/Lumeo/wwwroot/registry/registry.json");
 var initForceOpt = new Option<bool>("--force", "Overwrite an existing lumeo.json.");
 var initYesOpt = new Option<bool>(new[] { "--yes", "-y" }, "Accept all defaults, skip prompts (CI mode).");
 var initWithCssOpt = new Option<bool>("--with-css", "Copy Lumeo's pre-built CSS/JS into wwwroot/ (no Tailwind required).");
@@ -174,7 +174,7 @@ namespace Lumeo.Cli
     {
         [JsonPropertyName("namespace")] public string Namespace { get; set; } = "MyApp.Components";
         [JsonPropertyName("componentsPath")] public string ComponentsPath { get; set; } = "Components/Ui";
-        [JsonPropertyName("registry")] public string Registry { get; set; } = "https://lumeo.nativ.sh/registry/registry.json";
+        [JsonPropertyName("registry")] public string Registry { get; set; } = RegistryLoader.DefaultRegistryUrl;
         [JsonPropertyName("assets")] public AssetsConfig? Assets { get; set; }
         [JsonPropertyName("components")] public Dictionary<string, InstalledComponent>? Components { get; set; }
     }
@@ -284,9 +284,35 @@ namespace Lumeo.Cli
                 return r ?? throw new InvalidOperationException("Failed to parse local registry.");
             }
 
-            var url = registryUrl ?? "https://lumeo.nativ.sh/registry/registry.json";
+            var url = registryUrl ?? DefaultRegistryUrl;
             var r2 = await s_http.GetFromJsonAsync<Registry>(url, s_opts);
             return r2 ?? throw new InvalidOperationException($"Failed to fetch registry: {url}");
+        }
+
+        /// <summary>Default registry URL — jsDelivr mirrors github content globally over CDN,
+        /// no hosting setup required. Pinned to an RC tag so the registry and the CLI binary
+        /// always agree on schema/shape.</summary>
+        public const string DefaultRegistryUrl =
+            "https://cdn.jsdelivr.net/gh/Brain2k-0005/Lumeo@v2.0.0-rc.6/src/Lumeo/wwwroot/registry/registry.json";
+
+        /// <summary>Derive the base URL to fetch component source files from the registry URL.
+        /// Supports three layouts:
+        ///   1) jsDelivr / raw.githubusercontent.com / any URL ending in ".../Lumeo/wwwroot/registry/registry.json"
+        ///      → strip trailing "wwwroot/registry/registry.json" so file paths resolve under src/Lumeo/
+        ///   2) Self-hosted with legacy "/raw/" convention (".../registry.json" → ".../raw/")
+        ///   3) Anything else: append "/raw/" to the trimmed URL
+        /// </summary>
+        public static string DeriveFileBaseUrl(string registryUrl)
+        {
+            const string marker = "/wwwroot/registry/registry.json";
+            if (registryUrl.EndsWith(marker, StringComparison.OrdinalIgnoreCase))
+            {
+                // Strip marker, keep trailing slash so relative path (e.g. "UI/Button/Button.razor") lands at src/Lumeo/UI/...
+                return registryUrl.Substring(0, registryUrl.Length - marker.Length + 1);
+            }
+            if (registryUrl.Contains("/registry.json", StringComparison.OrdinalIgnoreCase))
+                return registryUrl.Replace("/registry.json", "/raw/", StringComparison.OrdinalIgnoreCase);
+            return registryUrl.TrimEnd('/') + "/raw/";
         }
 
         public static async Task<string> GetFileAsync(string relativePath, bool local, string registryUrl)
@@ -299,9 +325,7 @@ namespace Lumeo.Cli
                 if (!File.Exists(abs)) throw new FileNotFoundException($"Local file not found: {abs}");
                 return await File.ReadAllTextAsync(abs);
             }
-            var baseUrl = registryUrl.Contains("/registry.json")
-                ? registryUrl.Replace("/registry.json", "/raw/")
-                : registryUrl.TrimEnd('/') + "/raw/";
+            var baseUrl = DeriveFileBaseUrl(registryUrl);
             return await s_http.GetStringAsync(baseUrl + relativePath);
         }
 
@@ -313,23 +337,22 @@ namespace Lumeo.Cli
             {
                 var repoRoot = Paths.FindRepoRoot(Environment.CurrentDirectory)
                                ?? throw new InvalidOperationException("--local requires running inside the Lumeo repo.");
-                // Strip the "_content/Lumeo/" prefix to map to src/Lumeo/wwwroot.
-                var stripped = assetRelPath;
                 const string prefix = "_content/Lumeo/";
-                if (stripped.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
-                    stripped = stripped.Substring(prefix.Length);
+                var stripped = assetRelPath.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)
+                    ? assetRelPath.Substring(prefix.Length) : assetRelPath;
                 var abs = Path.Combine(Paths.LocalSourceRoot(repoRoot), "wwwroot",
                     stripped.Replace('/', Path.DirectorySeparatorChar));
                 if (!File.Exists(abs)) throw new FileNotFoundException($"Local asset not found: {abs}");
                 return await File.ReadAllBytesAsync(abs);
             }
-            // Base site URL, derived from registry URL. Registry is https://lumeo.nativ.sh/registry/registry.json;
-            // strip "registry/registry.json" to get the site root.
-            var siteBase = registryUrl;
-            var idx = siteBase.IndexOf("/registry/", StringComparison.OrdinalIgnoreCase);
-            if (idx > 0) siteBase = siteBase.Substring(0, idx);
-            siteBase = siteBase.TrimEnd('/');
-            var url = $"{siteBase}/{assetRelPath}";
+            // Strip "_content/Lumeo/" → relative wwwroot path, then fetch via the same base
+            // the file fetcher uses (which already knows how to resolve src/Lumeo/).
+            const string contentPrefix = "_content/Lumeo/";
+            var rel = assetRelPath.StartsWith(contentPrefix, StringComparison.OrdinalIgnoreCase)
+                ? assetRelPath.Substring(contentPrefix.Length) : assetRelPath;
+            var baseUrl = DeriveFileBaseUrl(registryUrl);
+            // Assets live under src/Lumeo/wwwroot/; DeriveFileBaseUrl returns src/Lumeo/ so add wwwroot/.
+            var url = $"{baseUrl}wwwroot/{rel}";
             return await s_http.GetByteArrayAsync(url);
         }
     }


### PR DESCRIPTION
…derivation

rc.5's CLI pointed at lumeo.nativ.sh which isn't DNS'd, so 'lumeo add' 404'd on fresh installs. rc.6 defaults to jsDelivr's GitHub mirror — zero hosting setup required — and auto-detects three URL layouts for file fetching:

1. jsDelivr / raw.githubusercontent.com: registry at '.../wwwroot/registry/registry.json' → files at '.../<relpath>'
2. Legacy self-hosted: '.../registry.json' → '.../raw/'
3. Bare: '<base>/' + '/raw/'

Default URL pinned to @v2.0.0-rc.6 so schema and binary stay in sync per release. Consumers can still override with --registry.

Also:
- deploy-docs.yml triggers on v2.0-dev too (in addition to master)
- Workflow copies src/Lumeo/wwwroot/registry/ → /registry/ and src/Lumeo/ → /raw/ in the published site so once Pages is live at lumeo.nativ.sh the CLI can ALSO point there (fallback / legacy deploys)
- Version bump Lumeo / Lumeo.Cli / Lumeo.Templates → 2.0.0-rc.6
- Changelog entry

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Released v2.0.0-rc.6
  * Default component registry now points to jsDelivr CDN, enabling fresh CLI installations to work without requiring a self-hosted registry

* **Chores**
  * Updated GitHub Pages deployment workflow to trigger on both `master` and `v2.0-dev` branches
  * Enhanced registry and source file distribution to GitHub Pages

<!-- end of auto-generated comment: release notes by coderabbit.ai -->