### PR TITLE
fix(docs): Bento mobile responsiveness + skip heavy demos on small screens

### DIFF
--- a/docs/Lumeo.Docs/Pages/Components/BentoPage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/BentoPage.razor
@@ -93,7 +93,7 @@
                         </tr>
                     </thead>
                     <tbody class="divide-y divide-border/40">
-                        <tr><td class="p-3 font-mono text-xs text-primary">Columns</td><td class="p-3 font-mono text-xs">int</td><td class="p-3 font-mono text-xs">4</td><td class="p-3 text-muted-foreground">Number of grid columns. 2/3/4/6 use pre-compiled Tailwind utilities; other values fall back to inline grid-template-columns.</td></tr>
+                        <tr><td class="p-3 font-mono text-xs text-primary">Columns</td><td class="p-3 font-mono text-xs">int</td><td class="p-3 font-mono text-xs">4</td><td class="p-3 text-muted-foreground">Target number of grid columns at the lg: breakpoint (≥1024 px). The grid collapses to 1 column on mobile and 2 on sm: (≥640 px) so embedded tiles stay readable. Standard values 1–6 use pre-compiled Tailwind utilities; other values fall back to inline grid-template-columns without responsive collapse.</td></tr>
                         <tr><td class="p-3 font-mono text-xs text-primary">Gap</td><td class="p-3 font-mono text-xs">BentoGap</td><td class="p-3 font-mono text-xs">Md</td><td class="p-3 text-muted-foreground">Gap between tiles. Sm = 0.75rem, Md = 1rem, Lg = 1.5rem.</td></tr>
                         <tr><td class="p-3 font-mono text-xs text-primary">ChildContent</td><td class="p-3 font-mono text-xs">RenderFragment?</td><td class="p-3 font-mono text-xs">-</td><td class="p-3 text-muted-foreground">BentoTile children (or any grid items).</td></tr>
                     </tbody>
@@ -114,8 +114,8 @@
                         </tr>
                     </thead>
                     <tbody class="divide-y divide-border/40">
-                        <tr><td class="p-3 font-mono text-xs text-primary">Span</td><td class="p-3 font-mono text-xs">int</td><td class="p-3 font-mono text-xs">1</td><td class="p-3 text-muted-foreground">Column span (grid-column: span N).</td></tr>
-                        <tr><td class="p-3 font-mono text-xs text-primary">RowSpan</td><td class="p-3 font-mono text-xs">int</td><td class="p-3 font-mono text-xs">1</td><td class="p-3 text-muted-foreground">Row span (grid-row: span N).</td></tr>
+                        <tr><td class="p-3 font-mono text-xs text-primary">Span</td><td class="p-3 font-mono text-xs">int</td><td class="p-3 font-mono text-xs">1</td><td class="p-3 text-muted-foreground">Column span at the lg: breakpoint. Tiles always span 1 column on mobile; tiles with Span ≥ 2 widen to 2 columns at sm: and the full Span at lg:.</td></tr>
+                        <tr><td class="p-3 font-mono text-xs text-primary">RowSpan</td><td class="p-3 font-mono text-xs">int</td><td class="p-3 font-mono text-xs">1</td><td class="p-3 text-muted-foreground">Row span at the lg: breakpoint. Mobile and tablet render each tile at its natural content height (RowSpan=1) so tall tiles don't create huge empty boxes.</td></tr>
                         <tr><td class="p-3 font-mono text-xs text-primary">Title</td><td class="p-3 font-mono text-xs">string?</td><td class="p-3 font-mono text-xs">null</td><td class="p-3 text-muted-foreground">Optional header title.</td></tr>
                         <tr><td class="p-3 font-mono text-xs text-primary">Description</td><td class="p-3 font-mono text-xs">string?</td><td class="p-3 font-mono text-xs">null</td><td class="p-3 text-muted-foreground">Optional header description below the title.</td></tr>
                         <tr><td class="p-3 font-mono text-xs text-primary">HeaderContent</td><td class="p-3 font-mono text-xs">RenderFragment?</td><td class="p-3 font-mono text-xs">-</td><td class="p-3 text-muted-foreground">Custom header slot; overrides Title/Description.</td></tr>

