### PR TITLE
2.1.4: cache-bust _content/Lumeo*/ JS module URLs by assembly version

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
   <!-- Lockstep version shared by all Lumeo packages.
        Update this single property to version all packages in unison. -->
   <PropertyGroup>
-    <Version>2.1.3</Version>
+    <Version>2.1.4</Version>
   </PropertyGroup>
 
   <!-- Shared NuGet README packing lives in Directory.Build.targets, NOT here.

--- a/docs/Lumeo.Docs/Pages/Components/CodePage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/CodePage.razor
@@ -22,7 +22,7 @@
     </ComponentDemo>
 
     <ComponentDemo Title="Block" Code="@_blockCode">
-        <Code Variant="block">dotnet add package Lumeo --version 2.1.3</Code>
+        <Code Variant="block">dotnet add package Lumeo --version 2.1.4</Code>
     </ComponentDemo>
 
     <ComponentDemo Title="Custom Size" Code="@_sizeCode">
@@ -121,7 +121,7 @@
     Pass <Code>Variant=""block""</Code> for multi-line blocks.
 </p>";
 
-    private string _blockCode = @"<Code Variant=""block"">dotnet add package Lumeo --version 2.1.3</Code>";
+    private string _blockCode = @"<Code Variant=""block"">dotnet add package Lumeo --version 2.1.4</Code>";
 
     private string _sizeCode = @"<Code Size=""xs"">text-xs code</Code>
 <Code Size=""base"">text-base code</Code>

--- a/docs/Lumeo.Docs/Pages/Docs/Changelog.razor
+++ b/docs/Lumeo.Docs/Pages/Docs/Changelog.razor
@@ -15,6 +15,35 @@
 
     <Separator Class="my-4" />
 
+    <!-- v2.1.4 -->
+    <Stack Gap="4">
+        <div class="flex items-center gap-3">
+            <Badge>v2.1.4</Badge>
+            <Lumeo.Text Size="sm" Color="muted">May 2026</Lumeo.Text>
+        </div>
+
+        <Lumeo.Text Size="base" Color="muted" Leading="relaxed">
+            <strong>JS module import URL gets a <code class="rounded bg-muted px-1.5 py-0.5 text-xs font-mono text-foreground">?v=&lt;version&gt;</code> cache-buster.</strong>
+            Library JS under <code class="rounded bg-muted px-1.5 py-0.5 text-xs font-mono text-foreground">_content/Lumeo/js/components.js</code> is served WITHOUT a content-hash (unlike the Blazor framework files), so an already-loaded browser tab kept its 2.1.2 <code class="rounded bg-muted px-1.5 py-0.5 text-xs font-mono text-foreground">components.js</code> after upgrading the lib to 2.1.3 — and new C# code calling new exports like <code class="rounded bg-muted px-1.5 py-0.5 text-xs font-mono text-foreground">registerViewportListener</code> threw <code class="rounded bg-muted px-1.5 py-0.5 text-xs font-mono text-foreground">JSException: 'registerViewportListener' is not a function</code> at runtime. Fixed by appending <code class="rounded bg-muted px-1.5 py-0.5 text-xs font-mono text-foreground">?v=&lt;assembly-version&gt;</code> to library module imports.
+        </Lumeo.Text>
+
+        <Stack Gap="3">
+            <Heading Level="3" Size="sm" Class="font-semibold">Fixed</Heading>
+            <ul class="space-y-1.5 text-sm list-disc list-inside text-muted-foreground">
+                <li><strong><code class="rounded bg-muted px-1.5 py-0.5 text-xs font-mono text-foreground">ComponentInteropService.GetModuleAsync</code></strong> + <strong><code class="rounded bg-muted px-1.5 py-0.5 text-xs font-mono text-foreground">ImportModuleAsync</code></strong> now append <code class="rounded bg-muted px-1.5 py-0.5 text-xs font-mono text-foreground">?v={assembly-version}</code> to all <code class="rounded bg-muted px-1.5 py-0.5 text-xs font-mono text-foreground">_content/Lumeo*/</code> module URLs. <code class="rounded bg-muted px-1.5 py-0.5 text-xs font-mono text-foreground">KeyboardShortcutService.GetModuleAsync</code> updated symmetrically.</li>
+                <li><strong>Upgrades from this release forward</strong> are immune to the stale-cache class of failure when new JS exports are added in the lib (e.g. the v2.1.3 <code class="rounded bg-muted px-1.5 py-0.5 text-xs font-mono text-foreground">registerViewportListener</code> failure). v2.1.3 users hitting that error today need a hard refresh (<code class="rounded bg-muted px-1.5 py-0.5 text-xs font-mono text-foreground">Ctrl/Cmd+Shift+R</code>); from v2.1.4 the cache-buster handles it automatically.</li>
+            </ul>
+            <Heading Level="3" Size="sm" Class="font-semibold mt-2">Notes</Heading>
+            <ul class="space-y-1.5 text-sm list-disc list-inside text-muted-foreground">
+                <li>Version derived once from <code class="rounded bg-muted px-1.5 py-0.5 text-xs font-mono text-foreground">AssemblyInformationalVersionAttribute</code> (which <code class="rounded bg-muted px-1.5 py-0.5 text-xs font-mono text-foreground">Directory.Build.props &lt;Version&gt;</code> drives), so it tracks every release without manual maintenance.</li>
+                <li>URLs that already contain a query string pass through untouched — consumer overrides (e.g. local debugging with <code class="rounded bg-muted px-1.5 py-0.5 text-xs font-mono text-foreground">?nocache=1</code>) are preserved.</li>
+                <li>Non-library URLs are passed through unchanged, so consumer JS modules loaded via <code class="rounded bg-muted px-1.5 py-0.5 text-xs font-mono text-foreground">ImportModuleAsync</code> aren't affected.</li>
+            </ul>
+        </Stack>
+    </Stack>
+
+    <Separator Class="my-4" />
+
     <!-- v2.1.3 -->
     <Stack Gap="4">
         <div class="flex items-center gap-3">

