### PR TITLE
test: update Bento/Splitter assertions for rc.10 CSS changes

### DIFF
--- a/tests/Lumeo.Tests/Components/Bento/BentoTests.cs
+++ b/tests/Lumeo.Tests/Components/Bento/BentoTests.cs
@@ -78,11 +78,14 @@ public class BentoTests : IAsyncLifetime
     }
 
     [Fact]
-    public void Container_Query_Inline_Style_Is_Present()
+    public void Grid_Auto_Rows_Inline_Style_Is_Present()
     {
+        // Bento swapped `container-type: inline-size` for `grid-auto-rows: minmax(0, 1fr)` so mixed
+        // RowSpan tiles stay aligned — every row gets the same fr unit and short-content tiles don't
+        // collapse to their minimum height.
         var cut = _ctx.Render<Lumeo.Bento>();
 
-        Assert.Contains("container-type: inline-size", cut.Find("div").GetAttribute("style"));
+        Assert.Contains("grid-auto-rows: minmax(0, 1fr)", cut.Find("div").GetAttribute("style"));
     }
 
     [Fact]

--- a/tests/Lumeo.Tests/Components/Splitter/SplitterPaneTests.cs
+++ b/tests/Lumeo.Tests/Components/Splitter/SplitterPaneTests.cs
@@ -53,11 +53,13 @@ public class SplitterPaneTests : IAsyncLifetime
     [Fact]
     public void Pane_With_Explicit_Size_Produces_Flex_Inline_Style()
     {
+        // Splitter switched from `flex: 0 0 X%` (broken in vertical mode without explicit parent height)
+        // to `flex: X 1 0` — grow ratio instead of flex-basis %.
         var cut = RenderWithPane(size: 40);
 
         var style = cut.Find("[data-testid='pane-body']").ParentElement!.GetAttribute("style");
-        Assert.Contains("flex: 0 0", style);
-        Assert.Contains("40", style); // size value appears
+        Assert.Contains("flex:", style);
+        Assert.Contains("40", style); // size value now appears as the grow ratio
     }
 
     [Fact]
@@ -66,9 +68,9 @@ public class SplitterPaneTests : IAsyncLifetime
         // Two panes, both size 0 → should each get 50% after distribution
         var cut = RenderWithPane(size: 0);
 
-        var panes = cut.FindAll("[style*='flex: 0 0']");
+        var panes = cut.FindAll("[style*='flex:']");
         Assert.Equal(2, panes.Count);
-        // Both should have ~50 in the style
+        // Both should have ~50 in the style (as the grow ratio)
         Assert.All(panes, p =>
         {
             var s = p.GetAttribute("style") ?? "";


### PR DESCRIPTION
Bento swapped `container-type: inline-size` → `grid-auto-rows: minmax(0, 1fr)` (fixes mixed-RowSpan tile overlap) and Splitter swapped `flex: 0 0 X%` → `flex: X 1 0` (fixes vertical mode without explicit parent height). The three assertion tests still checked the old strings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Updates**
  * Bento component: Improved automatic row sizing for better grid alignment and spacing.
  * SplitterPane component: Enhanced proportional sizing behavior for more consistent layout results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->