--- a/docs/Lumeo.Docs/Pages/Home.razor
+++ b/docs/Lumeo.Docs/Pages/Home.razor
@@ -422,8 +422,13 @@
             <!-- Map — Globe projection with great-circle arcs, DarkMatter basemap.
                  RowSpan=2 so the globe fills a tall tile next to the PdfViewer
                  row, and Zoom=2 so the sphere itself takes more of the canvas
-                 instead of floating tiny in the middle. -->
-            <BentoTile Span="2" RowSpan="2" Class="border-border/60 p-0 overflow-hidden">
+                 instead of floating tiny in the middle.
+                 `hidden lg:flex` keeps the entire tile out of the DOM layout
+                 on mobile/tablet — LazyRender's IntersectionObserver never
+                 fires for display:none placeholders, so MapLibre GL JS
+                 (~250 KB) is not downloaded on phones where the globe would
+                 be unusably small anyway. -->
+            <BentoTile Span="2" RowSpan="2" Class="border-border/60 p-0 overflow-hidden hidden lg:flex">
                 <div class="flex h-full flex-col overflow-hidden">
                     <div class="flex-1 min-h-0 relative overflow-hidden">
                         <LazyRender Height="100%">
@@ -457,8 +462,11 @@
 
             <!-- Charts — three live ECharts stacked vertically (Bar / Line /
                  Area), datasets reshuffle every ~2s in sync. Hover pauses.
-                 RowSpan=2 so each chart gets ~240px height. No Pie/Donut. -->
-            <BentoTile Span="2" RowSpan="2" Class="border-border/60 p-0 overflow-hidden">
+                 RowSpan=2 so each chart gets ~240px height. No Pie/Donut.
+                 Hidden on mobile: three ECharts re-rendering every 2 s pegs
+                 the main thread on phones, and at 1-col width the labels
+                 collide. Desktop visitors see the showcase intact. -->
+            <BentoTile Span="2" RowSpan="2" Class="border-border/60 p-0 overflow-hidden hidden lg:flex">
                 <div class="flex h-full flex-col overflow-hidden" @onmouseenter="@(() => _chartHovered = true)" @onmouseleave="@(() => _chartHovered = false)">
                     <div class="flex-1 min-h-0 grid grid-rows-3 gap-2 p-3 bg-muted/10">
                         <div class="rounded-md border border-border/40 bg-card/60 p-2 min-h-0 overflow-hidden">
@@ -487,8 +495,11 @@
             <!-- PdfViewer — inline PDF with search highlight. We use HARD heights
                  (not max-height) so the PdfViewer's `h-full` resolves to a real
                  number; without that, its inner `flex-1 overflow-auto` document
-                 area has no upper bound and the canvas can't scroll when zoomed in. -->
-            <BentoTile Span="2" Class="border-border/60 p-0 overflow-hidden">
+                 area has no upper bound and the canvas can't scroll when zoomed in.
+                 Hidden on mobile: pdf.js + its worker (~150 KB) plus the PDF
+                 download itself would crater LCP on a phone, and the viewer
+                 chrome is unusable at narrow widths. -->
+            <BentoTile Span="2" Class="border-border/60 p-0 overflow-hidden hidden lg:flex">
                 <div class="flex flex-col overflow-hidden" style="height:560px">
                     <div class="flex-1 min-h-0 overflow-hidden">
                         <LazyRender Height="100%">

--- a/src/Lumeo/UI/Bento/Bento.razor
+++ b/src/Lumeo/UI/Bento/Bento.razor
@@ -18,13 +18,19 @@
         _ => "gap-4"
     };
 
