### PR TITLE
2.2.1: DataGrid group panel — right-align picker + persist grouping to localStorage

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
   <!-- Lockstep version shared by all Lumeo packages.
        Update this single property to version all packages in unison. -->
   <PropertyGroup>
-    <Version>2.2.0</Version>
+    <Version>2.2.1</Version>
   </PropertyGroup>
 
   <!-- Shared NuGet README packing lives in Directory.Build.targets, NOT here.

--- a/docs/Lumeo.Docs/Pages/Components/CodePage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/CodePage.razor
@@ -22,7 +22,7 @@
     </ComponentDemo>
 
     <ComponentDemo Title="Block" Code="@_blockCode">
-        <Code Variant="block">dotnet add package Lumeo --version 2.2.0</Code>
+        <Code Variant="block">dotnet add package Lumeo --version 2.2.1</Code>
     </ComponentDemo>
 
     <ComponentDemo Title="Custom Size" Code="@_sizeCode">
@@ -121,7 +121,7 @@
     Pass <Code>Variant=""block""</Code> for multi-line blocks.
 </p>";
 
-    private string _blockCode = @"<Code Variant=""block"">dotnet add package Lumeo --version 2.2.0</Code>";
+    private string _blockCode = @"<Code Variant=""block"">dotnet add package Lumeo --version 2.2.1</Code>";
 
     private string _sizeCode = @"<Code Size=""xs"">text-xs code</Code>
 <Code Size=""base"">text-base code</Code>

--- a/docs/Lumeo.Docs/Pages/Docs/Changelog.razor
+++ b/docs/Lumeo.Docs/Pages/Docs/Changelog.razor
@@ -15,6 +15,30 @@
 
     <Separator Class="my-4" />
 
+    <!-- v2.2.1 -->
+    <Stack Gap="4">
+        <div class="flex items-center gap-3">
+            <Badge>v2.2.1</Badge>
+            <Lumeo.Text Size="sm" Color="muted">May 2026</Lumeo.Text>
+        </div>
+
+        <Lumeo.Text Size="base" Color="muted" Leading="relaxed">
+            <strong>DataGrid group panel: hard-right alignment + persistence on grouping changes.</strong>
+            Two 2.2.0 regressions surfaced by the first consumer of the new themed group-panel: the new "+ Add group level" <code class="rounded bg-muted px-1.5 py-0.5 text-xs font-mono text-foreground">DropdownMenu</code> didn't sit at the right edge of the panel, and grouping mutations weren't being written to localStorage even though sort/filter/columns were.
+        </Lumeo.Text>
+
+        <Stack Gap="3">
+            <Heading Level="3" Size="sm" Class="font-semibold">Fixed</Heading>
+            <ul class="space-y-1.5 text-sm list-disc list-inside text-muted-foreground">
+                <li><strong>Group panel "+ Add group level" picker now right-aligned</strong> — the 2.2.0 refactor moved the trigger into a <code class="rounded bg-muted px-1.5 py-0.5 text-xs font-mono text-foreground">&lt;DropdownMenu&gt;</code> component, which renders its own <code class="rounded bg-muted px-1.5 py-0.5 text-xs font-mono text-foreground">relative inline-block</code> wrapper as root. The <code class="rounded bg-muted px-1.5 py-0.5 text-xs font-mono text-foreground">ml-auto</code> on the inner trigger button had no effect on the flex-parent panel because <code class="rounded bg-muted px-1.5 py-0.5 text-xs font-mono text-foreground">DropdownMenu</code> was the actual flex child. Wrapped the component in a <code class="rounded bg-muted px-1.5 py-0.5 text-xs font-mono text-foreground">&lt;div class="ml-auto"&gt;</code> so the picker sits hard-right again.</li>
+                <li><strong>Grouping changes now persist to <code class="rounded bg-muted px-1.5 py-0.5 text-xs font-mono text-foreground">localStorage</code></strong> — <code class="rounded bg-muted px-1.5 py-0.5 text-xs font-mono text-foreground">AddGroupField</code> / <code class="rounded bg-muted px-1.5 py-0.5 text-xs font-mono text-foreground">RemoveGroupField</code> / <code class="rounded bg-muted px-1.5 py-0.5 text-xs font-mono text-foreground">ClearGroupFields</code> didn't call <code class="rounded bg-muted px-1.5 py-0.5 text-xs font-mono text-foreground">ScheduleAutoSave()</code>, so the snapshot serialization built in v2.1.1 had nothing to act on. Sort/filter changes had been calling it from day one. Three matching <code class="rounded bg-muted px-1.5 py-0.5 text-xs font-mono text-foreground">ScheduleAutoSave()</code> calls added — grouping now round-trips through reload identically to sort/filter/columns.</li>
+            </ul>
+        </Stack>
+        <Lumeo.Text Size="sm" Color="muted">No new tests — the existing v2.1.1 snapshot-and-restore tests cover the persistence contract; the missing trigger was the bug. The right-align fix is visual and covered by manual verification in the PR checklist.</Lumeo.Text>
+    </Stack>
+
+    <Separator Class="my-4" />
+
     <!-- v2.2.0 -->
     <Stack Gap="4">
         <div class="flex items-center gap-3">

