### PR TITLE
2.1.1: DataGrid group panel + filter popover, Sheet mobile-fullscreen, OverlayService SwipeToClose

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,14 +3,26 @@
 ## Rule #1: Never commit with a Co-Author
 Do NOT add `Co-Authored-By` lines in commit messages.
 
-## Rule #2: Tags = real library releases only
-A new tag + GitHub release MUST mean a real change in NuGet package content
+## Rule #2: Tags = real library releases, releases need owner confirmation
+A new tag MUST correspond to a real change in NuGet package content
 (component code, source generator, JS interop, CSS bundle). **Docs-only
 changes do NOT get a new tag** — they go to `master` with a `docs(...)` or
 `feat(docs)` commit prefix; Cloudflare Pages deploys the docs site from
 `master` automatically. Tagging docs-only changes produces orphaned NuGet
 versions that are functionally identical to the previous release and cannot
-be unpublished. If unsure: ask before tagging.
+be unpublished.
+
+**Claude may create git tags** for real library changes (matching the
+`Version` in `Directory.Build.props`), but **must NOT cut the GitHub
+release / publish to NuGet** — that step requires explicit confirmation
+from the repo owner (Brain2k-0005). Workflow:
+1. Code change merged → bump `Directory.Build.props`.
+2. Claude may create the annotated tag locally (`git tag -a 2.1.1 -m "..."`)
+   and push it (`git push origin 2.1.1`) only after the owner says "tag it".
+3. Owner triggers / approves the GitHub release + NuGet publish step.
+
+If unsure whether something is a real lib change or docs-only: ask before
+tagging.
 
 ## Agent Teams
 When tasks involve multiple independent components (frontend, backend, tests),

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
   <!-- Lockstep version shared by all Lumeo packages.
        Update this single property to version all packages in unison. -->
   <PropertyGroup>
-    <Version>2.1.0</Version>
+    <Version>2.1.1</Version>
   </PropertyGroup>
 
   <!-- Shared NuGet README packing lives in Directory.Build.targets, NOT here.

--- a/docs/Lumeo.Docs/Pages/Components/CodePage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/CodePage.razor
@@ -22,7 +22,7 @@
     </ComponentDemo>
 
     <ComponentDemo Title="Block" Code="@_blockCode">
-        <Code Variant="block">dotnet add package Lumeo --version 2.1.0</Code>
+        <Code Variant="block">dotnet add package Lumeo --version 2.1.1</Code>
     </ComponentDemo>
 
     <ComponentDemo Title="Custom Size" Code="@_sizeCode">
@@ -121,7 +121,7 @@
     Pass <Code>Variant=""block""</Code> for multi-line blocks.
 </p>";
 
-    private string _blockCode = @"<Code Variant=""block"">dotnet add package Lumeo --version 2.1.0</Code>";
+    private string _blockCode = @"<Code Variant=""block"">dotnet add package Lumeo --version 2.1.1</Code>";
 
     private string _sizeCode = @"<Code Size=""xs"">text-xs code</Code>
 <Code Size=""base"">text-base code</Code>

--- a/docs/Lumeo.Docs/Pages/Components/DataGridPage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/DataGridPage.razor
@@ -433,7 +433,7 @@
         </DataGrid>
     </ComponentDemo>
 
-    <ComponentDemo Title="Layout Persistence" Description="Save and restore column widths, order, visibility, sorts, and filters to localStorage. The layout survives page refreshes. Use the Layouts dropdown in the toolbar to save named layouts under Personal, Global, or System Default scopes." Code="@_layoutPersistenceCode">
+    <ComponentDemo Title="Layout Persistence" Description="Save and restore column widths, order, visibility, sorts, filters, and the group panel (runtime group fields) to localStorage. The layout survives page refreshes. Use the Layouts dropdown in the toolbar to save named layouts under Personal, Global, or System Default scopes." Code="@_layoutPersistenceCode">
         <DataGrid TItem="Employee" Items="@_employees" PageSize="5" ShowPagination="true"
                   ShowToolbar="true" Reorderable="true"
                   EnableLayoutPersistence="true" LayoutStorageKey="demo-datagrid-layout">
@@ -468,7 +468,7 @@
     <div class="space-y-3">
         <Heading Id="saving-and-loading-layouts" Level="2" Class="scroll-mt-20">Saving and loading layouts</Heading>
         <Text Size="sm" Color="muted">
-            For full control over where layouts are stored (your own database, a REST API, cookies, etc.), use the programmatic JSON API. Capture a grid reference with <code>@@ref</code>, then call <code>ExportLayout()</code> to get a JSON string and <code>ApplyLayoutJsonAsync(json)</code> to round-trip it later. The snapshot covers column order, widths, visibility, pin state, sorts, filters, global search, current page, page size, and group-by.
+            For full control over where layouts are stored (your own database, a REST API, cookies, etc.), use the programmatic JSON API. Capture a grid reference with <code>@@ref</code>, then call <code>ExportLayout()</code> to get a JSON string and <code>ApplyLayoutJsonAsync(json)</code> to round-trip it later. The snapshot covers column order, widths, visibility, pin state, sorts, filters, global search, current page, page size, and the group panel (multi-level group fields) — both single and multi-level grouping levels round-trip.
         </Text>
         <pre class="rounded-md border border-border/40 bg-muted/30 p-3 text-xs overflow-x-auto"><code>&lt;DataGrid @@ref="_grid" TItem="Order" Items="_orders"&gt;
     &lt;DataGridColumnDef TItem="Order" Field="Id" Title="ID" /&gt;
@@ -508,7 +508,7 @@
     }
 }</code></pre>
         <Text Size="sm" Color="muted">
-            The JSON shape is the public <code>DataGridLayoutSnapshot</code> record. The snapshot is versioned (<code>Version: 1</code> today) so future breaking changes can be migrated. Columns referenced in a snapshot that no longer exist on the grid are silently ignored; columns present on the grid but missing from the snapshot are appended at the end.
+            The JSON shape is the public <code>DataGridLayoutSnapshot</code> record. The snapshot is versioned (<code>Version: 2</code> today) so future breaking changes can be migrated; v1 payloads still load — the legacy single-level <code>GroupBy</code> field is honoured as a fallback when <code>GroupByFields</code> is absent. Columns referenced in a snapshot that no longer exist on the grid are silently ignored; columns present on the grid but missing from the snapshot are appended at the end.
         </Text>
     </div>
 