-    // Pre-approved columns use Tailwind utilities. Any other value falls back to inline style.
+    // Pre-approved column counts use responsive Tailwind utilities so the grid
+    // collapses gracefully on mobile (1 col), tablet (2 cols) and only expands
+    // to the caller-configured count at the lg: breakpoint. Without this,
+    // a Bento Columns="4" on a 375 px phone screen renders four tiny columns
+    // and the embedded components become unreadable.
     private string ColumnsClass => Columns switch
     {
-        2 => "grid-cols-2",
-        3 => "grid-cols-3",
-        4 => "grid-cols-4",
-        6 => "grid-cols-6",
+        1 => "grid-cols-1",
+        2 => "grid-cols-1 sm:grid-cols-2",
+        3 => "grid-cols-1 sm:grid-cols-2 lg:grid-cols-3",
+        4 => "grid-cols-1 sm:grid-cols-2 lg:grid-cols-4",
+        5 => "grid-cols-1 sm:grid-cols-2 lg:grid-cols-5",
+        6 => "grid-cols-1 sm:grid-cols-2 lg:grid-cols-6",
         _ => ""
     };
 
@@ -37,6 +43,8 @@
             var baseStyle = "grid-auto-rows: minmax(0, 1fr);";
             if (string.IsNullOrEmpty(ColumnsClass))
             {
+                // Non-standard column count — fall back to inline grid-template-columns
+                // without responsive breakpoints. (Inline styles can't carry media queries.)
                 baseStyle += $" grid-template-columns: repeat({Columns}, minmax(0, 1fr));";
             }
             return baseStyle;

--- a/src/Lumeo/UI/Bento/BentoTile.razor
+++ b/src/Lumeo/UI/Bento/BentoTile.razor
@@ -1,6 +1,6 @@
 @namespace Lumeo
 
-<div class="@RootClasses" style="@RootStyle" @attributes="AdditionalAttributes">
+<div class="@RootClasses" @attributes="AdditionalAttributes">
     @if (HeaderContent is not null || !string.IsNullOrEmpty(Title) || !string.IsNullOrEmpty(Description))
     {
         <div class="mb-3 flex flex-col gap-1">
@@ -48,8 +48,32 @@
     [Parameter] public string? Class { get; set; }
     [Parameter(CaptureUnmatchedValues = true)] public Dictionary<string, object>? AdditionalAttributes { get; set; }
 
-    private string RootClasses => $"flex flex-col min-w-0 min-h-0 rounded-xl border border-border/60 bg-card text-card-foreground p-5 {Class}".Trim();
+    private string RootClasses => $"flex flex-col min-w-0 min-h-0 rounded-xl border border-border/60 bg-card text-card-foreground p-5 {SpanClasses} {RowSpanClasses} {Class}".Trim();
 
-    private string RootStyle =>
-        $"grid-column: span {Span} / span {Span}; grid-row: span {RowSpan} / span {RowSpan};";
+    // Span classes are emitted as literal Tailwind strings (not interpolated
+    // `col-span-{n}`) so the JIT can see them at scan time. On mobile every
+    // tile spans 1 col; from `sm:` (≥ 640 px) we widen tiles meant to be 2+
+    // wide so they don't go single-column on tablet; the caller's exact span
+    // kicks in at `lg:` (≥ 1024 px). RowSpan stays at 1 on mobile so each
+    // tile's natural content height drives layout instead of an enforced
+    // double-row that creates huge empty boxes on a phone.
+    private string SpanClasses => Span switch
+    {
+        <= 1 => "col-span-1",
+        2 => "col-span-1 sm:col-span-2",
+        3 => "col-span-1 sm:col-span-2 lg:col-span-3",
+        4 => "col-span-1 sm:col-span-2 lg:col-span-4",
+        5 => "col-span-1 sm:col-span-2 lg:col-span-5",
+        6 => "col-span-1 sm:col-span-2 lg:col-span-6",
+        _ => "col-span-1 sm:col-span-2"
+    };
+
+    private string RowSpanClasses => RowSpan switch
+    {
+        <= 1 => "row-span-1",
+        2 => "row-span-1 lg:row-span-2",
+        3 => "row-span-1 lg:row-span-3",
+        4 => "row-span-1 lg:row-span-4",
+        _ => "row-span-1"
+    };
 }