--- a/docs/Lumeo.Docs/Pages/Docs/Cli.razor
+++ b/docs/Lumeo.Docs/Pages/Docs/Cli.razor
@@ -36,7 +36,7 @@
                 Install as a global <code class="rounded bg-muted px-1.5 py-0.5 text-xs font-mono text-foreground">dotnet</code> tool:
             </Lumeo.Text>
             <Stack Class="code-block rounded-lg border border-border/40 bg-muted px-4 py-3 font-mono text-sm text-foreground">
-                dotnet tool install -g Lumeo.Cli --version 2.2.0
+                dotnet tool install -g Lumeo.Cli --version 2.2.1
             </Stack>
             <Lumeo.Text Size="sm" Color="muted" Leading="relaxed">
                 The tool exposes a single command, <code class="rounded bg-muted px-1.5 py-0.5 text-xs font-mono text-foreground">lumeo</code>.

--- a/docs/Lumeo.Docs/Pages/Home.razor
+++ b/docs/Lumeo.Docs/Pages/Home.razor
@@ -14,7 +14,7 @@
                 <Lumeo.Link Href="docs/changelog" Class="no-underline group">
                     <Flex Inline="true" Align="center" Gap="2" Class="rounded-full border border-border/60 bg-background/80 px-3 py-1 text-xs font-medium text-muted-foreground backdrop-blur-sm hover:border-primary/40 hover:text-foreground transition-colors">
                         <Badge Variant="Badge.BadgeVariant.Default" Class="h-4 px-1.5 text-[10px] leading-none">New</Badge>
-                        <Lumeo.Text As="span">v2.2.0 — Theming & accessibility polish · 100% i18n coverage · DataGrid group panel themed dropdown · ~110 new focus-visible rings</Lumeo.Text>
+                        <Lumeo.Text As="span">v2.2.1 — DataGrid group panel add-button right-aligns + grouping persists to localStorage</Lumeo.Text>
                         <DynamicIcon Name="ArrowRight" Class="h-3 w-3 transition-transform group-hover:translate-x-0.5" />
                     </Flex>
                 </Lumeo.Link>

--- a/src/Lumeo.DataGrid/UI/DataGrid/DataGrid.razor
+++ b/src/Lumeo.DataGrid/UI/DataGrid/DataGrid.razor
@@ -249,26 +249,32 @@
                        pattern here anyway: this is an "execute an action"
                        picker, not a "bind a value" picker, so it shouldn't
                        maintain a selected state in the first place. *@
-                    <DropdownMenu>
-                        <DropdownMenuTrigger>
-                            <button type="button"
-                                    data-slot="datagrid-group-add-trigger"
-                                    class="ml-auto inline-flex items-center gap-1 h-6 rounded border border-border/60 bg-card px-2 text-xs text-muted-foreground hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-[1.5px] focus-visible:ring-ring focus-visible:ring-offset-2 transition-colors">
-                                <span>@L["DataGrid.AddGroupLevel"]</span>
-                                <Blazicon Svg="Lucide.ChevronDown" class="h-3 w-3" />
-                            </button>
-                        </DropdownMenuTrigger>
-                        <DropdownMenuContent>
-                            @foreach (var c in addableCols)
-                            {
-                                var field = c.Field!;
-                                <DropdownMenuItem AdditionalAttributes="@(new Dictionary<string, object> { ["data-group-add-field"] = field })"
-                                                  OnClick="@(() => { AddGroupField(field); return Task.CompletedTask; })">
-                                    @(c.Title ?? c.Field)
-                                </DropdownMenuItem>
-                            }
-                        </DropdownMenuContent>
-                    </DropdownMenu>
+                    @* The DropdownMenu component itself renders a relative-inline-block
+                       wrapper div as its root, so ml-auto on the inner trigger button has
+                       no effect on the flex parent. Wrap the whole component in a div that
+                       takes the ml-auto so the picker sits hard-right on the panel. *@
+                    <div class="ml-auto">
+                        <DropdownMenu>
+                            <DropdownMenuTrigger>
+                                <button type="button"
+                                        data-slot="datagrid-group-add-trigger"
+                                        class="inline-flex items-center gap-1 h-6 rounded border border-border/60 bg-card px-2 text-xs text-muted-foreground hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-[1.5px] focus-visible:ring-ring focus-visible:ring-offset-2 transition-colors">
+                                    <span>@L["DataGrid.AddGroupLevel"]</span>
+                                    <Blazicon Svg="Lucide.ChevronDown" class="h-3 w-3" />
+                                </button>
+                            </DropdownMenuTrigger>
+                            <DropdownMenuContent>
+                                @foreach (var c in addableCols)
+                                {
+                                    var field = c.Field!;
+                                    <DropdownMenuItem AdditionalAttributes="@(new Dictionary<string, object> { ["data-group-add-field"] = field })"
+                                                      OnClick="@(() => { AddGroupField(field); return Task.CompletedTask; })">
+                                        @(c.Title ?? c.Field)
+                                    </DropdownMenuItem>
+                                }
+                            </DropdownMenuContent>
+                        </DropdownMenu>
+                    </div>
                 }
             </div>
         }
