### PR TITLE
2.1.2: DataGrid filter popover uses position:fixed (no more phantom h-scrollbar)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
   <!-- Lockstep version shared by all Lumeo packages.
        Update this single property to version all packages in unison. -->
   <PropertyGroup>
-    <Version>2.1.1</Version>
+    <Version>2.1.2</Version>
   </PropertyGroup>
 
   <!-- Shared NuGet README packing lives in Directory.Build.targets, NOT here.

--- a/docs/Lumeo.Docs/Pages/Components/CodePage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/CodePage.razor
@@ -22,7 +22,7 @@
     </ComponentDemo>
 
     <ComponentDemo Title="Block" Code="@_blockCode">
-        <Code Variant="block">dotnet add package Lumeo --version 2.1.1</Code>
+        <Code Variant="block">dotnet add package Lumeo --version 2.1.2</Code>
     </ComponentDemo>
 
     <ComponentDemo Title="Custom Size" Code="@_sizeCode">
@@ -121,7 +121,7 @@
     Pass <Code>Variant=""block""</Code> for multi-line blocks.
 </p>";
 
-    private string _blockCode = @"<Code Variant=""block"">dotnet add package Lumeo --version 2.1.1</Code>";
+    private string _blockCode = @"<Code Variant=""block"">dotnet add package Lumeo --version 2.1.2</Code>";
 
     private string _sizeCode = @"<Code Size=""xs"">text-xs code</Code>
 <Code Size=""base"">text-base code</Code>

--- a/docs/Lumeo.Docs/Pages/Docs/Changelog.razor
+++ b/docs/Lumeo.Docs/Pages/Docs/Changelog.razor
@@ -15,6 +15,34 @@
 
     <Separator Class="my-4" />
 
