### PR TITLE
fix(mobile): stat-card heights, restore heavy demos, add touch drag

### DIFF
--- a/docs/Lumeo.Docs/Pages/Home.razor
+++ b/docs/Lumeo.Docs/Pages/Home.razor
@@ -423,13 +423,11 @@
                  RowSpan=2 so the globe fills a tall tile next to the PdfViewer
                  row, and Zoom=2 so the sphere itself takes more of the canvas
                  instead of floating tiny in the middle.
-                 `hidden lg:flex` keeps the entire tile out of the DOM layout
-                 on mobile/tablet — LazyRender's IntersectionObserver never
-                 fires for display:none placeholders, so MapLibre GL JS
-                 (~250 KB) is not downloaded on phones where the globe would
-                 be unusably small anyway. -->
-            <BentoTile Span="2" RowSpan="2" Class="border-border/60 p-0 overflow-hidden hidden lg:flex">
-                <div class="flex h-full flex-col overflow-hidden">
+                 Mobile gets a clamped 320 px tile (down from desktop's ~560 px)
+                 so the globe is visible but doesn't dominate the page. The
+                 heavy MapLibre bundle still defers via LazyRender. -->
+            <BentoTile Span="2" RowSpan="2" Class="border-border/60 p-0 overflow-hidden">
+                <div class="flex flex-col overflow-hidden h-[320px] lg:h-full">
                     <div class="flex-1 min-h-0 relative overflow-hidden">
                         <LazyRender Height="100%">
                             <Map Center="(20.0, 10.0)" Zoom="2" Height="100%" TileLayer="DarkMatter" Projection="globe">
@@ -463,11 +461,12 @@
             <!-- Charts — three live ECharts stacked vertically (Bar / Line /
                  Area), datasets reshuffle every ~2s in sync. Hover pauses.
                  RowSpan=2 so each chart gets ~240px height. No Pie/Donut.
-                 Hidden on mobile: three ECharts re-rendering every 2 s pegs
-                 the main thread on phones, and at 1-col width the labels
-                 collide. Desktop visitors see the showcase intact. -->
-            <BentoTile Span="2" RowSpan="2" Class="border-border/60 p-0 overflow-hidden hidden lg:flex">
-                <div class="flex h-full flex-col overflow-hidden" @onmouseenter="@(() => _chartHovered = true)" @onmouseleave="@(() => _chartHovered = false)">
+                 Mobile gets a clamped 360 px tile so all three charts still
+                 fit without dominating the page. ECharts handles narrow
+                 viewports gracefully thanks to the chart container's
+                 ResizeObserver. -->
+            <BentoTile Span="2" RowSpan="2" Class="border-border/60 p-0 overflow-hidden">
+                <div class="flex flex-col overflow-hidden h-[360px] lg:h-full" @onmouseenter="@(() => _chartHovered = true)" @onmouseleave="@(() => _chartHovered = false)">
                     <div class="flex-1 min-h-0 grid grid-rows-3 gap-2 p-3 bg-muted/10">
                         <div class="rounded-md border border-border/40 bg-card/60 p-2 min-h-0 overflow-hidden">
                             <BarChart Categories="_barCategories" Series="_barSeries" Stacked="true" Height="100%" ShowLoadingSkeleton="false" />
@@ -496,11 +495,11 @@
                  (not max-height) so the PdfViewer's `h-full` resolves to a real
                  number; without that, its inner `flex-1 overflow-auto` document
                  area has no upper bound and the canvas can't scroll when zoomed in.
-                 Hidden on mobile: pdf.js + its worker (~150 KB) plus the PDF
-                 download itself would crater LCP on a phone, and the viewer
-                 chrome is unusable at narrow widths. -->
-            <BentoTile Span="2" Class="border-border/60 p-0 overflow-hidden hidden lg:flex">
-                <div class="flex flex-col overflow-hidden" style="height:560px">
+                 Mobile gets a tighter 380 px tile so the PDF surface is browsable
+                 without taking up two phone screens. LazyRender keeps pdf.js out
+                 of the bundle until the tile is on screen. -->
+            <BentoTile Span="2" Class="border-border/60 p-0 overflow-hidden">
+                <div class="flex flex-col overflow-hidden h-[380px] lg:h-[560px]">
                     <div class="flex-1 min-h-0 overflow-hidden">
                         <LazyRender Height="100%">
                             <PdfViewer Src="https://mozilla.github.io/pdf.js/web/compressed.tracemonkey-pldi-09.pdf"

--- a/src/Lumeo/UI/Bento/Bento.razor
+++ b/src/Lumeo/UI/Bento/Bento.razor
@@ -38,20 +38,23 @@
     {
         get
         {
-            // grid-auto-rows: 1fr keeps every row the same height so short-content tiles don't
-            // shrink and tall-content tiles don't overlap their neighbors when row spans differ.
-            var baseStyle = "grid-auto-rows: minmax(0, 1fr);";
+            // Non-standard column count — fall back to inline grid-template-columns
+            // without responsive breakpoints. (Inline styles can't carry media queries.)
             if (string.IsNullOrEmpty(ColumnsClass))
             {
-                // Non-standard column count — fall back to inline grid-template-columns
-                // without responsive breakpoints. (Inline styles can't carry media queries.)
-                baseStyle += $" grid-template-columns: repeat({Columns}, minmax(0, 1fr));";
+                return $"grid-template-columns: repeat({Columns}, minmax(0, 1fr));";
             }
-            return baseStyle;
+            return string.Empty;
         }
     }
 
-    private string RootClasses => $"grid {ColumnsClass} {GapClass} {Class}".Trim();
+    // `lg:auto-rows-fr` is what keeps mixed-RowSpan tiles aligned on desktop —
+    // every row resolves to the same fr unit so a Span=2 RowSpan=2 tile is
+    // exactly twice as tall as a single tile. On mobile we deliberately let
+    // rows size to content (`auto-rows-auto`); otherwise a stack of short
+    // KPI cards inherits the height of the tallest possible row and every
+    // stat turns into a full-screen monster on a phone.
+    private string RootClasses => $"grid {ColumnsClass} {GapClass} auto-rows-auto lg:auto-rows-fr {Class}".Trim();
 
     public enum BentoGap { Sm, Md, Lg }
 }

