### PR TITLE
2.0.1 — regenerate MCP registry + fix stale-version & multi-@code-block bugs

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
   <!-- Lockstep version shared by all Lumeo packages.
        Update this single property to version all packages in unison. -->
   <PropertyGroup>
-    <Version>2.0.0</Version>
+    <Version>2.0.1</Version>
   </PropertyGroup>
 
   <!-- Shared NuGet README packing lives in Directory.Build.targets, NOT here.

--- a/docs/Lumeo.Docs/Pages/Components/CodePage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/CodePage.razor
@@ -22,7 +22,7 @@
     </ComponentDemo>
 
     <ComponentDemo Title="Block" Code="@_blockCode">
-        <Code Variant="block">dotnet add package Lumeo --version 2.0.0</Code>
+        <Code Variant="block">dotnet add package Lumeo --version 2.0.1</Code>
     </ComponentDemo>
 
     <ComponentDemo Title="Custom Size" Code="@_sizeCode">
@@ -121,7 +121,7 @@
     Pass <Code>Variant=""block""</Code> for multi-line blocks.
 </p>";
 
-    private string _blockCode = @"<Code Variant=""block"">dotnet add package Lumeo --version 2.0.0</Code>";
+    private string _blockCode = @"<Code Variant=""block"">dotnet add package Lumeo --version 2.0.1</Code>";
 
     private string _sizeCode = @"<Code Size=""xs"">text-xs code</Code>
 <Code Size=""base"">text-base code</Code>

--- a/docs/Lumeo.Docs/Pages/Docs/Cli.razor
+++ b/docs/Lumeo.Docs/Pages/Docs/Cli.razor
@@ -36,7 +36,7 @@
                 Install as a global <code class="rounded bg-muted px-1.5 py-0.5 text-xs font-mono text-foreground">dotnet</code> tool:
             </Lumeo.Text>
             <Stack Class="code-block rounded-lg border border-border/40 bg-muted px-4 py-3 font-mono text-sm text-foreground">
-                dotnet tool install -g Lumeo.Cli --version 2.0.0
+                dotnet tool install -g Lumeo.Cli --version 2.0.1
             </Stack>
             <Lumeo.Text Size="sm" Color="muted" Leading="relaxed">
                 The tool exposes a single command, <code class="rounded bg-muted px-1.5 py-0.5 text-xs font-mono text-foreground">lumeo</code>.