--- a/docs/Lumeo.Docs/Pages/Components/OverlayServicePage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/OverlayServicePage.razor
@@ -266,7 +266,13 @@
                             <td class="p-3 font-mono text-xs text-primary">SheetSize</td>
                             <td class="p-3 font-mono text-xs text-muted-foreground">SheetSize</td>
                             <td class="p-3 font-mono text-xs text-muted-foreground">Default</td>
-                            <td class="p-3 text-muted-foreground">Width of the sheet panel.</td>
+                            <td class="p-3 text-muted-foreground">Sheet dimension. On <code>Left</code>/<code>Right</code> controls width; on <code>Top</code>/<code>Bottom</code> controls height (2.1.1). <code>Full</code> on <code>Bottom</code> + <code>SwipeToClose=true</code> gives the mobile-fullscreen sheet pattern.</td>
+                        </tr>
+                        <tr>
+                            <td class="p-3 font-mono text-xs text-primary">SwipeToClose</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">bool</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">false</td>
+                            <td class="p-3 text-muted-foreground">Sheet-only (2.1.1). Pipes the SwipeToClose flag through to the rendered <code>SheetContent</code> so programmatically-opened sheets can be dismissed by swiping in the direction matching <code>SheetSide</code>. Default false to keep existing programmatic-open behaviour. Drawers already swipe-close by default.</td>
                         </tr>
                     </tbody>
                 </table>

--- a/docs/Lumeo.Docs/Pages/Components/SheetPage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/SheetPage.razor
@@ -350,7 +350,7 @@
                             <td class="p-3 font-mono text-xs text-primary">Size</td>
                             <td class="p-3 font-mono text-xs text-muted-foreground">SheetSize</td>
                             <td class="p-3 font-mono text-xs text-muted-foreground">Default</td>
-                            <td class="p-3 text-muted-foreground">Width of the sheet panel. Values: Sm, Default, Lg, Xl, Full.</td>
+                            <td class="p-3 text-muted-foreground">Sheet dimension. On <code>Left</code>/<code>Right</code> this controls width; on <code>Top</code>/<code>Bottom</code> it controls height (2.1.1). Values: Sm, Default, Lg, Xl, Full — where <strong>Full on Top/Bottom takes the entire viewport</strong>, the mobile-fullscreen bottom-sheet pattern.</td>
                         </tr>
                         <tr>
                             <td class="p-3 font-mono text-xs text-primary">PreventClose</td>

--- a/docs/Lumeo.Docs/Pages/Docs/Changelog.razor
+++ b/docs/Lumeo.Docs/Pages/Docs/Changelog.razor
@@ -15,6 +15,43 @@
 
     <Separator Class="my-4" />
 