--- a/docs/Lumeo.Docs/Pages/Docs/Cli.razor
+++ b/docs/Lumeo.Docs/Pages/Docs/Cli.razor
@@ -36,7 +36,7 @@
                 Install as a global <code class="rounded bg-muted px-1.5 py-0.5 text-xs font-mono text-foreground">dotnet</code> tool:
             </Lumeo.Text>
             <Stack Class="code-block rounded-lg border border-border/40 bg-muted px-4 py-3 font-mono text-sm text-foreground">
-                dotnet tool install -g Lumeo.Cli --version 2.1.3
+                dotnet tool install -g Lumeo.Cli --version 2.1.4
             </Stack>
             <Lumeo.Text Size="sm" Color="muted" Leading="relaxed">
                 The tool exposes a single command, <code class="rounded bg-muted px-1.5 py-0.5 text-xs font-mono text-foreground">lumeo</code>.

--- a/docs/Lumeo.Docs/Pages/Home.razor
+++ b/docs/Lumeo.Docs/Pages/Home.razor
@@ -14,7 +14,7 @@
                 <Lumeo.Link Href="docs/changelog" Class="no-underline group">
                     <Flex Inline="true" Align="center" Gap="2" Class="rounded-full border border-border/60 bg-background/80 px-3 py-1 text-xs font-medium text-muted-foreground backdrop-blur-sm hover:border-primary/40 hover:text-foreground transition-colors">
                         <Badge Variant="Badge.BadgeVariant.Default" Class="h-4 px-1.5 text-[10px] leading-none">New</Badge>
-                        <Lumeo.Text As="span">v2.1.3 — Responsive overlays, swipe-threshold polish, 100% docs parameter coverage</Lumeo.Text>
+                        <Lumeo.Text As="span">v2.1.4 — JS module URL gets a ?v= cache-buster so library upgrades no longer hit stale browser caches</Lumeo.Text>
                         <DynamicIcon Name="ArrowRight" Class="h-3 w-3 transition-transform group-hover:translate-x-0.5" />
                     </Flex>
                 </Lumeo.Link>

--- a/src/Lumeo/Services/ComponentInteropService.cs
+++ b/src/Lumeo/Services/ComponentInteropService.cs
@@ -29,9 +29,25 @@ public sealed class ComponentInteropService : IComponentInteropService
     private async Task<IJSObjectReference> GetModuleAsync()
     {
         _module ??= await _jsRuntime.InvokeAsync<IJSObjectReference>(
-            "import", "./_content/Lumeo/js/components.js");
+            "import", $"./_content/Lumeo/js/components.js?v={_jsModuleVersion}");
         return _module;
     }