@@ -1509,6 +1515,10 @@
         _currentPage = 1;
         if (ServerMode) RegroupServerItems();
         else ProcessClientData();
+        // Mirror Sort/Filter behaviour — persist the grouping change so a
+        // reload restores it. Without this the snapshot serialization built
+        // in v2.1.1 had nothing to act on for runtime-panel additions.
+        ScheduleAutoSave();
         StateHasChanged();
     }
 
@@ -1522,6 +1532,7 @@
         _currentPage = 1;
         if (ServerMode) RegroupServerItems();
         else ProcessClientData();
+        ScheduleAutoSave();
         StateHasChanged();
     }
 
@@ -1539,6 +1550,7 @@
         _currentPage = 1;
         if (ServerMode) RegroupServerItems();
         else ProcessClientData();
+        ScheduleAutoSave();
         StateHasChanged();
     }
 

--- a/tools/lumeo-mcp/package-lock.json
+++ b/tools/lumeo-mcp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lumeo-ui/mcp-server",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@lumeo-ui/mcp-server",
-      "version": "2.2.0",
+      "version": "2.2.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0"
@@ -465,7 +465,7 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/finalhandler": {
-      "version": "2.2.0",
+      "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
       "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
       "license": "MIT",
@@ -743,7 +743,7 @@
       }
     },
     "node_modules/ms": {
-      "version": "2.2.0",
+      "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
@@ -898,7 +898,7 @@
       }
     },
     "node_modules/router": {
-      "version": "2.2.0",
+      "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
       "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
       "license": "MIT",
@@ -914,7 +914,7 @@
       }
     },
     "node_modules/safer-buffer": {
-      "version": "2.2.0",
+      "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"

--- a/tools/lumeo-mcp/package.json
+++ b/tools/lumeo-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lumeo-ui/mcp-server",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "Model Context Protocol server for the Lumeo Blazor component library. Lets LLMs (Claude, Copilot, Cursor) author correct Lumeo markup.",
   "type": "module",
   "main": "dist/index.js",

--- a/tools/lumeo-mcp/src/index.ts
+++ b/tools/lumeo-mcp/src/index.ts
@@ -364,7 +364,7 @@ function validateMarkup(markup: string): { ok: boolean; issues: ValidationIssue[
 const server = new Server(
   {
     name: "lumeo-mcp",
-    version: "2.2.0",
+    version: "2.2.1",
   },
   {
     capabilities: {

--- a/tools/lumeo-mcp/src/registry.json
+++ b/tools/lumeo-mcp/src/registry.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://lumeo.nativ.sh/registry-schema.json",
-  "version": "2.2.0",
-  "generated": "2026-05-20T13:00:00.0000000Z",
+  "version": "2.2.1",
+  "generated": "2026-05-20T15:00:00.0000000Z",
   "components": {
     "accordion": {
       "name": "Accordion",


### PR DESCRIPTION
## Summary

Two 2.2.0 regressions caught by the first consumer of the new themed group-panel:

1. **"+ Add group level" picker not right-aligned** — the 2.2.0 refactor wrapped the trigger in `<DropdownMenu>`, which renders its own `relative inline-block` div as root. The `ml-auto` I put on the inner trigger button was on the wrong element; `<DropdownMenu>` (not the button) was the actual flex child. Wrapped the component in `<div class="ml-auto">` so the picker sits hard-right again.

2. **Grouping changes weren't being written to localStorage** — `AddGroupField` / `RemoveGroupField` / `ClearGroupFields` never called `ScheduleAutoSave()`. Sort/filter/column-resize/pin-toggle all triggered the auto-save so the user (correctly) noticed grouping was the odd one out. v2.1.1's snapshot serialization was wired correctly — it just had nothing to act on for runtime-panel mutations. Three matching `ScheduleAutoSave()` calls added.

Lockstep: Directory.Build.props + lumeo-mcp suite bumped to 2.2.1. Hero badge + install snippets + changelog entry updated.

No new tests — the v2.1.1 snapshot-and-restore tests already cover the persistence contract; the missing trigger was the bug, not the snapshot logic. Right-align fix is visual.

## Test plan
- [ ] CI green (build-and-test, e2e, bom-check)
- [ ] Manual: open a DataGrid with group panel — picker sits at the far right edge
- [ ] Manual: with `EnableLayoutPersistence="true"`, add a grouping via the picker, reload page → grouping chip survives
- [ ] Manual: same with `RemoveGroupField` (chip × button) and the "Clear all grouping" button
- [ ] After merge: tag `v2.2.1`, publish NuGet + npm, GitHub release

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rvm2C6y39FWuopi49ptzt9)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes v2.2.1

* **Bug Fixes**
  * DataGrid group panel "+ Add group level" button now correctly aligns to the right
  * DataGrid grouping changes now persist to localStorage

* **Chores**
  * Updated package version to 2.2.1
  * Updated documentation and CLI tool references

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Brain2k-0005/Lumeo/pull/23?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->