+    <!-- v2.1.1 -->
+    <Stack Gap="4">
+        <div class="flex items-center gap-3">
+            <Badge>v2.1.1</Badge>
+            <Lumeo.Text Size="sm" Color="muted">May 2026</Lumeo.Text>
+        </div>
+
+        <Lumeo.Text Size="base" Color="muted" Leading="relaxed">
+            <strong>DataGrid group panel survives reload, Sheet mobile-fullscreen, OverlayService swipe-to-close.</strong>
+            Four real library fixes folded into a single patch release. The biggest one: layout snapshots silently dropped the runtime group-panel chips so multi-level grouping vanished on reload while sorts/filters/columns restored cleanly.
+        </Lumeo.Text>
+
+        <Stack Gap="3">
+            <Heading Level="3" Size="sm" Class="font-semibold">Fixed</Heading>
+            <ul class="space-y-1.5 text-sm list-disc list-inside text-muted-foreground">
+                <li><strong>DataGrid layout persistence</strong>: <code class="rounded bg-muted px-1.5 py-0.5 text-xs font-mono text-foreground">SnapshotCurrentLayout</code> and <code class="rounded bg-muted px-1.5 py-0.5 text-xs font-mono text-foreground">BuildLayoutSnapshot</code> now capture <code class="rounded bg-muted px-1.5 py-0.5 text-xs font-mono text-foreground">_runtimeGroupFields</code>; <code class="rounded bg-muted px-1.5 py-0.5 text-xs font-mono text-foreground">ApplyLayoutAsync</code> / <code class="rounded bg-muted px-1.5 py-0.5 text-xs font-mono text-foreground">ApplyLayoutSnapshotAsync</code> restore the panel chips. Internal <code class="rounded bg-muted px-1.5 py-0.5 text-xs font-mono text-foreground">DataGridLayout</code> + public <code class="rounded bg-muted px-1.5 py-0.5 text-xs font-mono text-foreground">DataGridLayoutSnapshot</code> gain <code class="rounded bg-muted px-1.5 py-0.5 text-xs font-mono text-foreground">GroupByFields</code>; snapshot version bumped 1 → 2. v1 payloads still load via the legacy single-level <code class="rounded bg-muted px-1.5 py-0.5 text-xs font-mono text-foreground">GroupBy</code> fallback.</li>
+                <li><strong>DataGrid column filter popover</strong>: custom <code class="rounded bg-muted px-1.5 py-0.5 text-xs font-mono text-foreground">FilterTemplate</code> rows with <code class="rounded bg-muted px-1.5 py-0.5 text-xs font-mono text-foreground">hover:bg-accent</code> painted past the rounded-lg corners. <code class="rounded bg-muted px-1.5 py-0.5 text-xs font-mono text-foreground">DataGridColumnFilter</code> wrapper gains <code class="rounded bg-muted px-1.5 py-0.5 text-xs font-mono text-foreground">overflow-hidden</code>; <code class="rounded bg-muted px-1.5 py-0.5 text-xs font-mono text-foreground">w-64</code> → <code class="rounded bg-muted px-1.5 py-0.5 text-xs font-mono text-foreground">min-w-64</code> so wider templates grow the popover instead of overflowing.</li>
+            </ul>
+
+            <Heading Level="3" Size="sm" Class="font-semibold mt-2">Improved</Heading>
+            <ul class="space-y-1.5 text-sm list-disc list-inside text-muted-foreground">
+                <li><strong>Sheet <code class="rounded bg-muted px-1.5 py-0.5 text-xs font-mono text-foreground">Size="Full"</code> on Top/Bottom</strong>: now produces a true mobile-fullscreen sheet (<code class="rounded bg-muted px-1.5 py-0.5 text-xs font-mono text-foreground">inset-y-0 h-full max-h-full</code>) instead of being a silent no-op. <code class="rounded bg-muted px-1.5 py-0.5 text-xs font-mono text-foreground">Sm</code>/<code class="rounded bg-muted px-1.5 py-0.5 text-xs font-mono text-foreground">Lg</code>/<code class="rounded bg-muted px-1.5 py-0.5 text-xs font-mono text-foreground">Xl</code> cap height at 40/70/85vh for symmetry with Left/Right width caps. <code class="rounded bg-muted px-1.5 py-0.5 text-xs font-mono text-foreground">Default</code> keeps legacy content-driven height — back-compat.</li>
+                <li><strong>OverlayService <code class="rounded bg-muted px-1.5 py-0.5 text-xs font-mono text-foreground">OverlayOptions.SwipeToClose</code></strong>: programmatically-opened Sheets can now be swipe-dismissed, matching the declarative <code class="rounded bg-muted px-1.5 py-0.5 text-xs font-mono text-foreground">&lt;SheetContent SwipeToClose="true"&gt;</code> path. Drawers already had swipe-close by default; this puts Sheets at parity. Default <code class="rounded bg-muted px-1.5 py-0.5 text-xs font-mono text-foreground">false</code> — back-compat.</li>
+            </ul>
+
+            <Heading Level="3" Size="sm" Class="font-semibold mt-2">Docs</Heading>
+            <ul class="space-y-1.5 text-sm list-disc list-inside text-muted-foreground">
+                <li>DataGrid page: Persistence demo description and "Saving and loading layouts" prose now mention the group panel is included; <code class="rounded bg-muted px-1.5 py-0.5 text-xs font-mono text-foreground">Version: 2</code> noted alongside the v1-backcompat clause.</li>
+                <li>Sheet page: <code class="rounded bg-muted px-1.5 py-0.5 text-xs font-mono text-foreground">Size</code> row now documents the Top/Bottom height behaviour and the Full-on-Bottom mobile-fullscreen pattern.</li>
+                <li>Overlay Service page: <code class="rounded bg-muted px-1.5 py-0.5 text-xs font-mono text-foreground">SwipeToClose</code> added to the OverlayOptions API table.</li>
+            </ul>
+        </Stack>
+        <Lumeo.Text Size="sm" Color="muted">12 new bUnit tests cover snapshot capture &amp; round-trip (incl. v1 back-compat), filter popover clipping, Sheet sizing on Top/Bottom, and OverlayService option routing.</Lumeo.Text>
+    </Stack>
+
+    <Separator Class="my-4" />
+
     <!-- v2.1.0 -->
     <Stack Gap="4">
         <div class="flex items-center gap-3">

--- a/docs/Lumeo.Docs/Pages/Docs/Cli.razor
+++ b/docs/Lumeo.Docs/Pages/Docs/Cli.razor
@@ -36,7 +36,7 @@
                 Install as a global <code class="rounded bg-muted px-1.5 py-0.5 text-xs font-mono text-foreground">dotnet</code> tool:
             </Lumeo.Text>
             <Stack Class="code-block rounded-lg border border-border/40 bg-muted px-4 py-3 font-mono text-sm text-foreground">
-                dotnet tool install -g Lumeo.Cli --version 2.1.0
+                dotnet tool install -g Lumeo.Cli --version 2.1.1
             </Stack>
             <Lumeo.Text Size="sm" Color="muted" Leading="relaxed">
                 The tool exposes a single command, <code class="rounded bg-muted px-1.5 py-0.5 text-xs font-mono text-foreground">lumeo</code>.

--- a/docs/Lumeo.Docs/Pages/Home.razor
+++ b/docs/Lumeo.Docs/Pages/Home.razor
@@ -14,7 +14,7 @@
                 <Lumeo.Link Href="docs/changelog" Class="no-underline group">
                     <Flex Inline="true" Align="center" Gap="2" Class="rounded-full border border-border/60 bg-background/80 px-3 py-1 text-xs font-medium text-muted-foreground backdrop-blur-sm hover:border-primary/40 hover:text-foreground transition-colors">
                         <Badge Variant="Badge.BadgeVariant.Default" Class="h-4 px-1.5 text-[10px] leading-none">New</Badge>
-                        <Lumeo.Text As="span">v2.1.0 — DataGrid: multi-level grouping &amp; group panel now work in ServerMode</Lumeo.Text>
+                        <Lumeo.Text As="span">v2.1.1 — DataGrid group panel survives reload · Sheet mobile-fullscreen · OverlayService SwipeToClose</Lumeo.Text>
                         <DynamicIcon Name="ArrowRight" Class="h-3 w-3 transition-transform group-hover:translate-x-0.5" />
                     </Flex>
                 </Lumeo.Link>

--- a/src/Lumeo.DataGrid/UI/DataGrid/DataGrid.razor
+++ b/src/Lumeo.DataGrid/UI/DataGrid/DataGrid.razor
@@ -2505,7 +2505,10 @@
             Sorts = _sorts.Count > 0 ? new List<SortDescriptor>(_sorts) : null,
             Filters = _filters.Count > 0 ? new List<FilterDescriptor>(_filters) : null,
             PageSize = PageSize,
-            GlobalSearch = _globalSearch
+            GlobalSearch = _globalSearch,
+            GroupByFields = _runtimeGroupFields.Count > 0
+                ? new List<string>(_runtimeGroupFields)
+                : null
         };
     }
 
@@ -2552,6 +2555,26 @@
 
         // Restore global search
         _globalSearch = layout.GlobalSearch;