--- a/docs/Lumeo.Docs/wwwroot/registry/code.json
+++ b/docs/Lumeo.Docs/wwwroot/registry/code.json
@@ -83,7 +83,7 @@
       },
       {
         "title": "Block",
-        "code": "<Code Variant=\"block\">dotnet add package Lumeo --version 2.0.0</Code>"
+        "code": "<Code Variant=\"block\">dotnet add package Lumeo --version 2.0.1</Code>"
       },
       {
         "title": "Custom Size",

--- a/src/Lumeo/registry/registry.json
+++ b/src/Lumeo/registry/registry.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://lumeo.nativ.sh/registry-schema.json",
-  "version": "2.0.0",
-  "generated": "2026-05-19T13:36:52.9626450Z",
+  "version": "2.0.1",
+  "generated": "2026-05-19T14:27:18.1970393Z",
   "components": {
     "accordion": {
       "name": "Accordion",

--- a/src/Lumeo/registry/registry.json
+++ b/src/Lumeo/registry/registry.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://lumeo.nativ.sh/registry-schema.json",
   "version": "2.0.1",
-  "generated": "2026-05-19T14:27:18.1970393Z",
+  "generated": "2026-05-19T14:33:48.2437097Z",
   "components": {
     "accordion": {
       "name": "Accordion",

--- a/tools/lumeo-mcp/package.json
+++ b/tools/lumeo-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lumeo-ui/mcp-server",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Model Context Protocol server for the Lumeo Blazor component library. Lets LLMs (Claude, Copilot, Cursor) author correct Lumeo markup.",
   "type": "module",
   "main": "dist/index.js",

--- a/tools/lumeo-mcp/src/components-api.json
+++ b/tools/lumeo-mcp/src/components-api.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://lumeo.nativ.sh/components-api-schema.json",
-  "version": "2.0.0",
-  "generated": "2026-05-19T13:36:54.0485587Z",
+  "version": "2.0.1",
+  "generated": "2026-05-19T14:27:19.3116110Z",
   "stats": {
     "componentCount": 149,
     "totalParameters": 3510,

--- a/tools/lumeo-mcp/src/components-api.json
+++ b/tools/lumeo-mcp/src/components-api.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://lumeo.nativ.sh/components-api-schema.json",
   "version": "2.0.1",
-  "generated": "2026-05-19T14:27:19.3116110Z",
+  "generated": "2026-05-19T14:33:49.3382347Z",
   "stats": {
     "componentCount": 149,
     "totalParameters": 3510,
@@ -13010,7 +13010,7 @@
         },
         {
           "title": "Block",
-          "code": "<Code Variant=\"block\">dotnet add package Lumeo --version 2.0.0</Code>"
+          "code": "<Code Variant=\"block\">dotnet add package Lumeo --version 2.0.1</Code>"
         },
         {
           "title": "Custom Size",

--- a/tools/lumeo-mcp/src/index.ts
+++ b/tools/lumeo-mcp/src/index.ts
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
 /**
- * Lumeo MCP Server v2.0.0
+ * Lumeo MCP Server v2.0.1
  *
- * Source-of-truth schema for ALL 131 Lumeo components, generated at build time
+ * Source-of-truth schema for ALL Lumeo components, generated at build time
  * by `tools/Lumeo.RegistryGen` from the actual Razor source via Roslyn. Every
  * component now ships full parameter / enum / event / sub-component metadata —
  * no thin/rich split, no manual catalog drift.
@@ -364,7 +364,7 @@ function validateMarkup(markup: string): { ok: boolean; issues: ValidationIssue[
 const server = new Server(
   {
     name: "lumeo-mcp",
-    version: "2.0.0",
+    version: "2.0.1",
   },
   {
     capabilities: {

--- a/tools/lumeo-mcp/src/registry.json
+++ b/tools/lumeo-mcp/src/registry.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://lumeo.nativ.sh/registry-schema.json",
-  "version": "2.0.0",
-  "generated": "2026-05-19T13:36:52.9626450Z",
+  "version": "2.0.1",
+  "generated": "2026-05-19T14:27:18.1970393Z",
   "components": {
     "accordion": {
       "name": "Accordion",

--- a/tools/lumeo-mcp/src/registry.json
+++ b/tools/lumeo-mcp/src/registry.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://lumeo.nativ.sh/registry-schema.json",
   "version": "2.0.1",
-  "generated": "2026-05-19T14:27:18.1970393Z",
+  "generated": "2026-05-19T14:33:48.2437097Z",
   "components": {
     "accordion": {
       "name": "Accordion",


### PR DESCRIPTION
## Summary

The `@lumeo-ui/mcp-server` published on npm as `2.0.0` shipped **stale rc.38 data** (145 components, `2.0.0-rc.38` label) and a scanner bug that dropped component parameters. Since npm forbids overwriting `2.0.0`, this bumps the lockstep version to **2.0.1** and ships the fix.

- **Stale-version fix**: `tools/Lumeo.RegistryGen` now reads the lockstep `<Version>` from `Directory.Build.props` instead of two hardcoded literals (one was still `2.0.0-rc.38`), so `registry.json` / `components-api.json` can't drift again.
- **Scanner fix** (`RazorParameterScanner.cs`): only the **last** `@code` block was parsed, silently dropping all 14 of `FileManager`'s `[Parameter]`s. It now parses every `@code` block independently and merges results, so a markup-bearing `RenderFragment` block (e.g. `Checkbox`'s first block) no longer corrupts extraction.
- **Version bump**: `Directory.Build.props` 2.0.0 → 2.0.1; `tools/lumeo-mcp` `package.json` + `index.ts` → 2.0.1.
- **Regenerated** `registry.json` + `components-api.json` + per-component docs at **2.0.1**: 149 components (was 145), 3510 params, 104 enums, 59 records, **0 parse failures**.

> Note: this consciously creates new NuGet `2.0.1` packages even though Lumeo component code is unchanged (CLAUDE.md Rule #2 waived by the owner for this case — the npm MCP fix requires a new lockstep release).

## Test plan

- [x] `dotnet build tools/Lumeo.RegistryGen` — succeeds
- [x] RegistryGen run — 149 components, 0 parse failures, version 2.0.1
- [x] `npm run build` in `tools/lumeo-mcp` — succeeds with regenerated JSON
- [x] `FileManager` 14 params, `Checkbox` 19 params verified; `Overlay` legitimately 0 (imperative API)
- [ ] After merge: create `v2.0.1` tag + GitHub Release → `publish.yml` publishes npm + NuGet

https://claude.ai/code/session_01Qw2VgonMF7ruVsuA2b4Fsi

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qw2VgonMF7ruVsuA2b4Fsi)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped package version to 2.0.1 across all Lumeo packages and components.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Brain2k-0005/Lumeo/pull/15?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->