+
+    // Cache-buster query string appended to the components.js import URL so a
+    // version bump invalidates stale browser caches automatically. Static
+    // assets under _content/<Lib>/ are served WITHOUT content-hashes (unlike
+    // the Blazor framework JS), so without this query string a user who hit
+    // an older version would get the cached file and any new exports (e.g.
+    // registerViewportListener added in 2.1.3) would resolve to "not a
+    // function" at runtime. Derived once from the assembly's
+    // AssemblyInformationalVersion (driven by Directory.Build.props
+    // <Version>), so it tracks every release without manual maintenance.
+    private static readonly string _jsModuleVersion =
+        typeof(ComponentInteropService).Assembly
+            .GetCustomAttribute<System.Reflection.AssemblyInformationalVersionAttribute>()
+            ?.InformationalVersion
+        ?? typeof(ComponentInteropService).Assembly.GetName().Version?.ToString()
+        ?? "0";
 
     // --- Motion module (Lumeo.Motion satellite) ---
     // Loaded lazily on first use; apps that don't install Lumeo.Motion never pay
@@ -849,7 +865,19 @@ public sealed class ComponentInteropService : IComponentInteropService
     // directly in the component, satisfying the "no direct IJSRuntime in components" rule.
 
     public async ValueTask<IJSObjectReference> ImportModuleAsync(string moduleUrl)
-        => await _jsRuntime.InvokeAsync<IJSObjectReference>("import", moduleUrl);
+        => await _jsRuntime.InvokeAsync<IJSObjectReference>("import", AppendVersion(moduleUrl));
+
+    // Appends ?v=<assembly-version> to library JS module URLs that live under
+    // _content/Lumeo*/ so a version bump invalidates the browser cache. See
+    // GetModuleAsync for the full rationale. URLs that already carry a query
+    // string are passed through untouched so consumers can override (e.g. for
+    // local debugging) without us clobbering their fragment.
+    private static string AppendVersion(string url)
+    {
+        if (string.IsNullOrEmpty(url) || url.Contains('?')) return url;
+        if (!url.StartsWith("./_content/Lumeo", StringComparison.Ordinal)) return url;
+        return $"{url}?v={_jsModuleVersion}";
+    }
 
     // --- Scheduler (FullCalendar wrapper) ---
     // Scheduler ships its own JS module (scheduler.js) loaded lazily on first

--- a/src/Lumeo/Services/ComponentInteropService.cs
+++ b/src/Lumeo/Services/ComponentInteropService.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using Lumeo.Services.Interop;
 using Microsoft.JSInterop;
 
@@ -44,7 +45,7 @@ public sealed class ComponentInteropService : IComponentInteropService
     // <Version>), so it tracks every release without manual maintenance.
     private static readonly string _jsModuleVersion =
         typeof(ComponentInteropService).Assembly
-            .GetCustomAttribute<System.Reflection.AssemblyInformationalVersionAttribute>()
+            .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
             ?.InformationalVersion
         ?? typeof(ComponentInteropService).Assembly.GetName().Version?.ToString()
         ?? "0";

--- a/src/Lumeo/Services/KeyboardShortcutService.cs
+++ b/src/Lumeo/Services/KeyboardShortcutService.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using Microsoft.JSInterop;
 
 namespace Lumeo.Services;
@@ -17,8 +18,16 @@ public sealed class KeyboardShortcutService : IKeyboardShortcutService
 
     private async Task<IJSObjectReference> GetModuleAsync()
     {
+        // ?v=<assembly-version> cache-buster — see ComponentInteropService.GetModuleAsync
+        // for the rationale (library JS under _content/Lumeo/ is served WITHOUT
+        // a content-hash, so old browser caches survive across releases).
+        var v = typeof(KeyboardShortcutService).Assembly
+            .GetCustomAttribute<System.Reflection.AssemblyInformationalVersionAttribute>()
+            ?.InformationalVersion
+            ?? typeof(KeyboardShortcutService).Assembly.GetName().Version?.ToString()
+            ?? "0";
         _module ??= await _jsRuntime.InvokeAsync<IJSObjectReference>(
-            "import", "./_content/Lumeo/js/components.js");
+            "import", $"./_content/Lumeo/js/components.js?v={v}");
         return _module;
     }
 

--- a/src/Lumeo/UI/Calendar/Calendar.razor
+++ b/src/Lumeo/UI/Calendar/Calendar.razor
@@ -189,6 +189,48 @@
 
     private int GetDecadeStart(int year) => year / 10 * 10;
 
