### PR TITLE
fix(docs): map view persistence, touch drag-action, chart polish, PdfViewer doc

### DIFF
--- a/docs/Lumeo.Docs/Pages/Components/PdfViewerPage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/PdfViewerPage.razor
@@ -109,7 +109,71 @@
                    Class="h-[600px]" />
     </ComponentDemo>
 
+    <ComponentDemo Title="Controlled — header reports state + jump to page" Code="@_controlledCode">
+        <Stack Gap="3">
+            <Flex Align="center" Justify="between" Wrap="true" Gap="3" Class="rounded-md border border-border/40 bg-muted/30 px-4 py-2.5">
+                <Lumeo.Text Size="sm" Color="muted">
+                    Page <Lumeo.Text As="span" Color="foreground" Weight="semibold">@_ctrlPage</Lumeo.Text>
+                    of <Lumeo.Text As="span" Color="foreground" Weight="semibold">@_ctrlTotal</Lumeo.Text>
+                    &middot; zoom <Lumeo.Text As="span" Color="foreground" Weight="semibold">@($"{(int)Math.Round(_ctrlZoom * 100)}%")</Lumeo.Text>
+                </Lumeo.Text>
+                <Flex Align="center" Gap="2">
+                    <Button Variant="Button.ButtonVariant.Outline" Size="Button.ButtonSize.Sm" OnClick="@(() => _ctrlPage = 1)" Disabled="@(_ctrlPage == 1)">First</Button>
+                    <Button Variant="Button.ButtonVariant.Outline" Size="Button.ButtonSize.Sm" OnClick="@(() => _ctrlPage = Math.Max(1, _ctrlTotal))" Disabled="@(_ctrlPage == _ctrlTotal)">Last</Button>
+                    <Button Variant="Button.ButtonVariant.Outline" Size="Button.ButtonSize.Sm" OnClick="@(() => _ctrlZoom = 1.0)">Reset zoom</Button>
+                </Flex>
+            </Flex>
+            <PdfViewer Src="@SamplePdfUrl"
+                       @bind-Page="_ctrlPage"
+                       @bind-Zoom="_ctrlZoom"
+                       OnLoaded="@((t) => _ctrlTotal = t)"
+                       ShowSearch="true"
+                       Class="h-[500px]" />
+        </Stack>
+    </ComponentDemo>
+
 </Stack>
+
+<div class="mt-12 space-y-3">
+    <Heading Id="self-hosting" Level="2" Class="scroll-mt-20">Self-hosting pdf.js</Heading>
+    <Lumeo.Text Size="sm" Color="muted">
+        By default the viewer lazy-loads <Code>pdf.js</Code> + its worker from jsDelivr the
+        first time a <Code>PdfViewer</Code> mounts. That's the right tradeoff for low-traffic
+        apps and demos, but it doesn't work behind a strict CSP, on an air-gapped intranet,
+        or in compliance scenarios where every third-party script call is a no-go.
+    </Lumeo.Text>
+    <Lumeo.Text Size="sm" Color="muted">
+        The Lumeo CLI ships a one-shot installer that vendors <Code>pdf.js</Code> into
+        <Code>wwwroot/lib/lumeo-vendor/</Code> and wires up
+        <Code>window.lumeoCdn</Code> so the runtime loads from your own origin instead of
+        the CDN:
+    </Lumeo.Text>
+    <div class="rounded-lg overflow-hidden ring-1 ring-border/40" style="background-color: #0a0a0a;">
+        <div class="flex items-center justify-between px-3 py-2 border-b" style="border-color: rgba(255,255,255,0.08);">
+            <div class="flex items-center gap-1.5">
+                <span class="h-2.5 w-2.5 rounded-full" style="background-color: #ff5f56;"></span>
+                <span class="h-2.5 w-2.5 rounded-full" style="background-color: #ffbd2e;"></span>
+                <span class="h-2.5 w-2.5 rounded-full" style="background-color: #27c93f;"></span>
+            </div>
+            <span class="font-mono text-[10px]" style="color: rgba(255,255,255,0.55);">bash</span>
+        </div>
+<pre class="font-mono text-[12px] leading-relaxed whitespace-pre overflow-x-auto px-4 py-3 m-0" style="color: #e4e4e7;"><span style="color: #64748b;"># 1. Install the Lumeo CLI as a global dotnet tool</span>
+<span style="color: #27c93f;">$</span> <span style="color: #60a5fa;">dotnet</span> tool install -g <span style="color: #fbbf24;">Lumeo.Cli</span>
+
+<span style="color: #64748b;"># 2. Vendor pdf.js into wwwroot/lib/lumeo-vendor/ and write the bootstrap</span>
+<span style="color: #27c93f;">$</span> <span style="color: #60a5fa;">lumeo</span> deps install --lib pdfjs --write-bootstrap
+
+<span style="color: #64748b;"># 3. Include the bootstrap before _content/Lumeo.PdfViewer/js/* in index.html</span>
+<span style="color: #64748b;">#    &lt;script src="js/lumeo-cdn-init.js"&gt;&lt;/script&gt;</span></pre>
+    </div>
+    <Lumeo.Text Size="sm" Color="muted">
+        See <Lumeo.Link Href="docs/cdn-deps">CDN dependencies</Lumeo.Link> for the full list
+        of self-hostable libraries and the <Code>window.lumeoCdn</Code> override surface.
+        For more granular control (custom URL, integrity hash, alternative CDN) you can
+        set <Code>window.lumeoCdn = { pdfJs: "/my/cdn/pdf.min.mjs", pdfJsWorker: "/my/cdn/pdf.worker.min.mjs" };</Code>
+        before the first <Code>PdfViewer</Code> mounts.
+    </Lumeo.Text>
+</div>
 
 <div class="mt-16">
     <Heading Id="api-reference" Level="2" Class="scroll-mt-20">API Reference</Heading>