--- a/src/Lumeo/wwwroot/js/components.js
+++ b/src/Lumeo/wwwroot/js/components.js
@@ -29,6 +29,102 @@ const _clickOutsideHandler = (e) => {
 document.addEventListener('mousedown', _clickOutsideHandler);
 document.addEventListener('touchstart', _clickOutsideHandler, { passive: true });
 
+// ----------------------------------------------------------------------------
+// Touch-to-drag polyfill. iOS Safari and Android Chrome do not fire dragstart /
+// dragover / drop for `draggable="true"` elements on touch input, so every
+// Blazor `@ondragstart` / `@ondrop` handler is silently desktop-only.
+//
+// This shim synthesises the HTML5 drag-and-drop event sequence from touch
+// events so any [draggable="true"] element in a Lumeo (or consumer) page works
+// the same on phone as on desktop. Active on the document — single-finger
+// drags only; multitouch is left alone for pinch-zoom etc.
+//
+// Behaviour:
+//   touchstart on a draggable → record source, wait for movement (dead-zone)
+//   first touchmove past 8 px → dispatch `dragstart` on source
+//   subsequent touchmoves     → dispatch `dragenter`/`dragleave`/`dragover`
+//                               on the element under the finger
+//   touchend                  → dispatch `drop` on that element, then
+//                               `dragend` on the source
+//
+// Targets receive plain `Event` instances (not real `DragEvent`s). Blazor's
+// `DragEventArgs` will carry empty DataTransfer, which is fine for the typical
+// "remember which card is being dragged in C#" pattern. If you need real
+// DataTransfer payloads on mobile, opt out via `data-no-touch-drag="true"`.
+// ----------------------------------------------------------------------------
+const TOUCH_DRAG_DEAD_ZONE_PX = 8;
+let _touchDragSource = null;
+
+const _onTouchDragMove = (e) => {
+    if (!_touchDragSource || e.touches.length !== 1) return;
+    const t = e.touches[0];
+    const dx = t.clientX - _touchDragSource.startX;
+    const dy = t.clientY - _touchDragSource.startY;
+
+    if (!_touchDragSource.started) {
+        if (Math.hypot(dx, dy) < TOUCH_DRAG_DEAD_ZONE_PX) return;
+        _touchDragSource.started = true;
+        _touchDragSource.element.dispatchEvent(new Event('dragstart', { bubbles: true, cancelable: true }));
+    }
+
+    // Stop the page from scrolling while a drag is in progress. We only call
+    // preventDefault after the dead-zone is crossed so light taps and short
+    // intentional scrolls aren't hijacked.
+    e.preventDefault();
+
+    const over = document.elementFromPoint(t.clientX, t.clientY);
+    if (over !== _touchDragSource.lastOver) {
+        if (_touchDragSource.lastOver) {
+            _touchDragSource.lastOver.dispatchEvent(new Event('dragleave', { bubbles: true }));
+        }
+        if (over) {
+            over.dispatchEvent(new Event('dragenter', { bubbles: true }));
+        }
+        _touchDragSource.lastOver = over;
+    }
+    if (over) {
+        over.dispatchEvent(new Event('dragover', { bubbles: true, cancelable: true }));
+    }
+};
+
+const _onTouchDragEnd = (e) => {
+    if (!_touchDragSource) return;
+    if (_touchDragSource.started) {
+        const t = e.changedTouches && e.changedTouches[0];
+        const dropTarget = t ? document.elementFromPoint(t.clientX, t.clientY) : null;
+        if (dropTarget) {
+            dropTarget.dispatchEvent(new Event('drop', { bubbles: true, cancelable: true }));
+        }
+        _touchDragSource.element.dispatchEvent(new Event('dragend', { bubbles: true }));
+    }
+    document.removeEventListener('touchmove', _onTouchDragMove, { passive: false });
+    document.removeEventListener('touchend', _onTouchDragEnd);
+    document.removeEventListener('touchcancel', _onTouchDragEnd);
+    _touchDragSource = null;
+};
+
+document.addEventListener('touchstart', (e) => {
+    if (e.touches.length !== 1) return;
+    const t = e.touches[0];
+    const target = (t.target instanceof Element) ? t.target : null;
+    if (!target) return;
+    const src = target.closest('[draggable="true"]');
+    if (!src) return;
+    if (src.closest('[data-no-touch-drag="true"]')) return;
+
+    _touchDragSource = {
+        element: src,
+        startX: t.clientX,
+        startY: t.clientY,
+        started: false,
+        lastOver: null,
+    };
+    // touchmove must be non-passive so we can preventDefault once the drag starts.
+    document.addEventListener('touchmove', _onTouchDragMove, { passive: false });
+    document.addEventListener('touchend', _onTouchDragEnd, { passive: true });
+    document.addEventListener('touchcancel', _onTouchDragEnd, { passive: true });
+}, { passive: true });
+
 export function registerClickOutside(elementId, triggerElementId, dotnetRef) {
     clickOutsideHandlers.set(elementId, { triggerElementId, dotnetRef });
 }

--- a/tests/Lumeo.Tests/Components/Bento/BentoTests.cs
+++ b/tests/Lumeo.Tests/Components/Bento/BentoTests.cs
@@ -97,14 +97,18 @@ public class BentoTests : IAsyncLifetime
     }
 
     [Fact]