+    // Wrapper-div classes that render the connecting range bar BEHIND the
+    // day button (2.1.4). Previously each in-range day's button had its own
+    // rounded-md bg-accent rectangle, producing a pearl-necklace look with
+    // visual gaps between days. The wrapper carries the bar background and
+    // edge rounding so adjacent in-range cells touch seamlessly.
+    //
+    // Returns empty string for non-Range mode or days outside the range so
+    // the wrapper has no styling and the button keeps its original look.
+    //
+    // Edge cases:
+    // - First column on a row (col == 0) gets rounded-l-md so the bar starts
+    //   with a rounded cap when the range wraps to a new row.
+    // - Last column on a row (col == 6) gets rounded-r-md likewise.
+    // - The range-start and range-end days get rounded-l-md / rounded-r-md
+    //   so the bar terminates with a soft cap behind the primary circle.
+    // - Hover during in-flight selection (RangeStart set, RangeEnd null,
+    //   _hoverDate carries the preview) extends the bar dynamically.
+    private string RangeBarClasses(DateOnly day, DateOnly monthDate, int col)
+    {
+        if (!IsRange) return "";
+
+        var effectiveEnd = RangeEnd ?? (RangeStart.HasValue && _hoverDate.HasValue ? _hoverDate : null);
+        var rangeFrom = RangeStart;
+        var rangeTo = effectiveEnd;
+        if (rangeFrom.HasValue && rangeTo.HasValue && rangeTo < rangeFrom)
+        {
+            (rangeFrom, rangeTo) = (rangeTo, rangeFrom);
+        }
+        if (!rangeFrom.HasValue || !rangeTo.HasValue) return "";
+        if (day < rangeFrom.Value || day > rangeTo.Value) return "";
+
+        var isStart = day == rangeFrom.Value;
+        var isEnd = day == rangeTo.Value;
+
+        // flex layout keeps the button (h-8 w-8) centered horizontally so the
+        // surrounding bar extends to the cell edges on either side.
+        var parts = new List<string> { "flex items-center justify-center bg-accent" };
+        if (isStart || col == 0) parts.Add("rounded-l-md");
+        if (isEnd || col == 6) parts.Add("rounded-r-md");
+        return string.Join(" ", parts);
+    }
+
     private string DayClasses(DateOnly day, DateOnly monthDate)
     {
         var isCurrentMonth = day.Month == monthDate.Month;
@@ -469,13 +511,15 @@
                         var dt = d.ToDateTime(TimeOnly.MinValue);
                         var tooltip = DateTooltip?.Invoke(dt);
                         var badge = DateBadge?.Invoke(dt);
-                        <button type="button" class="@DayClasses(d, monthDate)" disabled="@IsDisabled(d)" title="@tooltip" @onclick="() => SelectDay(d)" @onmouseenter="() => OnDayHover(d)">
-                            @d.Day
-                            @if (badge is not null)
-                            {
-                                <span class="absolute -bottom-0.5 -right-0.5 pointer-events-none flex">@badge</span>
-                            }
-                        </button>
+                        <div class="@RangeBarClasses(d, monthDate, col)">
+                            <button type="button" class="@DayClasses(d, monthDate)" disabled="@IsDisabled(d)" title="@tooltip" @onclick="() => SelectDay(d)" @onmouseenter="() => OnDayHover(d)">
+                                @d.Day
+                                @if (badge is not null)
+                                {
+                                    <span class="absolute -bottom-0.5 -right-0.5 pointer-events-none flex">@badge</span>
+                                }
+                            </button>
+                        </div>
                     }
                 }
             </div>

--- a/tests/Lumeo.Tests/Services/StrictInteropTests.cs
+++ b/tests/Lumeo.Tests/Services/StrictInteropTests.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using Bunit;
 using Xunit;
 using Lumeo.Services;