+
+        // Restore group-panel runtime fields (chip-strip). Only consider fields
+        // that exist as a Groupable column on the current grid — silently drop
+        // any that no longer match so a stale snapshot doesn't crash the grid.
+        if (layout.GroupByFields is { Count: > 0 })
+        {
+            _runtimeGroupFields = layout.GroupByFields
+                .Where(f => EffectiveColumns.Any(c => c.Field == f))
+                .Distinct()
+                .ToList();
+        }
+        else
+        {
+            _runtimeGroupFields = new List<string>();
+        }
+        _expandedGroupPaths.Clear();
+        _knownGroupPaths.Clear();
+        _expandedGroups.Clear();
+        _knownGroupKeys.Clear();
+        _lastGroupBy = null;
 
         _currentPage = 1;
 
@@ -2685,8 +2708,11 @@
     /// <summary>
     /// Snapshot schema version — bump when <see cref="DataGridLayoutSnapshot"/>
     /// changes in a breaking way.
+    /// v2 (2.1.1): added <c>GroupByFields</c> for multi-level group-panel
+    /// persistence. v1 payloads still load — the new field is nullable and
+    /// the legacy single-level <c>GroupBy</c> is honoured as a fallback.
     /// </summary>
-    private const int LayoutSnapshotVersion = 1;
+    private const int LayoutSnapshotVersion = 2;
 
     /// <summary>
     /// Cached, shared JsonSerializerOptions used for every ExportLayout / ApplyLayoutJsonAsync
@@ -2750,7 +2776,12 @@
             GlobalSearch: _globalSearch,
             CurrentPage: _currentPage,
             PageSize: PageSize,
-            GroupBy: GroupBy
+            // Preserve the static parameter for back-compat readers; new
+            // consumers should rely on GroupByFields for multi-level state.
+            GroupBy: _runtimeGroupFields.Count > 0 ? _runtimeGroupFields[0] : GroupBy,
+            GroupByFields: _runtimeGroupFields.Count > 0
+                ? new List<string>(_runtimeGroupFields)
+                : null
         );
     }
 
@@ -2794,6 +2825,24 @@
         _globalSearch = snapshot.GlobalSearch;
         if (snapshot.PageSize > 0) PageSize = snapshot.PageSize;
         _currentPage = snapshot.CurrentPage > 0 ? snapshot.CurrentPage : 1;
+
+        // Restore group-panel runtime fields. v2 payloads carry the full
+        // ordered list in GroupByFields; v1 payloads only have GroupBy
+        // (single level) — fall back to that for back-compat.
+        var groupFields = snapshot.GroupByFields is { Count: > 0 }
+            ? snapshot.GroupByFields
+            : (!string.IsNullOrEmpty(snapshot.GroupBy)
+                ? new List<string> { snapshot.GroupBy! }
+                : new List<string>());
+        _runtimeGroupFields = groupFields
+            .Where(f => EffectiveColumns.Any(c => c.Field == f))
+            .Distinct()
+            .ToList();
+        _expandedGroupPaths.Clear();
+        _knownGroupPaths.Clear();
+        _expandedGroups.Clear();
+        _knownGroupKeys.Clear();
+        _lastGroupBy = null;
 
         if (ServerMode)
             await RequestServerData();

--- a/src/Lumeo.DataGrid/UI/DataGrid/DataGridColumnFilter.razor
+++ b/src/Lumeo.DataGrid/UI/DataGrid/DataGridColumnFilter.razor
@@ -127,7 +127,12 @@
     [Parameter] public string? Class { get; set; }
     [Parameter(CaptureUnmatchedValues = true)] public Dictionary<string, object>? AdditionalAttributes { get; set; }
 
-    private string CssClass => $"w-64 rounded-lg border border-border/40 bg-popover text-popover-foreground shadow-md {Class}".Trim();
+    // overflow-hidden is required so descendant hover/selected backgrounds
+    // (e.g. inside a custom FilterTemplate) get clipped by the rounded-lg
+    // corners — CSS border-radius alone only rounds the box itself, not its
+    // children. min-w-64 (was w-64) lets a wider FilterTemplate grow the
+    // popover instead of horizontally overflowing past the rounded edge.
+    private string CssClass => $"min-w-64 rounded-lg border border-border/40 bg-popover text-popover-foreground shadow-md overflow-hidden {Class}".Trim();
 
     private FilterOperator _selectedOperator = FilterOperator.Contains;
     private string? _filterValue;

--- a/src/Lumeo.DataGrid/UI/DataGrid/DataGridState.cs
+++ b/src/Lumeo.DataGrid/UI/DataGrid/DataGridState.cs
@@ -159,6 +159,13 @@ public class DataGridLayout
     public List<FilterDescriptor>? Filters { get; set; }
     public int? PageSize { get; set; }
     public string? GlobalSearch { get; set; }
+    /// <summary>
+    /// Ordered list of fields the group-panel was grouping by when the
+    /// snapshot was taken. Restored verbatim into the grid's runtime
+    /// grouping state so the chip-strip survives a reload. Null/empty
+    /// means no grouping was active.
+    /// </summary>
+    public List<string>? GroupByFields { get; set; }
 }
 
 public class ColumnLayout
@@ -224,7 +231,8 @@ public record DataGridLayoutSnapshot(
     string? GlobalSearch,
     int CurrentPage,
     int PageSize,
-    string? GroupBy
+    string? GroupBy,
+    List<string>? GroupByFields = null
 );
 
 /// <summary>

--- a/src/Lumeo/Services/OverlayService.cs
+++ b/src/Lumeo/Services/OverlayService.cs
@@ -124,6 +124,14 @@ public sealed record OverlayOptions
     public bool PreventClose { get; init; }
     public SheetSide SheetSide { get; init; } = SheetSide.Right;
     public SheetSize SheetSize { get; init; } = SheetSize.Default;
+    /// <summary>
+    /// When true, a Sheet opened via <see cref="OverlayService.ShowSheetAsync{T}"/>
+    /// can be dismissed by swiping in the direction opposite to its
+    /// <see cref="SheetSide"/> (e.g. swipe-down on a Bottom sheet). Ignored for
+    /// non-Sheet overlay types. Drawers already enable swipe by default.
+    /// Default false to preserve the existing programmatic-open behaviour.
+    /// </summary>
+    public bool SwipeToClose { get; init; }
 }
 
 public sealed record AlertDialogOptions