-    public void Grid_Auto_Rows_Inline_Style_Is_Present()
+    public void Grid_Auto_Rows_Equalises_Tile_Height_On_Desktop()
     {
-        // Bento swapped `container-type: inline-size` for `grid-auto-rows: minmax(0, 1fr)` so mixed
-        // RowSpan tiles stay aligned — every row gets the same fr unit and short-content tiles don't
-        // collapse to their minimum height.
+        // Mixed-RowSpan tiles need equal fr-unit rows so a `RowSpan=2` tile is
+        // exactly twice as tall as a single tile. We apply this only at the
+        // lg: breakpoint — on mobile every tile sizes to content, otherwise
+        // short KPI cards inherit the height of the tallest possible row and
+        // each stat fills the entire phone viewport.
         var cut = _ctx.Render<Lumeo.Bento>();
 
-        Assert.Contains("grid-auto-rows: minmax(0, 1fr)", cut.Find("div").GetAttribute("style"));
+        var cls = cut.Find("div").GetAttribute("class");
+        Assert.Contains("auto-rows-auto", cls);
+        Assert.Contains("lg:auto-rows-fr", cls);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Real-device review of the previous mobile pass surfaced three concrete issues. This PR fixes all three.

### 1. Stat cards span the entire phone viewport
`Bento` applied `grid-auto-rows: minmax(0, 1fr)` unconditionally as an inline style. On desktop that's the right behaviour — mixed-`RowSpan` tiles stay perfectly aligned. On a 1-column mobile stack every row inherits the height of the tallest possible row, so each KPI card (`Tests 2,194`, `Locales 14`, `Themes 8`, `Compliance WCAG AA`) filled the whole screen.

**Fix:** auto-rows-fr only applies at the `lg:` breakpoint via `lg:auto-rows-fr`. Mobile uses `auto-rows-auto` so each tile sizes to its actual content.

### 2. Restore Map / PdfViewer / Live Charts on mobile
The previous PR hid these three tiles with `hidden lg:flex` purely as a bytes-saving measure. The showcase is interesting enough on mobile that the right tradeoff is to *show* them — `LazyRender`'s `IntersectionObserver` still keeps MapLibre / pdf.js / ECharts out of the bundle until the user actually scrolls them on screen.

**Fix:** removed the `hidden lg:flex` gating. Each tile now has a clamped mobile height so it's visible without taking over the page:

| Tile | Mobile height | Desktop height |
| --- | --- | --- |
| Map (Globe) | 320 px | full grid row |
| PdfViewer | 380 px | 560 px |
| Live Charts | 360 px | full grid row |

### 3. Kanban drag-and-drop doesn't work on touch devices
HTML5 `draggable="true"` never fires `dragstart` / `drop` events on iOS Safari or Android Chrome. Any Blazor `@ondragstart` / `@ondrop` binding is silently desktop-only — Kanban being the obvious case, but the same restriction applies anywhere a consumer wires up HTML5 D&D inside a Lumeo app.

**Fix:** added a tiny touch-to-drag polyfill at the top of `components.js` that synthesises the full HTML5 drag sequence from touch events:

- `touchstart` on `[draggable="true"]` → record source, wait for movement
- First `touchmove` past an 8 px dead-zone → dispatch `dragstart`
- Subsequent `touchmove` → dispatch `dragenter` / `dragleave` / `dragover` on the element under the finger
- `touchend` → dispatch `drop` on that element, then `dragend` on the source

Works automatically for every `[draggable="true"]` element in Lumeo or consumer code. Opt out with `data-no-touch-drag="true"` if you genuinely need native `DragEvent` semantics (real `DataTransfer` payloads etc.). The Kanban demo case — "remember which card is being dragged in C# state" — works because both the wrapper `<div draggable="true">` and the column drop zone bind plain `@ondragstart` / `@ondrop` and read no event-specific data.

## Test plan

- [ ] Phone: scroll the homepage — Tests / Locales / Themes / Compliance cards are content-height, not full-screen
- [ ] Phone: Globe, PDF viewer, and Live Charts tiles all render at sensible heights
- [ ] Phone: in the Kanban demo, long-press-and-drag a card from "To do" to "In progress" — the card moves
- [ ] Desktop: layout unchanged from prior PR — `lg:auto-rows-fr` preserves the aligned multi-row grid, drag works as before
- [ ] DevTools network on mobile: confirm MapLibre / pdf.js / ECharts only load when the respective tile scrolls into view
- [ ] `BentoTests.Grid_Auto_Rows_Equalises_Tile_Height_On_Desktop` passes (replaces the inline-style assertion)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XMy2ZxQDK3fAPw766fAc19)_