### PR TITLE
ci(publish): trigger publish on v*.*.* tag push

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,6 +7,9 @@ name: Publish 2.0 packages
 on:
   release:
     types: [published]
+  push:
+    tags:
+      - 'v*.*.*'
 
 jobs:
   publish-lumeo:


### PR DESCRIPTION
## Summary

`publish.yml` only triggered on `release: published`. A GitHub Release cannot be created through the automation available in this environment (no release/tag/workflow-dispatch tooling), so the 2.0.1 packages could not be shipped.

This adds a `push: tags: ['v*.*.*']` trigger so pushing a `v<semver>` tag runs the full publish pipeline (publish-lumeo + satellites, publish-cli, publish-templates, publish-mcp).

- Version derivation is unchanged: `version=${GITHUB_REF_NAME#v}` resolves a tag `v2.0.1` to `2.0.1` exactly as it did for releases.
- The existing `release: published` trigger is untouched.
- npm `npm publish` (already-published swallow) and `dotnet nuget push --skip-duplicate` are idempotent, so a double trigger (tag + release) is safe.

Follow-up: push tag `v2.0.1` at master → triggers the publish.

https://claude.ai/code

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qw2VgonMF7ruVsuA2b4Fsi)_