--- a/src/Lumeo/UI/Overlay/OverlayProvider.razor
+++ b/src/Lumeo/UI/Overlay/OverlayProvider.razor
@@ -26,7 +26,7 @@
 
         case OverlayType.Sheet:
             <Sheet @key="overlay.Id" Open="true" OpenChanged="(bool val) => OnOverlayClosed(val, overlay.Id)">
-                <SheetContent Side="@MapSheetSide(overlay.Options.SheetSide)" Size="@MapSheetSize(overlay.Options.SheetSize)" PreventClose="@overlay.Options.PreventClose" Class="@overlay.Options.Class">
+                <SheetContent Side="@MapSheetSide(overlay.Options.SheetSide)" Size="@MapSheetSize(overlay.Options.SheetSize)" PreventClose="@overlay.Options.PreventClose" SwipeToClose="@overlay.Options.SwipeToClose" Class="@overlay.Options.Class">
                     @if (overlay.Title is not null)
                     {
                         <SheetHeader>

--- a/src/Lumeo/UI/Sheet/SheetContent.razor
+++ b/src/Lumeo/UI/Sheet/SheetContent.razor
@@ -72,12 +72,24 @@ else if (Context.IsOpen)
             SheetSize.Full => "sm:max-w-full",
             _ => "sm:max-w-sm"
         }
-        : "";
+        // Top/Bottom: width is always full (inset-x-0). Size controls
+        // the height — Full takes the entire viewport (mobile-fullscreen
+        // pattern), the other sizes cap at a fraction of the viewport
+        // height. Default keeps the legacy content-driven height so
+        // existing layouts are unchanged.
+        : Size switch
+        {
+            SheetSize.Sm => "max-h-[40vh] h-auto",
+            SheetSize.Lg => "max-h-[70vh] h-auto",
+            SheetSize.Xl => "max-h-[85vh] h-auto",
+            SheetSize.Full => "inset-y-0 h-full max-h-full",
+            _ => ""
+        };
 
     private string PositionClasses => Side switch
     {
-        SheetSide.Top => "inset-x-0 top-0",
-        SheetSide.Bottom => "inset-x-0 bottom-0",
+        SheetSide.Top => $"inset-x-0 top-0 {SizeClass}",
+        SheetSide.Bottom => $"inset-x-0 bottom-0 {SizeClass}",
         SheetSide.Left => $"inset-y-0 left-0 h-full w-3/4 {SizeClass}",
         SheetSide.Right => $"inset-y-0 right-0 h-full w-3/4 {SizeClass}",
         _ => $"inset-y-0 right-0 h-full w-3/4 {SizeClass}"

--- a/tests/Lumeo.Tests/Components/DataGrid/DataGridFilterExtensibilityTests.cs
+++ b/tests/Lumeo.Tests/Components/DataGrid/DataGridFilterExtensibilityTests.cs
@@ -199,4 +199,79 @@ public class DataGridFilterExtensibilityTests : IAsyncLifetime
 
         Assert.Null(captured);
     }
+
+    // ---------------------------------------------------------------------------
+    // Filter popover wrapper: rounded corners must clip descendants (2.1.1)
+    //
+    // Bug: a custom FilterTemplate with hover:bg-accent rows painted hover
+    // backgrounds past the rounded-lg corners of the filter popover, because
+    // the wrapper div had rounded-lg but no overflow-hidden. CSS border-radius
+    // only rounds the box itself, not its children.
+    //
+    // Fix: DataGridColumnFilter's CssClass now includes overflow-hidden, and
+    // w-64 became min-w-64 so a wider custom template grows the popover
+    // instead of overflowing past the rounded edge.
+    // ---------------------------------------------------------------------------
+
+    [Fact]
+    public void ColumnFilter_Root_Has_OverflowHidden_And_MinWidth_For_Rounded_Clipping()
+    {
+        var column = new DataGridColumn<TestItem>
+        {
+            Field = "Name",
+            Title = "Name",
+            Filterable = true,
+            FilterType = DataGridFilterType.Text
+        };
+
+        var cut = _ctx.Render<DataGridColumnFilter<TestItem>>(p => p
+            .Add(x => x.Column, column));
+
+        // The component's root div is the first child of the bUnit render
+        // root and carries the popover styling.
+        var root = cut.Nodes[0] as AngleSharp.Dom.IElement;
+        Assert.NotNull(root);
+        var cls = root!.GetAttribute("class") ?? "";
+
+        Assert.Contains("overflow-hidden", cls);
+        Assert.Contains("min-w-64", cls);
+        Assert.Contains("rounded-lg", cls);
+        // Back-compat guard: the fixed w-64 must NOT be present, otherwise
+        // a wider custom FilterTemplate would overflow past the rounded edge
+        // again.
+        Assert.DoesNotContain(" w-64 ", $" {cls} ");
+    }
+
+    [Fact]
+    public void ColumnFilter_With_Custom_Template_Still_Has_OverflowHidden()
+    {
+        // Even when FilterTemplate is set (custom-template branch), the
+        // outer wrapper must still clip descendants. The custom-template
+        // branch and the default branch share the same root div.
+        RenderFragment<DataGridFilterTemplateContext> customTemplate = ctx => b =>
+        {
+            b.OpenElement(0, "label");
+            b.AddAttribute(1, "class", "hover:bg-accent");
+            b.AddContent(2, "row");
+            b.CloseElement();
+        };
+
+        var column = new DataGridColumn<TestItem>
+        {
+            Field = "Name",
+            Title = "Name",
+            Filterable = true,
+            FilterTemplate = customTemplate
+        };
+
+        var cut = _ctx.Render<DataGridColumnFilter<TestItem>>(p => p
+            .Add(x => x.Column, column));
+
+        var root = cut.Nodes[0] as AngleSharp.Dom.IElement;
+        Assert.NotNull(root);
+        var cls = root!.GetAttribute("class") ?? "";
+
+        Assert.Contains("overflow-hidden", cls);
+        Assert.Contains("rounded-lg", cls);
+    }
 }