--- a/tests/Lumeo.Tests/Components/Bento/BentoTests.cs
+++ b/tests/Lumeo.Tests/Components/Bento/BentoTests.cs
@@ -49,12 +49,31 @@ public class BentoTests : IAsyncLifetime
     [Fact]
     public void Columns_Custom_Value_Falls_Back_To_Inline_Style()
     {
+        // 1–6 columns now use Tailwind utilities with responsive collapse;
+        // 7+ is the off-the-beaten-path fallback that emits inline
+        // grid-template-columns without responsive breakpoints.
         var cut = _ctx.Render<Lumeo.Bento>(p => p
-            .Add(b => b.Columns, 5));
+            .Add(b => b.Columns, 7));
 
         var style = cut.Find("div").GetAttribute("style");
         Assert.Contains("grid-template-columns", style);
-        Assert.Contains("repeat(5", style);
+        Assert.Contains("repeat(7", style);
+    }
+
+    [Theory]
+    [InlineData(2)]
+    [InlineData(3)]
+    [InlineData(4)]
+    [InlineData(6)]
+    public void Columns_Collapse_To_One_On_Mobile(int columns)
+    {
+        // Every multi-column Bento must collapse to grid-cols-1 on phones —
+        // without this guard, a regression that drops the responsive prefix
+        // would silently reintroduce the unusable-on-mobile bug.
+        var cut = _ctx.Render<Lumeo.Bento>(p => p
+            .Add(b => b.Columns, columns));
+
+        Assert.Contains("grid-cols-1", cut.Find("div").GetAttribute("class"));
     }
 
     [Fact]

--- a/tests/Lumeo.Tests/Components/Bento/BentoTileTests.cs
+++ b/tests/Lumeo.Tests/Components/Bento/BentoTileTests.cs
@@ -20,29 +20,42 @@ public class BentoTileTests : IAsyncLifetime
     [Fact]
     public void Default_Span_And_RowSpan_Render_As_Span_1()
     {
+        // Span/RowSpan moved off inline styles onto literal Tailwind classes
+        // so the mobile breakpoint can override them. Default tile is a
+        // single-cell tile in any grid.
         var cut = _ctx.Render<Lumeo.BentoTile>();
 
-        var style = cut.Find("div").GetAttribute("style");
-        Assert.Contains("grid-column: span 1 / span 1", style);
-        Assert.Contains("grid-row: span 1 / span 1", style);
+        var cls = cut.Find("div").GetAttribute("class");
+        Assert.Contains("col-span-1", cls);
+        Assert.Contains("row-span-1", cls);
     }
 
     [Fact]
-    public void Span_Produces_Inline_Grid_Column_Style()
+    public void Span_Produces_Responsive_Col_Span_Classes()
     {
+        // Mobile-first: every tile spans 1 on phones, widens to 2 at sm:, and
+        // hits the caller's Span at lg: so wide tiles don't punch holes in
+        // the mobile single-column stack.
         var cut = _ctx.Render<Lumeo.BentoTile>(p => p
             .Add(t => t.Span, 3));
 
-        Assert.Contains("grid-column: span 3 / span 3", cut.Find("div").GetAttribute("style"));
+        var cls = cut.Find("div").GetAttribute("class");
+        Assert.Contains("col-span-1", cls);
+        Assert.Contains("sm:col-span-2", cls);
+        Assert.Contains("lg:col-span-3", cls);
     }
 
     [Fact]