@@ -275,6 +339,12 @@
     private int _totalPages;
     private string? _errorMessage;
 
+    // Controlled-demo state — page + zoom owned by the parent, surfaced in the
+    // header strip, and jumped via "First" / "Last" / "Reset zoom" buttons.
+    private int _ctrlPage = 1;
+    private double _ctrlZoom = 1.0;
+    private int _ctrlTotal = 1;
+
     private void HandleLoaded(int total) => _totalPages = total;
     private void HandleError(string msg) => _errorMessage = msg;
 
@@ -375,4 +445,31 @@
            Zoom="1.5"
            Class="h-[600px]" />
 """;
+
+    private const string _controlledCode = """
+<Flex Align="center" Justify="between" Class="rounded-md border bg-muted/30 px-4 py-2.5">
+    <Lumeo.Text Size="sm">
+        Page @_page of @_total &middot; zoom @($"{(int)Math.Round(_zoom * 100)}%")
+    </Lumeo.Text>
+    <Flex Gap="2">
+        <Button Size="Sm" OnClick="@(() => _page = 1)" Disabled="@(_page == 1)">First</Button>
+        <Button Size="Sm" OnClick="@(() => _page = _total)" Disabled="@(_page == _total)">Last</Button>
+        <Button Size="Sm" OnClick="@(() => _zoom = 1.0)">Reset zoom</Button>
+    </Flex>
+</Flex>
+
+<PdfViewer Src="@_pdfUrl"
+           @bind-Page="_page"
+           @bind-Zoom="_zoom"
+           OnLoaded="@(t => _total = t)"
+           ShowSearch="true"
+           Class="h-[500px]" />
+
+@code {
+    private int _page = 1;
+    private double _zoom = 1.0;
+    private int _total = 1;
+}
+""";
+
 }

--- a/docs/Lumeo.Docs/Pages/Home.razor
+++ b/docs/Lumeo.Docs/Pages/Home.razor
@@ -427,10 +427,10 @@
                  so the globe is visible but doesn't dominate the page. The
                  heavy MapLibre bundle still defers via LazyRender. -->
             <BentoTile Span="2" RowSpan="2" Class="border-border/60 p-0 overflow-hidden">
-                <div class="flex flex-col overflow-hidden h-[320px] lg:h-full">
+                <div class="flex flex-col overflow-hidden h-[440px] lg:h-full">
                     <div class="flex-1 min-h-0 relative overflow-hidden">
                         <LazyRender Height="100%">
-                            <Map Center="(20.0, 10.0)" Zoom="2" Height="100%" TileLayer="DarkMatter" Projection="globe">
+                            <Map @bind-Center="_mapCenter" @bind-Zoom="_mapZoom" Height="100%" TileLayer="DarkMatter" Projection="globe">
                                 <ChildContent>
                                     <MapMarker Lat="51.5074" Lon="-0.1278"  Title="London"     Variant="Dot" Color="teal" Label="London" />
                                     <MapMarker Lat="40.7128" Lon="-74.0060" Title="New York"   Variant="Dot" Color="teal" Label="New York" />
@@ -445,14 +445,14 @@
                             </Map>
                         </LazyRender>
                     </div>
-                    <Flex Align="center" Justify="between" Class="border-t border-border/40 px-4 py-2.5">
-                        <Flex Align="center" Gap="2">
-                            <DynamicIcon Name="Globe" Class="h-4 w-4 text-primary" />
-                            <Lumeo.Text Size="xs" Weight="semibold">Map · Globe projection</Lumeo.Text>
-                            <Badge Variant="Badge.BadgeVariant.Outline" Class="text-[10px] h-4 ml-1">Lumeo.Maps</Badge>
+                    <Flex Align="center" Justify="between" Gap="2" Class="border-t border-border/40 px-4 py-2.5 min-w-0">
+                        <Flex Align="center" Gap="2" Class="min-w-0">
+                            <DynamicIcon Name="Globe" Class="h-4 w-4 text-primary shrink-0" />
+                            <Lumeo.Text Size="xs" Weight="semibold" Class="truncate">Map · Globe projection</Lumeo.Text>
+                            <Badge Variant="Badge.BadgeVariant.Outline" Class="hidden sm:inline-flex text-[10px] h-4 ml-1 shrink-0">Lumeo.Maps</Badge>
                         </Flex>
-                        <Lumeo.Link Href="components/map" Class="text-xs text-muted-foreground hover:text-foreground flex items-center gap-1 no-underline">
-                            View docs <DynamicIcon Name="ArrowRight" Class="h-3 w-3" />
+                        <Lumeo.Link Href="components/map" Class="text-xs text-muted-foreground hover:text-foreground flex items-center gap-1 no-underline whitespace-nowrap shrink-0">
+                            <Lumeo.Text As="span" Class="hidden sm:inline">View docs</Lumeo.Text><DynamicIcon Name="ArrowRight" Class="h-3 w-3" />
                         </Lumeo.Link>
                     </Flex>
                 </div>
@@ -466,7 +466,7 @@
                  viewports gracefully thanks to the chart container's
                  ResizeObserver. -->
             <BentoTile Span="2" RowSpan="2" Class="border-border/60 p-0 overflow-hidden">
-                <div class="flex flex-col overflow-hidden h-[360px] lg:h-full" @onmouseenter="@(() => _chartHovered = true)" @onmouseleave="@(() => _chartHovered = false)">
+                <div class="flex flex-col overflow-hidden h-[620px] lg:h-full" @onmouseenter="@(() => _chartHovered = true)" @onmouseleave="@(() => _chartHovered = false)">
                     <div class="flex-1 min-h-0 grid grid-rows-3 gap-2 p-3 bg-muted/10">
                         <div class="rounded-md border border-border/40 bg-card/60 p-2 min-h-0 overflow-hidden">
                             <BarChart Categories="_barCategories" Series="_barSeries" Stacked="true" Height="100%" ShowLoadingSkeleton="false" />
@@ -478,14 +478,14 @@
                             <RadarChart Indicators="_radarIndicators" Series="_radarSeries" Height="100%" ShowLegend="false" ShowLoadingSkeleton="false" />
                         </div>
                     </div>
-                    <Flex Align="center" Justify="between" Class="border-t border-border/40 px-4 py-2.5">
-                        <Flex Align="center" Gap="2">
-                            <DynamicIcon Name="BarChart3" Class="h-4 w-4 text-primary" />
-                            <Lumeo.Text Size="xs" Weight="semibold">Charts · Bar · Line · Radar</Lumeo.Text>
-                            <Badge Variant="Badge.BadgeVariant.Outline" Class="text-[10px] h-4 ml-1">Lumeo.Charts</Badge>
+                    <Flex Align="center" Justify="between" Gap="2" Class="border-t border-border/40 px-4 py-2.5 min-w-0">
+                        <Flex Align="center" Gap="2" Class="min-w-0">
+                            <DynamicIcon Name="BarChart3" Class="h-4 w-4 text-primary shrink-0" />
+                            <Lumeo.Text Size="xs" Weight="semibold" Class="truncate">Charts · Bar · Line · Radar</Lumeo.Text>
+                            <Badge Variant="Badge.BadgeVariant.Outline" Class="hidden sm:inline-flex text-[10px] h-4 ml-1 shrink-0">Lumeo.Charts</Badge>
                         </Flex>
-                        <Lumeo.Link Href="components/charts/bar" Class="text-xs text-muted-foreground hover:text-foreground flex items-center gap-1 no-underline">
-                            View docs <DynamicIcon Name="ArrowRight" Class="h-3 w-3" />
+                        <Lumeo.Link Href="components/charts/bar" Class="text-xs text-muted-foreground hover:text-foreground flex items-center gap-1 no-underline whitespace-nowrap shrink-0">
+                            <Lumeo.Text As="span" Class="hidden sm:inline">View docs</Lumeo.Text><DynamicIcon Name="ArrowRight" Class="h-3 w-3" />
                         </Lumeo.Link>
                     </Flex>
                 </div>
@@ -506,14 +506,14 @@
                                        Page="1" Zoom="0.5" ShowSearch="true" ShowDownload="false" Class="h-full" />
                         </LazyRender>
                     </div>
-                    <Flex Align="center" Justify="between" Class="border-t border-border/40 px-4 py-2.5">
-                        <Flex Align="center" Gap="2">
-                            <DynamicIcon Name="FileText" Class="h-4 w-4 text-primary" />
-                            <Lumeo.Text Size="xs" Weight="semibold">PdfViewer · Search + Highlight</Lumeo.Text>
-                            <Badge Variant="Badge.BadgeVariant.Outline" Class="text-[10px] h-4 ml-1">Lumeo.PdfViewer</Badge>
+                    <Flex Align="center" Justify="between" Gap="2" Class="border-t border-border/40 px-4 py-2.5 min-w-0">
+                        <Flex Align="center" Gap="2" Class="min-w-0">
+                            <DynamicIcon Name="FileText" Class="h-4 w-4 text-primary shrink-0" />
+                            <Lumeo.Text Size="xs" Weight="semibold" Class="truncate">PdfViewer · Search + Highlight</Lumeo.Text>
+                            <Badge Variant="Badge.BadgeVariant.Outline" Class="hidden sm:inline-flex text-[10px] h-4 ml-1 shrink-0">Lumeo.PdfViewer</Badge>
                         </Flex>
-                        <Lumeo.Link Href="components/pdf-viewer" Class="text-xs text-muted-foreground hover:text-foreground flex items-center gap-1 no-underline">
-                            View docs <DynamicIcon Name="ArrowRight" Class="h-3 w-3" />
+                        <Lumeo.Link Href="components/pdf-viewer" Class="text-xs text-muted-foreground hover:text-foreground flex items-center gap-1 no-underline whitespace-nowrap shrink-0">
+                            <Lumeo.Text As="span" Class="hidden sm:inline">View docs</Lumeo.Text><DynamicIcon Name="ArrowRight" Class="h-3 w-3" />
                         </Lumeo.Link>
                     </Flex>
                 </div>
@@ -1084,6 +1084,14 @@ builder.Services.<span style="color: #a78bfa;">AddLumeo</span>();</pre>
 </footer>
 
 @code {
+    // Map view state — two-way bound so the user's pan / zoom survives the
+    // chart tile's 2 s StateHasChanged ticks. Without `@bind-Center`/`@bind-Zoom`
+    // every re-render would resubmit the literal Center/Zoom parameter values
+    // and the Map's "did the parameter change?" guard would call setCenter()
+    // back to the original view, undoing every pan the user just made.
+    private (double Lat, double Lon) _mapCenter = (20.0, 10.0);
+    private int _mapZoom = 2;
+
     private bool _switchOn = true;
     private double _sliderVal = 62;
     private bool _togglePressed;
@@ -1462,7 +1470,7 @@ builder.Services.<span style="color: #a78bfa;">AddLumeo</span>();</pre>
                 for (int i = 0; i < _barSeries.Count && i < snap.Length; i++)
                     _barSeries[i].Values = new List<double>(snap[i]);
                 // Line — first stripe of the snapshot, scaled down so the axis stays readable.
-                _lineSeries[0].Values = snap[0].Select(v => v / 12d).ToList();
+                _lineSeries[0].Values = snap[0].Select(v => Math.Round(v / 12d)).ToList();
                 // Radar — second stripe normalised into 0–100 range per axis so
                 // the polygon morphs visibly without collapsing.
                 var raw = snap[1];

--- a/src/Lumeo/wwwroot/js/components.js
+++ b/src/Lumeo/wwwroot/js/components.js
@@ -30,6 +30,24 @@ document.addEventListener('mousedown', _clickOutsideHandler);
 document.addEventListener('touchstart', _clickOutsideHandler, { passive: true });
 
 // ----------------------------------------------------------------------------
+// touch-action: none on every [draggable="true"] element. Without this, the
+// mobile browser commits to a vertical-scroll interpretation of the touch
+// gesture before our touchmove listener can call preventDefault, so the
+// polyfill below never gets a chance to take over. We do it from JS rather
+// than CSS so consumer apps that already ship a Lumeo CSS bundle pick it up
+// automatically without having to add a global rule. Opt out with
+// `data-no-touch-drag="true"` on the element itself or any ancestor.
+(function injectDraggableTouchActionStyle() {
+    if (document.getElementById('lumeo-draggable-touch-action')) return;
+    const style = document.createElement('style');
+    style.id = 'lumeo-draggable-touch-action';
+    style.textContent =
+        '[draggable="true"]:not([data-no-touch-drag="true"]):not([data-no-touch-drag="true"] *) ' +
+        '{ touch-action: none; -webkit-user-select: none; user-select: none; }';
+    (document.head || document.documentElement).appendChild(style);
+})();
+
+// ----------------------------------------------------------------------------
 // Touch-to-drag polyfill. iOS Safari and Android Chrome do not fire dragstart /
 // dragover / drop for `draggable="true"` elements on touch input, so every
 // Blazor `@ondragstart` / `@ondrop` handler is silently desktop-only.


### PR DESCRIPTION
## Summary

Follow-up to 3.2.1 — real-device review of the live home page surfaced four more issues.

### 1. Map auto-resets every ~2 s
The home page's chart-tile timer fires `StateHasChanged` every 2 s, which re-runs `Home.razor`'s render. The Map demo passed `Center` as the literal `(20.0, 10.0)` — once the user panned, `_lastCenter` (user's pan) no longer matched the literal parameter, so `OnAfterRenderAsync` called `setCenter` back to the original view on every tick.

**Fix:** two-way bind Center + Zoom to parent state so user interaction is the source of truth.

```razor
<Map @bind-Center="_mapCenter" @bind-Zoom="_mapZoom" ...>
```

### 2. Touch drag still didn't fire on mobile
The 3.2.1 polyfill ran but never got control. iOS Safari and Android Chrome commit to a vertical-scroll interpretation of a touch gesture **before** a passive `touchstart` listener can hand it off. We inject a global CSS rule that sets `touch-action: none` on every `[draggable="true"]` element (opt out with `data-no-touch-drag="true"` on the element or any ancestor). The browser now defers to the polyfill on touch.

### 3. Bento tile polish on mobile
- **Charts tile too small.** Three ECharts stacked into a 360 px tile = ~120 px each → unreadable axes. Bumped to 620 px → ~200 px per chart.
- **Globe tile too small.** Bumped mobile height 320 → 440 px.
- **Line chart tooltip showed `3,508.3333333333335`.** The cycle timer divided by `12d` without rounding. Now `Math.Round(v / 12d)`.
- **Footer rows wrapped awkwardly.** `Map · Globe projection` + `Lumeo.Maps` badge + `View docs →` collided on narrow screens. Refactored with `min-w-0 + truncate + shrink-0`; satellite badge and `View docs` label now hide on `< 640 px`, collapsing the right-hand link to icon-only.

### 4. PdfViewer doc: self-hosting + controlled-component pattern
- **New "Controlled — header reports state + jump to page" demo.** Shows the `@bind-Page` + `OnLoaded`-total-pages pattern with First / Last / Reset-zoom buttons driven by parent state. Covers the gap between the trivial demos and the full API table.
- **New "Self-hosting pdf.js" section.** Documents how to swap the jsDelivr CDN for an in-app vendor via `lumeo deps install --lib pdfjs --write-bootstrap` — the real-world deployment scenario for CSP-strict apps and air-gapped intranets that the existing Alert hinted at but never explained.

## Test plan

- [ ] Phone: pan the Globe — view stays where you put it (no 2 s snap-back).
- [ ] Phone: long-press a Kanban card and drag it to another column — card moves.
- [ ] Phone: scroll past Charts tile — three ECharts visible at readable height.
- [ ] Phone: scroll past Map / Charts / PDF footer rows — no two-line wraps, badge hidden, arrow-only `→` link on the right.
- [ ] Visit `/components/pdf-viewer` — new "Controlled" demo renders and the page input + First / Last buttons work. "Self-hosting pdf.js" section renders the bash snippet.
- [ ] Desktop: layout identical to 3.2.1 — `lg:auto-rows-fr` preserves the aligned grid, mouse drag still works as before, Map / Charts / PDF footers show the full satellite badge + `View docs` label.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XMy2ZxQDK3fAPw766fAc19)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added controlled state demo for PdfViewer component with parent-managed navigation controls (First, Last, Reset zoom)
  * Enhanced touch interaction support for draggable elements

* **Bug Fixes**
  * Fixed line chart value rounding in computed output

* **Style**
  * Improved responsive layout for component showcase tiles on smaller screens

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Brain2k-0005/Lumeo/pull/37?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->