--- a/tests/Lumeo.Tests/Components/DataGrid/DataGridLayoutJsonTests.cs
+++ b/tests/Lumeo.Tests/Components/DataGrid/DataGridLayoutJsonTests.cs
@@ -35,8 +35,8 @@ public class DataGridLayoutJsonTests : IAsyncLifetime
     private static List<DataGridColumn<Row>> Cols() => new()
     {
         new() { Field = "Id", Title = "ID", Sortable = true },
-        new() { Field = "Name", Title = "Name", Sortable = true, Filterable = true },
-        new() { Field = "Email", Title = "Email" },
+        new() { Field = "Name", Title = "Name", Sortable = true, Filterable = true, Groupable = true },
+        new() { Field = "Email", Title = "Email", Groupable = true },
     };
 
     // -------------------------------------------------------------------------
@@ -60,7 +60,7 @@ public class DataGridLayoutJsonTests : IAsyncLifetime
                 Converters = { new System.Text.Json.Serialization.JsonStringEnumConverter() }
             });
         Assert.NotNull(snap);
-        Assert.Equal(1, snap!.Version);
+        Assert.Equal(2, snap!.Version);
         Assert.Equal(3, snap.Columns.Count);
         Assert.Equal(7, snap.PageSize);
         Assert.Contains(snap.Columns, c => c.Field == "Id" && c.Order == 0);
@@ -183,6 +183,115 @@ public class DataGridLayoutJsonTests : IAsyncLifetime
         {
             Assert.Equal("false", th.GetAttribute("draggable"));
         }
+    }
+
+    // -------------------------------------------------------------------------
+    // Group-panel runtime field persistence (v2 schema)
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public void ExportLayout_Includes_GroupByFields_When_Group_Panel_Active()
+    {
+        var cut = _ctx.Render<DataGrid<Row>>(p => p
+            .Add(g => g.Items, Data())
+            .Add(g => g.Columns, Cols())
+            .Add(g => g.ShowGroupPanel, true)
+            .Add(g => g.GroupByFields, new[] { "Name" }));
+
+        var json = cut.Instance.ExportLayout();
+        var snap = JsonSerializer.Deserialize<DataGridLayoutSnapshot>(json,
+            new JsonSerializerOptions(JsonSerializerDefaults.Web)
+            {
+                Converters = { new System.Text.Json.Serialization.JsonStringEnumConverter() }
+            });
+
+        Assert.NotNull(snap);
+        Assert.NotNull(snap!.GroupByFields);
+        Assert.Contains("Name", snap.GroupByFields!);
+    }
+
+    [Fact]
+    public async Task ApplyLayoutJsonAsync_Restores_Multi_Level_GroupByFields()
+    {
+        // Grid A: pre-seeded with two grouping levels, in order.
+        var cutA = _ctx.Render<DataGrid<Row>>(p => p
+            .Add(g => g.Items, Data())
+            .Add(g => g.Columns, Cols())
+            .Add(g => g.ShowGroupPanel, true)
+            .Add(g => g.GroupByFields, new[] { "Name", "Email" }));
+
+        var exported = cutA.Instance.ExportLayout();
+
+        // Grid B: fresh, no GroupByFields parameter. Apply the JSON.
+        var cutB = _ctx.Render<DataGrid<Row>>(p => p
+            .Add(g => g.Items, Data())
+            .Add(g => g.Columns, Cols())
+            .Add(g => g.ShowGroupPanel, true));
+
+        await cutB.InvokeAsync(async () => await cutB.Instance.ApplyLayoutJsonAsync(exported));
+
+        var layout = cutB.Instance.GetCurrentLayout();
+        Assert.NotNull(layout.GroupByFields);
+        Assert.Equal(new[] { "Name", "Email" }, layout.GroupByFields!);
+
+        // Panel chips render — markup should contain both field names.
+        var panel = cutB.Find("[data-slot=\"datagrid-group-panel\"]");
+        Assert.Contains("Name", panel.TextContent);
+        Assert.Contains("Email", panel.TextContent);
+    }
+
+    [Fact]
+    public async Task ApplyLayoutJsonAsync_Backcompat_v1_GroupBy_Falls_Back_To_Single_Level()
+    {
+        // Hand-craft a v1 payload: GroupBy populated, GroupByFields null.
+        var v1Snap = new DataGridLayoutSnapshot(
+            Version: 1,
+            Columns: new List<DataGridColumnLayout>
+            {
+                new("Id", 0, true, null, PinDirection.None),
+                new("Name", 1, true, null, PinDirection.None),
+                new("Email", 2, true, null, PinDirection.None),
+            },
+            Sorts: new(),
+            Filters: new(),
+            GlobalSearch: null,
+            CurrentPage: 1,
+            PageSize: 10,
+            GroupBy: "Name",
+            GroupByFields: null);
+
+        var json = JsonSerializer.Serialize(v1Snap, new JsonSerializerOptions
+        {
+            Converters = { new System.Text.Json.Serialization.JsonStringEnumConverter() }
+        });
+
+        var cut = _ctx.Render<DataGrid<Row>>(p => p
+            .Add(g => g.Items, Data())
+            .Add(g => g.Columns, Cols())
+            .Add(g => g.ShowGroupPanel, true));
+
+        await cut.InvokeAsync(async () => await cut.Instance.ApplyLayoutJsonAsync(json));
+
+        var layout = cut.Instance.GetCurrentLayout();
+        Assert.NotNull(layout.GroupByFields);
+        Assert.Equal(new[] { "Name" }, layout.GroupByFields!);
+    }
+
+    [Fact]
+    public void SnapshotCurrentLayout_Captures_Runtime_GroupFields_From_Panel()
+    {
+        var cut = _ctx.Render<DataGrid<Row>>(p => p
+            .Add(g => g.Items, Data())
+            .Add(g => g.Columns, Cols())
+            .Add(g => g.ShowGroupPanel, true));
+
+        // Drive the group panel <select> to add "Name" as a grouping level.
+        var select = cut.Find("[data-slot=\"datagrid-group-panel\"] select");
+        select.Change("Name");
+
+        var layout = cut.Instance.GetCurrentLayout();
+        Assert.NotNull(layout.GroupByFields);
+        Assert.Contains("Name", layout.GroupByFields!);
     }
 
     [Fact]