@@ -28,7 +29,15 @@ public class StrictInteropTests : IAsyncLifetime
     {
         // Module interop requires loose mode — strict verification is done via VerifyInvoke
         _ctx.JSInterop.Mode = JSRuntimeMode.Loose;
-        _module = _ctx.JSInterop.SetupModule("./_content/Lumeo/js/components.js");
+        // 2.1.4: ComponentInteropService now appends ?v=<assembly-version> to the
+        // module import URL as a browser-cache-buster. Mirror the lib's URL builder
+        // so the test's SetupModule handle matches what the service actually imports.
+        var v = typeof(ComponentInteropService).Assembly
+            .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
+            ?.InformationalVersion
+            ?? typeof(ComponentInteropService).Assembly.GetName().Version?.ToString()
+            ?? "0";
+        _module = _ctx.JSInterop.SetupModule($"./_content/Lumeo/js/components.js?v={v}");
         _module.Mode = JSRuntimeMode.Loose;
 
         _ctx.Services.AddScoped<ComponentInteropService>();

--- a/tools/lumeo-mcp/package-lock.json
+++ b/tools/lumeo-mcp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lumeo-ui/mcp-server",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@lumeo-ui/mcp-server",
-      "version": "2.1.3",
+      "version": "2.1.4",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0"
@@ -465,7 +465,7 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/finalhandler": {
-      "version": "2.1.3",
+      "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
       "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
       "license": "MIT",
@@ -743,7 +743,7 @@
       }
     },
     "node_modules/ms": {
-      "version": "2.1.3",
+      "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
@@ -914,7 +914,7 @@
       }
     },
     "node_modules/safer-buffer": {
-      "version": "2.1.3",
+      "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"

--- a/tools/lumeo-mcp/package.json
+++ b/tools/lumeo-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lumeo-ui/mcp-server",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "description": "Model Context Protocol server for the Lumeo Blazor component library. Lets LLMs (Claude, Copilot, Cursor) author correct Lumeo markup.",
   "type": "module",
   "main": "dist/index.js",

--- a/tools/lumeo-mcp/src/index.ts
+++ b/tools/lumeo-mcp/src/index.ts
@@ -364,7 +364,7 @@ function validateMarkup(markup: string): { ok: boolean; issues: ValidationIssue[
 const server = new Server(
   {
     name: "lumeo-mcp",
-    version: "2.1.3",
+    version: "2.1.4",
   },
   {
     capabilities: {

--- a/tools/lumeo-mcp/src/registry.json
+++ b/tools/lumeo-mcp/src/registry.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://lumeo.nativ.sh/registry-schema.json",
-  "version": "2.1.3",
-  "generated": "2026-05-20T11:30:00.0000000Z",
+  "version": "2.1.4",
+  "generated": "2026-05-20T12:15:00.0000000Z",
   "components": {
     "accordion": {
       "name": "Accordion",


### PR DESCRIPTION
## Summary

A user upgrading from 2.1.2 → 2.1.3 hit:

```
Microsoft.JSInterop.JSException: The value 'registerViewportListener' is not a function.
```

Cause: library JS under `_content/Lumeo/js/components.js` is served WITHOUT a content-hash by the static-web-assets pipeline (unlike the Blazor framework JS, which IS hashed). After a lib upgrade the browser kept the previous `components.js` in cache. New C# code expecting new exports — here 2.1.3's `ResponsiveService` calling the brand-new `registerViewportListener` — got back the stale module without the function and exploded at runtime.

## Fix

Append `?v=<assembly-informational-version>` to every library module import URL. Version is read once from `AssemblyInformationalVersion` (driven by `Directory.Build.props <Version>`), so the cache key tracks every release with zero manual maintenance.

- `ComponentInteropService.GetModuleAsync` — appends `?v=2.1.4` to the `components.js` import.
- `ComponentInteropService.ImportModuleAsync` — wraps any URL through a small `AppendVersion` helper. Only `_content/Lumeo*/` URLs get the suffix; URLs that already contain a query string pass through untouched (so consumer overrides like `?nocache=1` aren't clobbered); consumer module URLs (not under `_content/Lumeo*/`) pass through unchanged.
- `KeyboardShortcutService.GetModuleAsync` — imports `components.js` directly, same pattern applied.

**Existing 2.1.3 users hitting the JSException today still need one hard refresh** (Ctrl/Cmd+Shift+R) — the cache-buster can only help upgrades from this release forward.

Lockstep bump 2.1.3 → 2.1.4 (Directory.Build.props, lumeo-mcp suite, install snippets, hero, changelog).

## Test plan
- [ ] CI green (build-and-test, e2e, bom-check)
- [ ] After merge: tag `v2.1.4`, publish NuGet + npm, GitHub release
- [ ] Manual: open the deployed docs site, verify `_content/Lumeo/js/components.js?v=2.1.4` in DevTools Network tab

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rvm2C6y39FWuopi49ptzt9)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic cache-busting functionality for JavaScript module imports to prevent stale browser caches. Module URLs now include version identifiers as query parameters, ensuring users always receive the latest module code following package upgrades and updates.

* **Chores**
  * Version updated to 2.1.4 across all packages, core documentation, CLI installation examples, and configuration files.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Brain2k-0005/Lumeo/pull/21?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->