-    public void RowSpan_Produces_Inline_Grid_Row_Style()
+    public void RowSpan_Produces_Responsive_Row_Span_Classes()
     {
+        // RowSpan only kicks in at lg: so mobile rows hug their content
+        // height instead of inheriting a desktop multi-row tile.
         var cut = _ctx.Render<Lumeo.BentoTile>(p => p
             .Add(t => t.RowSpan, 2));
 
-        Assert.Contains("grid-row: span 2 / span 2", cut.Find("div").GetAttribute("style"));
+        var cls = cut.Find("div").GetAttribute("class");
+        Assert.Contains("row-span-1", cls);
+        Assert.Contains("lg:row-span-2", cls);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Addresses two pieces of user feedback on https://lumeo.nativ.sh:

> "the website performance is not good" (PageSpeed)
> "website is unusable on mobile device"

### Root cause: Bento was not responsive

`Bento.razor` hardcoded `grid-cols-4` / `grid-cols-3` / `grid-cols-6` with no breakpoints, and `BentoTile.razor` used inline `grid-column: span N`. So a `<Bento Columns="4">` on a 375 px phone screen still rendered four columns, squashing the DataGrid / code blocks / charts / kanban into unreadable strips. The Home page uses Bento in **four** places, so the whole landing experience broke below `lg:`.

### Fix

- **`Bento.razor`**: column count collapses to 1 on mobile, 2 at `sm:` (≥ 640 px), expands to caller-configured `Columns` at `lg:` (≥ 1024 px). Non-standard column counts still fall back to inline `grid-template-columns` (with no responsive collapse, as before).
- **`BentoTile.razor`**: `Span` and `RowSpan` apply only at `lg:`. On mobile every tile is `col-span-1 row-span-1` so wide/tall tiles don't punch holes in the stack. Span classes are emitted as **literal Tailwind strings** via switch expressions so the JIT picks them up at scan time — no safelist needed.
- **`Home.razor`**: the three heaviest demo tiles get `hidden lg:flex`:
  - **Map** (MapLibre globe with great-circle arcs) — `~250 KB` JS + tiles
  - **PdfViewer** (pdf.js + worker + sample PDF) — `~150 KB` JS + ~70 KB PDF
  - **Live Charts** (three ECharts redrawing every 2 s) — was pegging the main thread

  `LazyRender`'s `IntersectionObserver` never fires for `display:none` placeholders, so on phones these heavy bundles are simply **not downloaded and not parsed**. Desktop visitors see the full showcase unchanged. This is the meaningful PageSpeed win on mobile.

- **`Pages/Components/BentoPage.razor`**: updated the API description rows for `Columns` / `Span` / `RowSpan` to document the new responsive behavior.

### Result

| Surface | Before | After |
| --- | --- | --- |
| Home Bento at 375 px | 4 columns crammed side-by-side | 1-column stack |
| Map + PdfViewer + live Charts on phone | Mounts when scrolled into view (~400 KB extra JS) | Never mounts |
| Desktop layout (≥ 1024 px) | unchanged | unchanged |

## Test plan

- [ ] Visit https://lumeo.nativ.sh on a phone (or 375 px DevTools viewport): no horizontal scroll, every Bento tile fills the width, no Map / PDF / Charts demos.
- [ ] Visit on a tablet (768 px): Bento renders as 2 columns, still no Map / PDF / Charts.
- [ ] Visit on desktop (≥ 1024 px): identical to current production — full Bento with Map, PDF, and live charts.
- [ ] Network tab on mobile: confirm `maplibre-gl*.js` and `pdf.worker*.js` are not requested.
- [ ] Lighthouse / PageSpeed mobile run should show improved TBT and INP scores.
- [ ] `/components/bento` doc page still renders the example bentos correctly at all breakpoints.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XMy2ZxQDK3fAPw766fAc19)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated API reference to describe Bento component responsive behavior across mobile, tablet, and desktop breakpoints, including column and span sizing.

* **Improvements**
  * Enhanced Bento grid layout with responsive column adjustments that collapse on smaller screens and expand at larger breakpoints.
  * Optimized mobile homepage performance by deferring rendering of non-essential components.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Brain2k-0005/Lumeo/pull/34?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->