--- a/tests/Lumeo.Tests/Components/Overlay/OverlayProviderTests.cs
+++ b/tests/Lumeo.Tests/Components/Overlay/OverlayProviderTests.cs
@@ -1,4 +1,6 @@
 using Bunit;
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Rendering;
 using Xunit;
 using Lumeo.Services;
 using Lumeo.Tests.Helpers;
@@ -50,5 +52,58 @@ public class OverlayProviderTests : IAsyncLifetime
 
         Assert.Contains("Confirm Delete", cut.Markup);
         Assert.Contains("Confirm Archive", cut.Markup);
+    }
+
+    // --- Mobile-fullscreen bottom sheet via OverlayService (2.1.1) ---
+    //
+    // OverlayOptions gained SwipeToClose so Sheets opened programmatically
+    // can mirror the declarative <SheetContent SwipeToClose="true"> path.
+    // Combined with SheetSize.Full on Side=Bottom the consumer gets a true
+    // mobile-fullscreen bottom sheet with swipe-down dismiss — without
+    // hand-rolling CSS selectors.
+
+    private sealed class DummyOverlayBody : ComponentBase
+    {
+        protected override void BuildRenderTree(RenderTreeBuilder builder)
+        {
+            builder.AddContent(0, "BODY");
+        }
+    }
+
+    [Fact]
+    public void ShowSheet_Routes_SwipeToClose_Option_Through_To_SheetContent()
+    {
+        var service = _ctx.Services.GetRequiredService<OverlayService>();
+        var cut = _ctx.Render<Lumeo.OverlayProvider>();
+
+        _ = service.ShowSheetAsync<DummyOverlayBody>(
+            title: "Mobile sheet",
+            side: SheetSide.Bottom,
+            size: SheetSize.Full,
+            options: new OverlayOptions { SwipeToClose = true });
+
+        cut.WaitForState(() => cut.Markup.Contains("BODY"));
+
+        var dialog = cut.Find("[role='dialog']");
+        var cls = dialog.GetAttribute("class") ?? "";
+
+        // Side=Bottom + Size=Full now emits the fullscreen anchor + height,
+        // and SwipeToClose=true means the JS swipe listener will be attached
+        // on OnAfterRender. The class assertion proves the size/side option
+        // round-trip; the SwipeToClose hook can only be observed via JS
+        // interop, which bUnit does not exercise.
+        Assert.Contains("bottom-0", cls);
+        Assert.Contains("h-full", cls);
+        Assert.Contains("max-h-full", cls);
+    }
+
+    [Fact]
+    public void ShowSheet_Default_SwipeToClose_Is_False()
+    {
+        // Back-compat: existing OverlayService consumers that don't set
+        // SwipeToClose must continue to get the legacy non-dismissable-by-swipe
+        // behaviour. We assert the option default here as a regression guard.
+        var options = new OverlayOptions();
+        Assert.False(options.SwipeToClose);
     }
 }

--- a/tests/Lumeo.Tests/Components/Sheet/SheetTests.cs
+++ b/tests/Lumeo.Tests/Components/Sheet/SheetTests.cs
@@ -390,4 +390,84 @@ public class SheetTests : IAsyncLifetime
         var backdropCount = System.Text.RegularExpressions.Regex.Matches(markup, "bg-black\\\\?\\/80").Count;
         Assert.Equal(1, backdropCount);
     }
+
+    // --- Size=Full on Top/Bottom emits fullscreen height classes (2.1.1) ---
+    //
+    // Previously SheetSize.Full only applied to Left/Right (sm:max-w-full).
+    // For Top/Bottom it was a silent no-op, so the mobile-fullscreen
+    // bottom-sheet pattern required a manual Class override. Now Full
+    // emits inset-y-0 + h-full + max-h-full alongside the existing
+    // bottom-0 / top-0 anchor so the sheet covers the entire viewport.
+
+    private IRenderedComponent<IComponent> RenderSheetWithSize(
+        L.SheetContent.SheetSide side,
+        L.SheetContent.SheetSize size)
+    {
+        return _ctx.Render(builder =>
+        {
+            builder.OpenComponent<L.Sheet>(0);
+            builder.AddAttribute(1, "IsOpen", true);
+            builder.AddAttribute(2, "ChildContent", (RenderFragment)(b =>
+            {
+                b.OpenComponent<L.SheetContent>(0);
+                b.AddAttribute(1, "Side", side);
+                b.AddAttribute(2, "Size", size);
+                b.AddAttribute(3, "ChildContent", (RenderFragment)(inner =>
+                {
+                    inner.AddContent(0, "Body");
+                }));
+                b.CloseComponent();
+            }));
+            builder.CloseComponent();
+        });
+    }
+
+    [Fact]
+    public void SheetContent_Bottom_Size_Full_Emits_FullScreen_Height_Classes()
+    {
+        var cut = RenderSheetWithSize(L.SheetContent.SheetSide.Bottom, L.SheetContent.SheetSize.Full);
+        var dialog = cut.Find("[role='dialog']");
+        var cls = dialog.GetAttribute("class") ?? "";
+
+        Assert.Contains("bottom-0", cls);
+        Assert.Contains("h-full", cls);
+        Assert.Contains("max-h-full", cls);
+    }
+
+    [Fact]
+    public void SheetContent_Top_Size_Full_Emits_FullScreen_Height_Classes()
+    {
+        var cut = RenderSheetWithSize(L.SheetContent.SheetSide.Top, L.SheetContent.SheetSize.Full);
+        var dialog = cut.Find("[role='dialog']");
+        var cls = dialog.GetAttribute("class") ?? "";
+
+        Assert.Contains("top-0", cls);
+        Assert.Contains("h-full", cls);
+        Assert.Contains("max-h-full", cls);
+    }
+
+    [Fact]
+    public void SheetContent_Bottom_Size_Default_Does_Not_Force_Height()
+    {
+        // Default size on Top/Bottom must remain content-height (legacy
+        // behaviour). Only Full / Sm / Lg / Xl introduce height caps.
+        var cut = RenderSheetWithSize(L.SheetContent.SheetSide.Bottom, L.SheetContent.SheetSize.Default);
+        var dialog = cut.Find("[role='dialog']");
+        var cls = dialog.GetAttribute("class") ?? "";
+
+        Assert.DoesNotContain("h-full", cls);
+        Assert.DoesNotContain("max-h-", cls);
+    }
+
+    [Fact]
+    public void SheetContent_Right_Size_Full_Still_Uses_Width_Class()
+    {
+        // Back-compat: Full on Left/Right must keep sm:max-w-full
+        // and must NOT pick up the Top/Bottom inset-y-0/h-full branch.
+        var cut = RenderSheetWithSize(L.SheetContent.SheetSide.Right, L.SheetContent.SheetSize.Full);
+        var dialog = cut.Find("[role='dialog']");
+        var cls = dialog.GetAttribute("class") ?? "";
+
+        Assert.Contains("sm:max-w-full", cls);
+    }
 }