+    <!-- v2.1.2 -->
+    <Stack Gap="4">
+        <div class="flex items-center gap-3">
+            <Badge>v2.1.2</Badge>
+            <Lumeo.Text Size="sm" Color="muted">May 2026</Lumeo.Text>
+        </div>
+
+        <Lumeo.Text Size="base" Color="muted" Leading="relaxed">
+            <strong>DataGrid column filter popover no longer spawns a phantom horizontal scrollbar.</strong>
+            On the rightmost columns of a grid with <code class="rounded bg-muted px-1.5 py-0.5 text-xs font-mono text-foreground">overflow-x:auto</code>, opening a column filter made the entire grid scroll horizontally. The popover wrapper was <code class="rounded bg-muted px-1.5 py-0.5 text-xs font-mono text-foreground">position:absolute</code> relative to its <code class="rounded bg-muted px-1.5 py-0.5 text-xs font-mono text-foreground">&lt;th&gt;</code>, so its content extended past the cell edge and was counted in the scroll-container's <code class="rounded bg-muted px-1.5 py-0.5 text-xs font-mono text-foreground">scrollWidth</code>. Fixed by reusing the Floating-UI-style positioner that <code class="rounded bg-muted px-1.5 py-0.5 text-xs font-mono text-foreground">PopoverContent</code> already uses — <code class="rounded bg-muted px-1.5 py-0.5 text-xs font-mono text-foreground">position:fixed</code> with coords from the trigger's <code class="rounded bg-muted px-1.5 py-0.5 text-xs font-mono text-foreground">getBoundingClientRect()</code>, follow on scroll/resize, and viewport-flip when overflow would push the popover off-screen.
+        </Lumeo.Text>
+
+        <Stack Gap="3">
+            <Heading Level="3" Size="sm" Class="font-semibold">Fixed</Heading>
+            <ul class="space-y-1.5 text-sm list-disc list-inside text-muted-foreground">
+                <li><strong>DataGrid column filter popover</strong> now renders with <code class="rounded bg-muted px-1.5 py-0.5 text-xs font-mono text-foreground">position:fixed</code> instead of <code class="rounded bg-muted px-1.5 py-0.5 text-xs font-mono text-foreground">position:absolute</code>. The popover is pinned to the trigger via <code class="rounded bg-muted px-1.5 py-0.5 text-xs font-mono text-foreground">Interop.PositionFixed</code> (same path as <code class="rounded bg-muted px-1.5 py-0.5 text-xs font-mono text-foreground">PopoverContent</code>), so its layout box no longer contributes to the scroll container's <code class="rounded bg-muted px-1.5 py-0.5 text-xs font-mono text-foreground">scrollWidth</code>.</li>
+            </ul>
+
+            <Heading Level="3" Size="sm" Class="font-semibold mt-2">Improved</Heading>
+            <ul class="space-y-1.5 text-sm list-disc list-inside text-muted-foreground">
+                <li><strong>Filter popover click-outside dismiss</strong> — previously the popover only closed via Apply / Clear; clicking elsewhere left it open. Now registers a click-outside listener (excluding the trigger so the toggle button doesn't immediately close-then-reopen) and follows the trigger on grid scroll/resize.</li>
+            </ul>
+        </Stack>
+        <Lumeo.Text Size="sm" Color="muted">2 new bUnit regression tests guard the inline <code class="rounded bg-muted px-1.5 py-0.5 text-xs font-mono text-foreground">position:fixed</code> + stable trigger-id contract that the JS positioner depends on.</Lumeo.Text>
+    </Stack>
+
+    <Separator Class="my-4" />
+
     <!-- v2.1.1 -->
     <Stack Gap="4">
         <div class="flex items-center gap-3">

--- a/docs/Lumeo.Docs/Pages/Docs/Cli.razor
+++ b/docs/Lumeo.Docs/Pages/Docs/Cli.razor
@@ -36,7 +36,7 @@
                 Install as a global <code class="rounded bg-muted px-1.5 py-0.5 text-xs font-mono text-foreground">dotnet</code> tool:
             </Lumeo.Text>
             <Stack Class="code-block rounded-lg border border-border/40 bg-muted px-4 py-3 font-mono text-sm text-foreground">
-                dotnet tool install -g Lumeo.Cli --version 2.1.1
+                dotnet tool install -g Lumeo.Cli --version 2.1.2
             </Stack>
             <Lumeo.Text Size="sm" Color="muted" Leading="relaxed">
                 The tool exposes a single command, <code class="rounded bg-muted px-1.5 py-0.5 text-xs font-mono text-foreground">lumeo</code>.

--- a/docs/Lumeo.Docs/Pages/Home.razor
+++ b/docs/Lumeo.Docs/Pages/Home.razor
@@ -14,7 +14,7 @@
                 <Lumeo.Link Href="docs/changelog" Class="no-underline group">
                     <Flex Inline="true" Align="center" Gap="2" Class="rounded-full border border-border/60 bg-background/80 px-3 py-1 text-xs font-medium text-muted-foreground backdrop-blur-sm hover:border-primary/40 hover:text-foreground transition-colors">
                         <Badge Variant="Badge.BadgeVariant.Default" Class="h-4 px-1.5 text-[10px] leading-none">New</Badge>
-                        <Lumeo.Text As="span">v2.1.1 — DataGrid group panel survives reload · Sheet mobile-fullscreen · OverlayService SwipeToClose</Lumeo.Text>
+                        <Lumeo.Text As="span">v2.1.2 — DataGrid filter popover no longer spawns phantom horizontal scrollbars</Lumeo.Text>
                         <DynamicIcon Name="ArrowRight" Class="h-3 w-3 transition-transform group-hover:translate-x-0.5" />
                     </Flex>
                 </Lumeo.Link>

--- a/src/Lumeo.DataGrid/UI/DataGrid/DataGridHeaderCell.razor
+++ b/src/Lumeo.DataGrid/UI/DataGrid/DataGridHeaderCell.razor
@@ -54,6 +54,7 @@
         @if (Column.Filterable)
         {
             <button type="button"
+                    id="@_filterTriggerId"
                     class="inline-flex items-center justify-center h-5 w-5 rounded hover:bg-muted/60 @(HasActiveFilter ? "text-primary" : "text-muted-foreground opacity-0 group-hover/th:opacity-100")"
                     @onclick="ToggleFilter"
                     @onclick:stopPropagation="true">
@@ -64,7 +65,15 @@
 
     @if (IsFilterOpen && Column.Filterable)
     {
-        <div class="absolute top-full left-0 z-50 mt-1">
+        @* Rendered with position:fixed and pinned to the trigger via
+           Interop.PositionFixed (JS reads the trigger's getBoundingClientRect
+           on open + on scroll/resize). Was previously position:absolute relative
+           to the <th> which extended the grid's overflow:auto scrollWidth on the
+           rightmost columns and made a phantom horizontal scrollbar appear when
+           opening the filter. Floating-UI-style positioning sidesteps that
+           entirely: the popover lives in the same DOM subtree but its layout
+           box doesn't touch the scroll container. *@
+        <div id="@_filterContentId" style="position: fixed; z-index: 50;">
             <DataGridColumnFilter TItem="TItem"
                                   Column="Column"
                                   FilterOptions="Column.FilterOptions"
@@ -156,6 +165,15 @@
     private bool _isDragOver;
     private string? _dropSide; // "left" or "right" — where the drop indicator is rendered
 
+    // Filter popover positioning (2.1.2): the filter content is rendered with
+    // position:fixed and pinned to the trigger via JS-computed coords from
+    // getBoundingClientRect, matching the pattern in PopoverContent. Stable IDs
+    // are needed so the JS positioner can find both elements and so click-outside
+    // can exclude the trigger from its dismiss target list.
+    private readonly string _filterTriggerId = $"dg-filter-trigger-{Guid.NewGuid():N}";
+    private readonly string _filterContentId = $"dg-filter-content-{Guid.NewGuid():N}";
+    private bool _filterPositionRegistered;
+
     /// <summary>
     /// Drag-reorder is only active when both the grid-level <c>Reorderable</c>
     /// flag and the per-column <c>Reorderable</c> flag are true.
@@ -229,6 +247,42 @@
     private async Task ToggleFilter()
     {
         await OnFilterToggle.InvokeAsync();
+    }
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (!Column.Filterable) return;
+
+        if (IsFilterOpen && !_filterPositionRegistered)
+        {
+            // Pin the filter content (position:fixed) to the trigger button's
+            // viewport rect. The "start" align + "bottom" side mirror the
+            // previous absolute top-full left-0 layout. JS handles flip if the
+            // popover would overflow the viewport (e.g. last row on a tall
+            // grid) and follows the trigger on scroll/resize.
+            await Interop.PositionFixed(_filterContentId, _filterTriggerId, align: "start", matchWidth: false, side: "bottom");
+            // Click-outside dismiss — explicitly exclude the trigger so the
+            // toggle button doesn't immediately close-then-reopen on click.
+            // Closing routes through OnFilterToggle (the same callback the
+            // button uses) so parent state stays consistent.
+            await Interop.RegisterClickOutside(_filterContentId, _filterTriggerId, async () =>
+            {
+                await OnFilterToggle.InvokeAsync();
+                await InvokeAsync(StateHasChanged);
+            });
+            _filterPositionRegistered = true;
+        }
+        else if (!IsFilterOpen && _filterPositionRegistered)
+        {
+            await CleanupFilterPosition();
+        }
+    }
+
+    private async Task CleanupFilterPosition()
+    {
+        try { await Interop.UnpositionFixed(_filterContentId); } catch (JSDisconnectedException) { }
+        try { await Interop.UnregisterClickOutside(_filterContentId); } catch (JSDisconnectedException) { }
+        _filterPositionRegistered = false;
     }
 
     private async Task HandleFilterApply(FilterDescriptor? descriptor)
@@ -342,6 +396,10 @@
                 await Interop.UnregisterColumnResize(_resizeHandleId);
             }
             catch (JSDisconnectedException) { }
+        }
+        if (_filterPositionRegistered)
+        {
+            await CleanupFilterPosition();
         }
     }
 }

