### PR TITLE
chore: bump to 3.2.1 — mobile fixes

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
   <!-- Lockstep version shared by all Lumeo packages.
        Update this single property to version all packages in unison. -->
   <PropertyGroup>
-    <Version>3.2.0</Version>
+    <Version>3.2.1</Version>
   </PropertyGroup>
 
   <!-- Shared NuGet README packing lives in Directory.Build.targets, NOT here.

--- a/docs/Lumeo.Docs/Pages/Docs/Changelog.razor
+++ b/docs/Lumeo.Docs/Pages/Docs/Changelog.razor
@@ -15,6 +15,43 @@
 
     <Separator Class="my-4" />
 
+    <!-- v3.2.1 -->
+    <Stack Gap="4">
+        <div class="flex items-center gap-3">
+            <Badge>v3.2.1</Badge>
+            <Lumeo.Text Size="sm" Color="muted">May 2026</Lumeo.Text>
+        </div>
+
+        <Lumeo.Text Size="base" Color="muted" Leading="relaxed">
+            Mobile-readiness patch. The docs site was unusable on phones — root cause was the same in any consumer app using <code class="rounded bg-muted px-1 text-xs">Bento</code> or HTML5 drag. Three fixes, no API changes.
+        </Lumeo.Text>
+
+        <Stack Gap="3">
+            <Heading Level="3" Size="sm" Class="font-semibold">Bento (core)</Heading>
+            <ul class="space-y-1.5 text-sm list-disc list-inside text-muted-foreground">
+                <li><strong>Responsive column collapse.</strong> <code class="rounded bg-muted px-1 text-xs">Bento Columns="4"</code> now renders as 1 column on mobile (&lt; 640 px), 2 columns at <code class="rounded bg-muted px-1 text-xs">sm:</code>, and the configured count at <code class="rounded bg-muted px-1 text-xs">lg:</code>. Previously the grid stayed at 4 narrow columns on a phone, squashing every embedded component.</li>
+                <li><strong>BentoTile span + row-span at lg: only.</strong> Wide and tall tiles ( <code class="rounded bg-muted px-1 text-xs">Span="2" RowSpan="2"</code>) collapse to a single-cell tile on mobile so they don't punch holes in the 1-column stack. Behaviour at <code class="rounded bg-muted px-1 text-xs">lg:</code> is unchanged. Implementation moved from inline <code class="rounded bg-muted px-1 text-xs">grid-column: span N</code> styles to literal Tailwind <code class="rounded bg-muted px-1 text-xs">col-span-* / row-span-*</code> classes so they can be media-queried.</li>
+                <li><strong>Auto-rows-fr at lg: only.</strong> The "every row the same fr unit" rule that keeps mixed-RowSpan tiles aligned only applies on desktop. On mobile each tile sizes to its actual content, so short KPI cards stay short instead of inheriting the height of the tallest possible row.</li>
+            </ul>
+        </Stack>
+
+        <Stack Gap="3">
+            <Heading Level="3" Size="sm" Class="font-semibold">JS interop (core)</Heading>
+            <ul class="space-y-1.5 text-sm list-disc list-inside text-muted-foreground">
+                <li><strong>Touch drag-and-drop polyfill.</strong> iOS Safari and Android Chrome never fire <code class="rounded bg-muted px-1 text-xs">dragstart</code> / <code class="rounded bg-muted px-1 text-xs">drop</code> events for <code class="rounded bg-muted px-1 text-xs">draggable="true"</code> elements, so every Blazor <code class="rounded bg-muted px-1 text-xs">@@ondragstart</code> / <code class="rounded bg-muted px-1 text-xs">@@ondrop</code> binding (Kanban being the visible case) was silently desktop-only. A tiny shim in <code class="rounded bg-muted px-1 text-xs">components.js</code> now synthesises the full HTML5 drag sequence from touch events with an 8 px dead-zone. Opt out per element with <code class="rounded bg-muted px-1 text-xs">data-no-touch-drag="true"</code> if you genuinely need native <code class="rounded bg-muted px-1 text-xs">DragEvent</code> semantics.</li>
+            </ul>
+        </Stack>
+
+        <Stack Gap="3">
+            <Heading Level="3" Size="sm" Class="font-semibold">Docs</Heading>
+            <ul class="space-y-1.5 text-sm list-disc list-inside text-muted-foreground">
+                <li><strong>Home page mobile polish.</strong> Map (globe), PdfViewer and live Charts tiles get clamped mobile heights so they're visible without taking over the viewport. <code class="rounded bg-muted px-1 text-xs">LazyRender</code> still keeps MapLibre / pdf.js / ECharts out of the bundle until each tile scrolls on screen.</li>
+            </ul>
+        </Stack>
+    </Stack>
+
+    <Separator Class="my-4" />
+
     <!-- v3.2.0 -->
     <Stack Gap="4">
         <div class="flex items-center gap-3">


### PR DESCRIPTION
## Summary

Patch release covering the three post-3.2.0 mobile-readiness fixes that are already on `master`:

* `Bento` responsive column collapse + `Span`/`RowSpan` applied only at `lg:` (PR #34)
* `auto-rows-fr` applied only at `lg:` so KPI tiles size to content on mobile (PR #35)
* Touch-to-drag polyfill in `components.js` so `[draggable="true"]` works on iOS Safari and Android Chrome (PR #35)

No new public API surface; drop-in upgrade from 3.2.0.

## Test plan

- [ ] CI green
- [ ] After merge: owner says "tag it" → I create `v3.2.1` annotated tag and push; the existing `publish.yml` workflow handles NuGet publish + GitHub release.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XMy2ZxQDK3fAPw766fAc19)_