--- a/tools/lumeo-mcp/package-lock.json
+++ b/tools/lumeo-mcp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lumeo-ui/mcp-server",
-  "version": "2.0.0",
+  "version": "2.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@lumeo-ui/mcp-server",
-      "version": "2.0.0",
+      "version": "2.1.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0"

--- a/tools/lumeo-mcp/package.json
+++ b/tools/lumeo-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lumeo-ui/mcp-server",
-  "version": "2.0.1",
+  "version": "2.1.1",
   "description": "Model Context Protocol server for the Lumeo Blazor component library. Lets LLMs (Claude, Copilot, Cursor) author correct Lumeo markup.",
   "type": "module",
   "main": "dist/index.js",

--- a/tools/lumeo-mcp/src/index.ts
+++ b/tools/lumeo-mcp/src/index.ts
@@ -364,7 +364,7 @@ function validateMarkup(markup: string): { ok: boolean; issues: ValidationIssue[
 const server = new Server(
   {
     name: "lumeo-mcp",
-    version: "2.0.1",
+    version: "2.1.1",
   },
   {
     capabilities: {

--- a/tools/lumeo-mcp/src/registry.json
+++ b/tools/lumeo-mcp/src/registry.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://lumeo.nativ.sh/registry-schema.json",
-  "version": "2.1.0",
-  "generated": "2026-05-19T14:33:48.2437097Z",
+  "version": "2.1.1",
+  "generated": "2026-05-20T09:38:00.0000000Z",
   "components": {
     "accordion": {
       "name": "Accordion",


### PR DESCRIPTION
## Summary

Four real library fixes bundled into 2.1.1 (Directory.Build.props bumped 2.1.0 → 2.1.1, snapshot version 1 → 2).

- **DataGrid layout snapshots now persist the group panel.** `_runtimeGroupFields` (the chip-strip) was silently dropped on reload while sorts/filters/columns survived. Both the internal `DataGridLayout` (localStorage) and the public `DataGridLayoutSnapshot` (`ExportLayout()` / `ApplyLayoutJsonAsync()`) gain `GroupByFields`. v1 payloads still load via the legacy single-level `GroupBy` fallback.
- **DataGrid column filter popover clips its hover backgrounds.** `DataGridColumnFilter`'s root div had `rounded-lg` but no `overflow-hidden`, so a custom `<FilterTemplate>` with `hover:bg-accent` rows painted past the rounded corners. `w-64` → `min-w-64` so wider custom templates grow the popover instead of overflowing.
- **Sheet `Size=Full` now produces a true mobile-fullscreen sheet on Top/Bottom.** Previously the size class only applied to Left/Right; on Bottom the sheet stayed content-height. Now `Full` emits `inset-y-0 h-full max-h-full`; Sm/Lg/Xl cap height at 40/70/85vh; Default keeps legacy content-height.
- **OverlayService can swipe-dismiss sheets.** `OverlayOptions.SwipeToClose` (default false, back-compat) is piped through `OverlayProvider` to the rendered `<SheetContent>`. Mobile bottom-sheet pattern via the service is now first-class:
  ```csharp
  await Overlay.ShowSheetAsync<MyForm>(
      side: SheetSide.Bottom,
      size: SheetSize.Full,
      options: new OverlayOptions { SwipeToClose = true });
  ```

Plus one governance note: CLAUDE.md Rule #2 clarified — Claude may create annotated tags for real lib changes, GitHub release / NuGet publish still requires owner confirmation.

12 new bUnit tests across DataGrid layout/snapshot, filter popover clipping, Sheet sizing, and OverlayService option routing. Docs updated on the DataGrid, Sheet and OverlayService pages.

## Test plan
- [ ] CI green (build + tests + Directory.Build.props version sanity)
- [ ] Manual: reload a DataGrid with multi-level grouping active → chips return
- [ ] Manual: open a column filter with a custom `<FilterTemplate>` and hover a row → background stays inside rounded corners
- [ ] Manual: `Overlay.ShowSheetAsync<X>(side: Bottom, size: Full, options: new(){ SwipeToClose = true })` → fullscreen bottom sheet with swipe-down dismiss
- [ ] After merge: tag `v2.1.1` pushed → publish.yml runs → NuGet packages live

https://claude.ai/code/session_01Rvm2C6y39FWuopi49ptzt9

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rvm2C6y39FWuopi49ptzt9)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes v2.1.1

* **New Features**
  * Multi-level grouping state now persists in DataGrid layouts with backwards compatibility for single-level grouping.
  * Added `SwipeToClose` option to overlay sheets for swipe-to-dismiss functionality.
  * Sheet positioning on top/bottom now correctly applies full-height sizing.

* **Documentation**
  * Updated DataGrid layout persistence documentation to reflect multi-level grouping support.
  * Enhanced overlay and sheet API reference documentation.

* **Style**
  * DataGridColumnFilter now uses flexible minimum width for improved layout flexibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Brain2k-0005/Lumeo/pull/18?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->