--- a/tests/Lumeo.Tests/Components/DataGrid/DataGridFilterExtensibilityTests.cs
+++ b/tests/Lumeo.Tests/Components/DataGrid/DataGridFilterExtensibilityTests.cs
@@ -274,4 +274,79 @@ public class DataGridFilterExtensibilityTests : IAsyncLifetime
         Assert.Contains("overflow-hidden", cls);
         Assert.Contains("rounded-lg", cls);
     }
+
+    // ---------------------------------------------------------------------------
+    // Filter popover positioning: must NOT contribute to grid scroll-width (2.1.2)
+    //
+    // Bug: the filter popover wrapper was <div class="absolute top-full left-0">
+    // anchored to its <th> (which is position:relative). On the rightmost column,
+    // the popover's content extended past the th's right edge → the overflow:auto
+    // scroll container interpreted the absolute descendant's overflow as
+    // scrollWidth → a phantom horizontal scrollbar appeared every time the user
+    // opened a filter on the right side of the grid.
+    //
+    // Fix: render the popover with position:fixed (inline style) and pin to the
+    // trigger via JS-computed getBoundingClientRect coords (Interop.PositionFixed,
+    // same mechanism PopoverContent uses). The fixed-positioned descendant does
+    // not contribute to its ancestor's scrollWidth, so the bug can't recur.
+    // ---------------------------------------------------------------------------
+
+    [Fact]
+    public void Filter_Popover_Uses_Fixed_Positioning_Not_Absolute()
+    {
+        var cut = _ctx.Render<DataGrid<TestItem>>(p => p
+            .Add(x => x.Items, Data())
+            .AddChildContent<DataGridColumnDef<TestItem>>(c => c
+                .Add(x => x.Field, "Name")
+                .Add(x => x.Filterable, true)));
+
+        // Click the filter trigger button on the only data column to open the popover.
+        var filterBtn = cut.Find("th[data-slot='datagrid-header-cell'] button:has(svg)");
+        // The first matching button is the sort toggle; the filter button comes after
+        // when Filterable=true. We want the one that is NOT the sort button — the
+        // sort toggle disables itself when Sortable is false but is still present
+        // here (Sortable defaults to false on this column). Find the filter button
+        // by its visible-on-hover icon class signature.
+        var filterTriggers = cut.FindAll("th[data-slot='datagrid-header-cell'] button");
+        var trigger = filterTriggers.FirstOrDefault(b =>
+            (b.GetAttribute("class") ?? "").Contains("hover:bg-muted/60"));
+        Assert.NotNull(trigger);
+        trigger!.Click();
+
+        // The popover container must now exist with inline position:fixed.
+        // Querying by id is brittle (GUID), so we sweep all descendants and
+        // assert the inline style contains "position: fixed".
+        var fixedDivs = cut.FindAll("div").Where(d =>
+            (d.GetAttribute("style") ?? "").Contains("position: fixed")
+            && d.QuerySelector("[data-slot='datagrid-filter-custom']") is null
+            && d.QuerySelector("input, button, label") is not null).ToList();
+
+        Assert.NotEmpty(fixedDivs);
+
+        // Hard regression guard: the old "absolute top-full left-0" wrapper
+        // must NOT be present on any element containing the filter content.
+        var absWrappers = cut.FindAll("div.absolute.top-full.left-0").ToList();
+        Assert.Empty(absWrappers);
+    }
+
+    [Fact]
+    public void Filter_Trigger_Button_Has_Stable_Id_For_Positioning_Anchor()
+    {
+        // The JS positioner reads the trigger via document.getElementById, so
+        // the trigger button MUST carry a stable id whenever the column is
+        // Filterable — irrespective of whether the popover is currently open.
+        var cut = _ctx.Render<DataGrid<TestItem>>(p => p
+            .Add(x => x.Items, Data())
+            .AddChildContent<DataGridColumnDef<TestItem>>(c => c
+                .Add(x => x.Field, "Name")
+                .Add(x => x.Filterable, true)));
+
+        var triggers = cut.FindAll("th[data-slot='datagrid-header-cell'] button");
+        var filterTrigger = triggers.FirstOrDefault(b =>
+            (b.GetAttribute("class") ?? "").Contains("hover:bg-muted/60"));
+        Assert.NotNull(filterTrigger);
+        var id = filterTrigger!.GetAttribute("id");
+        Assert.False(string.IsNullOrWhiteSpace(id), "filter trigger must have an id");
+        Assert.StartsWith("dg-filter-trigger-", id);
+    }
 }

