### PR TITLE
3.0.3 — sticky aggregate row: move position from tfoot to td cells

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
   <!-- Lockstep version shared by all Lumeo packages.
        Update this single property to version all packages in unison. -->
   <PropertyGroup>
-    <Version>3.0.2</Version>
+    <Version>3.0.3</Version>
   </PropertyGroup>
 
   <!-- Shared NuGet README packing lives in Directory.Build.targets, NOT here.

--- a/src/Lumeo.DataGrid/UI/DataGrid/DataGridFooter.razor
+++ b/src/Lumeo.DataGrid/UI/DataGrid/DataGridFooter.razor
@@ -4,22 +4,25 @@
 
 @if (Context is not null && HasAggregates)
 {
-    @* sticky bottom-0 keeps the aggregate row pinned to the visible bottom of
-       the scrolling table body when the DataGrid is height-constrained. Falls
-       back to natural placement when the table itself isn't scrolling. *@
-    <tfoot data-slot="datagrid-footer" class="@CssClass sticky bottom-0 z-10" @attributes="AdditionalAttributes">
-        <tr class="border-t border-border/40">
+    @* CSS sticky on <tfoot> is unreliable across browsers — most engines
+       ignore sticky on <thead>/<tfoot> wrapper elements. The pattern that
+       actually works is putting `position: sticky; bottom: 0` on each <td>
+       cell directly, so each cell sticks to the bottom of its scrolling
+       ancestor (the table wrapper div). bg-muted/95 + backdrop-blur-sm
+       occludes rows scrolling underneath. *@
+    <tfoot data-slot="datagrid-footer" class="@CssClass" @attributes="AdditionalAttributes">
+        <tr>
             @if (Context.SelectionMode != DataGridSelectionMode.None)
             {
-                <td class="px-3 py-2 w-10 bg-muted/95 backdrop-blur-sm"></td>
+                <td class="sticky bottom-0 z-10 px-3 py-2 w-10 border-t border-border/40 bg-muted/95 backdrop-blur-sm"></td>
             }
             @if (HasDetailTemplate)
             {
-                <td class="px-1 py-2 w-8 bg-muted/95 backdrop-blur-sm"></td>
+                <td class="sticky bottom-0 z-10 px-1 py-2 w-8 border-t border-border/40 bg-muted/95 backdrop-blur-sm"></td>
             }
             @foreach (var column in Context.VisibleColumns)
             {
-                <td @key="column.Id" class="px-3 py-2 text-xs font-medium text-muted-foreground bg-muted/95 backdrop-blur-sm">
+                <td @key="column.Id" class="sticky bottom-0 z-10 px-3 py-2 text-xs font-medium text-muted-foreground border-t border-border/40 bg-muted/95 backdrop-blur-sm">
                     @if (column.Aggregate != AggregateType.None)
                     {
                         <span>@GetAggregateLabel(column.Aggregate): @ComputeAggregate(column)</span>


### PR DESCRIPTION
## Summary

3.0.2 added `sticky bottom-0` to the DataGrid `<tfoot>` but most browser table engines silently ignore CSS `sticky` on `<thead>` / `<tfoot>` wrapper elements — they position table sections via the table-internal flow, not the scrolling ancestor. The aggregate row stayed at the natural end of the table, never anchoring to the scroll viewport.

This patch moves `position: sticky; bottom: 0` from the `<tfoot>` onto **each `<td>` cell**. That's the pattern that actually works for sticky table headers / footers across Chrome, Firefox, Safari.

## Test plan

- [ ] CI green
- [ ] Manual: `/components/datagrid/playground` — PageSize=8, AVG row sits flush at the bottom of the table area (not floating mid-card)
- [ ] Manual: scroll the table body (PageSize=50, many rows) — AVG row stays pinned at the bottom of the viewport
- [ ] Manual: DataGrid without fixed Height — AVG row still at natural end (sticky no-op when no scrolling ancestor)

## Release path

Patch — owner says "tag it" → I tag `v3.0.3` and publish workflow runs.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rvm2C6y39FWuopi49ptzt9)_