--- a/tools/lumeo-mcp/package-lock.json
+++ b/tools/lumeo-mcp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lumeo-ui/mcp-server",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@lumeo-ui/mcp-server",
-      "version": "2.1.1",
+      "version": "2.1.2",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0"
@@ -465,7 +465,7 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/finalhandler": {
-      "version": "2.1.1",
+      "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
       "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
       "license": "MIT",

--- a/tools/lumeo-mcp/package.json
+++ b/tools/lumeo-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lumeo-ui/mcp-server",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "Model Context Protocol server for the Lumeo Blazor component library. Lets LLMs (Claude, Copilot, Cursor) author correct Lumeo markup.",
   "type": "module",
   "main": "dist/index.js",

--- a/tools/lumeo-mcp/src/index.ts
+++ b/tools/lumeo-mcp/src/index.ts
@@ -364,7 +364,7 @@ function validateMarkup(markup: string): { ok: boolean; issues: ValidationIssue[
 const server = new Server(
   {
     name: "lumeo-mcp",
-    version: "2.1.1",
+    version: "2.1.2",
   },
   {
     capabilities: {

--- a/tools/lumeo-mcp/src/registry.json
+++ b/tools/lumeo-mcp/src/registry.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://lumeo.nativ.sh/registry-schema.json",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "generated": "2026-05-20T09:38:00.0000000Z",
   "components": {
     "accordion": {


### PR DESCRIPTION
## Summary

Fixes the bug reported by a DataGrid user: opening a column filter on the rightmost columns of a `overflow-x:auto` grid spawned a phantom horizontal scrollbar (the popover's content extended past the `<th>` and got counted in the container's `scrollWidth`).

Root cause: `DataGridHeaderCell.razor:67` rendered the filter content as `<div class="absolute top-full left-0 z-50 mt-1">` anchored to the `<th>`. `position:absolute` descendants contribute to their containing block's scrollWidth.

Fix: route the filter popover through the same `position:fixed` + `Interop.PositionFixed` path that `PopoverContent.razor` already uses (Floating-UI-style coords from the trigger's `getBoundingClientRect`, follow on scroll/resize, viewport-flip). Fixed descendants do NOT contribute to ancestor scrollWidth, so the bug can't recur structurally.

Side benefit: filter now dismisses on click-outside (previously only Apply / Clear closed it). The trigger button is excluded from the click-outside target list so the toggle doesn't immediately close-then-reopen.

Plus lockstep bump (Directory.Build.props 2.1.1 → 2.1.2, lumeo-mcp, hero badge, changelog, install snippets).

## Test plan
- [ ] CI green (build-and-test, e2e, bom-check)
- [ ] 2 new bUnit regression tests pass (`Filter_Popover_Uses_Fixed_Positioning_Not_Absolute`, `Filter_Trigger_Button_Has_Stable_Id_For_Positioning_Anchor`)
- [ ] Manual: render a grid with `overflow-x:auto` parent, mark a right-side column `Filterable=true`, open the filter → no horizontal scrollbar appears
- [ ] Manual: scroll the grid while filter is open → popover follows the trigger
- [ ] Manual: click outside the popover → it closes
- [ ] After merge: tag `v2.1.2`, publish to NuGet + npm, create GitHub release

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rvm2C6y39FWuopi49ptzt9)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed DataGrid column filter popover positioning to prevent horizontal scrollbar artifacts.

* **Documentation**
  * Updated package version references and installation instructions to v2.1.2.
  * Added changelog entry documenting filter popover improvements.

* **Tests**
  * Added regression tests for DataGrid filter popover positioning behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Brain2k-0005/Lumeo/pull/19?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->