### PR TITLE
fix(mobile): Resizable + RichTextEditor touch, mobile drawer Docs pre-select (3.2.2)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
   <!-- Lockstep version shared by all Lumeo packages.
        Update this single property to version all packages in unison. -->
   <PropertyGroup>
-    <Version>3.2.1</Version>
+    <Version>3.2.2</Version>
   </PropertyGroup>
 
   <!-- Shared NuGet README packing lives in Directory.Build.targets, NOT here.

--- a/docs/Lumeo.Docs/Layout/MainLayout.razor
+++ b/docs/Lumeo.Docs/Layout/MainLayout.razor
@@ -254,33 +254,35 @@
                 </Button>
             </div>
             <nav class="px-3 py-2 border-b border-border/30 flex gap-1 shrink-0">
-                <a href="docs/introduction" class="@NavLinkClass("docs")">Docs</a>
-                <a href="components" class="@NavLinkClass("catalog")">Components</a>
-                <a href="patterns" class="@NavLinkClass("patterns")">Patterns</a>
-                <a href="blocks" class="@NavLinkClass("blocks")">Blocks</a>
+                <a href="docs/introduction" class="@MobileNavLinkClass("docs")">Docs</a>
+                <a href="components" class="@MobileNavLinkClass("catalog")">Components</a>
+                <a href="patterns" class="@MobileNavLinkClass("patterns")">Patterns</a>
+                <a href="blocks" class="@MobileNavLinkClass("blocks")">Blocks</a>
             </nav>
-            @if (ShowDocsLayout)
-            {
-                <div class="flex-1 overflow-y-auto">
-                    @switch (SidebarSection)
-                    {
-                        case "blocks":
-                            <BlocksSidebar IsMobile="true" />
-                            break;
-                        case "docs":
-                            <DocsSidebar IsMobile="true" />
-                            break;
-                        case "components":
-                            <NavMenu Section="components" IsMobile="true" />
-                            break;
-                        case "patterns":
-                            <PatternsSidebar IsMobile="true" />
-                            break;
-                        default:
-                            break;
-                    }
-                </div>
-            }
+            @* On home + bare catalog ShowDocsLayout is false (the page itself owns
+               its canvas). The mobile drawer used to render an empty body there,
+               which is useless — phone visitors had no way to discover the docs
+               tree without first navigating into a doc page. We now always show
+               a sidebar in the mobile drawer, defaulting to DocsSidebar when no
+               other section applies, and the matching "Docs" tab above lights up
+               so the active state matches what's shown. *@
+            <div class="flex-1 overflow-y-auto">
+                @switch (MobileSidebarSection)
+                {
+                    case "blocks":
+                        <BlocksSidebar IsMobile="true" />
+                        break;
+                    case "components":
+                        <NavMenu Section="components" IsMobile="true" />
+                        break;
+                    case "patterns":
+                        <PatternsSidebar IsMobile="true" />
+                        break;
+                    default:
+                        <DocsSidebar IsMobile="true" />
+                        break;
+                }
+            </div>
         </div>
     </div>
 }
@@ -400,6 +402,48 @@
                 isActive = CurrentPath.StartsWith(segment, StringComparison.OrdinalIgnoreCase);
                 break;
         }
+        return isActive
+            ? "rounded-md px-3 py-1.5 text-foreground bg-accent transition-colors no-underline"
+            : "rounded-md px-3 py-1.5 text-muted-foreground hover:text-foreground hover:bg-accent transition-colors no-underline";
+    }
+
+    /// <summary>
+    /// Mobile-only counterpart to <see cref="SidebarSection"/>. Diverges in
+    /// two places where the desktop layout intentionally has no sidebar but
+    /// the mobile drawer would otherwise be empty:
+    ///   "/"             → "docs"        (home defaults to the docs tree)
+    ///   "/components"   → "components"  (bare catalog shows the component list)
+    /// Every other route delegates to the existing SidebarSection mapping.
+    /// </summary>
+    private string MobileSidebarSection
+    {
+        get
+        {
+            var p = CurrentPath;
+            if (p == "") return "docs";
+            if (p.Equals("components", StringComparison.OrdinalIgnoreCase)) return "components";
+            return SidebarSection;
+        }
+    }
+
+    /// <summary>
+    /// Top-tab highlight inside the mobile drawer — keyed off
+    /// <see cref="MobileSidebarSection"/> so the active tab always matches the
+    /// sidebar body shown below it. Specifically: on home the "Docs" tab is
+    /// pre-selected (instead of "no tab active") because the drawer also
+    /// defaults to the DocsSidebar there.
+    /// </summary>
+    private string MobileNavLinkClass(string segment)
+    {
+        var sec = MobileSidebarSection;
+        bool isActive = segment switch
+        {
+            "docs"     => sec == "docs",
+            "catalog"  => sec == "components",
+            "patterns" => sec == "patterns",
+            "blocks"   => sec == "blocks",
+            _          => false
+        };
         return isActive
             ? "rounded-md px-3 py-1.5 text-foreground bg-accent transition-colors no-underline"
             : "rounded-md px-3 py-1.5 text-muted-foreground hover:text-foreground hover:bg-accent transition-colors no-underline";

--- a/docs/Lumeo.Docs/Pages/Docs/Changelog.razor
+++ b/docs/Lumeo.Docs/Pages/Docs/Changelog.razor
@@ -39,6 +39,13 @@
                 <li><strong>Toolbar buttons keep the editor selection on touch.</strong> <code class="rounded bg-muted px-1 text-xs">BubbleMenu</code>, <code class="rounded bg-muted px-1 text-xs">TriggerDropdown</code>, <code class="rounded bg-muted px-1 text-xs">AiActionMenu</code> and <code class="rounded bg-muted px-1 text-xs">Mention</code> used <code class="rounded bg-muted px-1 text-xs">@@onmousedown:preventDefault</code> to stop the toolbar button from stealing focus from the editor (which would collapse the selection and the next <code class="rounded bg-muted px-1 text-xs">bold</code> / <code class="rounded bg-muted px-1 text-xs">italic</code> click would apply to nothing). <code class="rounded bg-muted px-1 text-xs">mousedown</code> doesn't fire during a touch sequence; switched to <code class="rounded bg-muted px-1 text-xs">@@onpointerdown:preventDefault</code> which fires for mouse, pen and touch. 8 call sites across 4 files.</li>
             </ul>
         </Stack>
+
+        <Stack Gap="3">
+            <Heading Level="3" Size="sm" Class="font-semibold">Docs site mobile drawer</Heading>
+            <ul class="space-y-1.5 text-sm list-disc list-inside text-muted-foreground">
+                <li><strong>"Docs" tab is pre-selected on home.</strong> Opening the hamburger menu on <code class="rounded bg-muted px-1 text-xs">/</code> or the bare <code class="rounded bg-muted px-1 text-xs">/components</code> page used to render an empty body — those routes have no sidebar section, so the drawer's <code class="rounded bg-muted px-1 text-xs">@@switch</code> fell through to no-op. Phone visitors had no way to discover the docs tree without navigating into a doc page first. The drawer now always shows a sidebar, defaulting to <code class="rounded bg-muted px-1 text-xs">DocsSidebar</code> on home and to the component list on bare catalog, and the matching top tab lights up so the active state matches what's rendered below.</li>
+            </ul>
+        </Stack>
     </Stack>
 
     <Separator Class="my-4" />

--- a/docs/Lumeo.Docs/Pages/Docs/Changelog.razor
+++ b/docs/Lumeo.Docs/Pages/Docs/Changelog.razor
@@ -15,6 +15,34 @@
 
     <Separator Class="my-4" />
 
+    <!-- v3.2.2 -->
+    <Stack Gap="4">
+        <div class="flex items-center gap-3">
+            <Badge>v3.2.2</Badge>
+            <Lumeo.Text Size="sm" Color="muted">May 2026</Lumeo.Text>
+        </div>
+
+        <Lumeo.Text Size="base" Color="muted" Leading="relaxed">
+            Touch-readiness sweep across the library. Audit triggered by a mobile report of Kanban + Resizable + RichTextEditor menus not responding on iOS Safari / Android Chrome.
+        </Lumeo.Text>
+
+        <Stack Gap="3">
+            <Heading Level="3" Size="sm" Class="font-semibold">Resizable (core)</Heading>
+            <ul class="space-y-1.5 text-sm list-disc list-inside text-muted-foreground">
+                <li><strong>ResizableHandle is now drag-able on touch.</strong> <code class="rounded bg-muted px-1 text-xs">registerResizeHandle</code> in <code class="rounded bg-muted px-1 text-xs">components.js</code> was listening to <code class="rounded bg-muted px-1 text-xs">mousedown</code> / <code class="rounded bg-muted px-1 text-xs">mousemove</code> / <code class="rounded bg-muted px-1 text-xs">mouseup</code> on <code class="rounded bg-muted px-1 text-xs">document</code> — mouse events are only synthesised AFTER a touch sequence ends, so the divider was silently desktop-only. Migrated to pointer events with <code class="rounded bg-muted px-1 text-xs">setPointerCapture</code> and <code class="rounded bg-muted px-1 text-xs">touch-action: none</code> on the handle, matching Splitter / Window / AudioPlayer's existing pattern.</li>
+            </ul>
+        </Stack>
+
+        <Stack Gap="3">
+            <Heading Level="3" Size="sm" Class="font-semibold">RichTextEditor + Mention (core / Lumeo.Editor)</Heading>
+            <ul class="space-y-1.5 text-sm list-disc list-inside text-muted-foreground">
+                <li><strong>Toolbar buttons keep the editor selection on touch.</strong> <code class="rounded bg-muted px-1 text-xs">BubbleMenu</code>, <code class="rounded bg-muted px-1 text-xs">TriggerDropdown</code>, <code class="rounded bg-muted px-1 text-xs">AiActionMenu</code> and <code class="rounded bg-muted px-1 text-xs">Mention</code> used <code class="rounded bg-muted px-1 text-xs">@@onmousedown:preventDefault</code> to stop the toolbar button from stealing focus from the editor (which would collapse the selection and the next <code class="rounded bg-muted px-1 text-xs">bold</code> / <code class="rounded bg-muted px-1 text-xs">italic</code> click would apply to nothing). <code class="rounded bg-muted px-1 text-xs">mousedown</code> doesn't fire during a touch sequence; switched to <code class="rounded bg-muted px-1 text-xs">@@onpointerdown:preventDefault</code> which fires for mouse, pen and touch. 8 call sites across 4 files.</li>
+            </ul>
+        </Stack>
+    </Stack>
+
+    <Separator Class="my-4" />
+
     <!-- v3.2.1 -->
     <Stack Gap="4">
         <div class="flex items-center gap-3">

--- a/src/Lumeo.Editor/UI/RichTextEditor/AiActionMenu.razor
+++ b/src/Lumeo.Editor/UI/RichTextEditor/AiActionMenu.razor
@@ -15,7 +15,7 @@
         <button type="button"
                 role="menuitem"
                 class="flex w-full items-center gap-2 px-2.5 py-1.5 rounded-md text-sm hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground focus:outline-none"
-                @onmousedown:preventDefault="true"
+                @onpointerdown:preventDefault="true"
                 @onclick="() => OnAction.InvokeAsync(a)">
             @if (!string.IsNullOrEmpty(a.IconName))
             {

--- a/src/Lumeo.Editor/UI/RichTextEditor/BubbleMenu.razor
+++ b/src/Lumeo.Editor/UI/RichTextEditor/BubbleMenu.razor
@@ -10,25 +10,25 @@
 
 <div class="@RootClass" role="toolbar" aria-label="@L["Editor.FormatSelection"]" @attributes="AdditionalAttributes">
     <button type="button" class="@BtnClass" title="@L["Editor.Bold"]" aria-label="@L["Editor.Bold"]"
-            @onmousedown:preventDefault="true" @onclick="@(() => OnCommand.InvokeAsync("bold"))">
+            @onpointerdown:preventDefault="true" @onclick="@(() => OnCommand.InvokeAsync("bold"))">
         <Icon Name="Bold" Size="Lumeo.Size.Sm" />
     </button>
     <button type="button" class="@BtnClass" title="@L["Editor.Italic"]" aria-label="@L["Editor.Italic"]"
-            @onmousedown:preventDefault="true" @onclick="@(() => OnCommand.InvokeAsync("italic"))">
+            @onpointerdown:preventDefault="true" @onclick="@(() => OnCommand.InvokeAsync("italic"))">
         <Icon Name="Italic" Size="Lumeo.Size.Sm" />
     </button>
     <button type="button" class="@BtnClass" title="@L["Editor.Underline"]" aria-label="@L["Editor.Underline"]"
-            @onmousedown:preventDefault="true" @onclick="@(() => OnCommand.InvokeAsync("underline"))">
+            @onpointerdown:preventDefault="true" @onclick="@(() => OnCommand.InvokeAsync("underline"))">
         <Icon Name="Underline" Size="Lumeo.Size.Sm" />
     </button>
     <button type="button" class="@BtnClass" title="@L["Editor.Link"]" aria-label="@L["Editor.Link"]"
-            @onmousedown:preventDefault="true" @onclick="@(() => OnCommand.InvokeAsync("link"))">
+            @onpointerdown:preventDefault="true" @onclick="@(() => OnCommand.InvokeAsync("link"))">
         <Icon Name="Link" Size="Lumeo.Size.Sm" />
     </button>
     @if (EnableAiActions)
     {
         <button type="button" class="@BtnClass" title="@L["Editor.AiActions"]" aria-label="@L["Editor.AiActions"]"
-                @onmousedown:preventDefault="true" @onclick="@(() => OnAiMenuToggled.InvokeAsync())">
+                @onpointerdown:preventDefault="true" @onclick="@(() => OnAiMenuToggled.InvokeAsync())">
             <Icon Name="Sparkles" Size="Lumeo.Size.Sm" />
         </button>
     }

--- a/src/Lumeo.Editor/UI/RichTextEditor/TriggerDropdown.razor
+++ b/src/Lumeo.Editor/UI/RichTextEditor/TriggerDropdown.razor
@@ -28,7 +28,7 @@
             <div role="option"
                  aria-selected="@(selected ? "true" : "false")"
                  class="@rowClass"
-                 @onmousedown:preventDefault="true"
+                 @onpointerdown:preventDefault="true"
                  @onclick="() => OnPick.InvokeAsync(item)"
                  @onmouseenter="() => OnHover.InvokeAsync(idx)">
                 @if (ItemTemplate is not null)

--- a/src/Lumeo/UI/Mention/Mention.razor
+++ b/src/Lumeo/UI/Mention/Mention.razor
@@ -37,7 +37,7 @@
                 var isActive = index == _activeIndex;
                 <button @key="option.Value" type="button"
                         class="@OptionCssClass(isActive)"
-                        @onmousedown:preventDefault
+                        @onpointerdown:preventDefault
                         @onclick="() => SelectOption(option)">
                     @if (!string.IsNullOrEmpty(option.Avatar))
                     {

--- a/src/Lumeo/wwwroot/js/components.js
+++ b/src/Lumeo/wwwroot/js/components.js
@@ -1146,42 +1146,63 @@ export function unregisterTabSwipe(elementId) {
 
 const resizeHandlers = new Map();
 
+// Resizable panel-group handle. Originally listened to mousedown/mousemove/
+// mouseup on document, so touch users could not drag the divider at all
+// (mouse events are only synthesised AFTER a touch sequence ends, never
+// during). Migrated to pointer events with setPointerCapture so a single
+// code path serves mouse, pen and touch — matching what Splitter/Window/
+// AudioPlayer already do. `touch-action: none` on the handle hands the
+// gesture to us instead of the browser interpreting it as a vertical scroll.
 export function registerResizeHandle(elementId, direction, dotnetRef) {
     const el = document.getElementById(elementId);
     if (!el) return;
 
+    el.style.touchAction = 'none';
+
     let isDragging = false;
     let startPos = 0;
+    let activePointerId = null;
 
-    const onMouseDown = (e) => {
+    const onPointerDown = (e) => {
+        // Ignore secondary buttons (right-click, middle-click) so the divider
+        // doesn't grab a context-menu attempt.
+        if (e.button !== undefined && e.button !== 0) return;
         isDragging = true;
+        activePointerId = e.pointerId;
         startPos = direction === 'horizontal' ? e.clientX : e.clientY;
         document.body.style.cursor = direction === 'horizontal' ? 'col-resize' : 'row-resize';
         document.body.style.userSelect = 'none';
+        try { el.setPointerCapture(e.pointerId); } catch { /* not all browsers/contexts */ }
         e.preventDefault();
     };
 
-    const onMouseMove = (e) => {
-        if (!isDragging) return;
+    const onPointerMove = (e) => {
+        if (!isDragging || e.pointerId !== activePointerId) return;
         const currentPos = direction === 'horizontal' ? e.clientX : e.clientY;
         const delta = currentPos - startPos;
         startPos = currentPos;
         dotnetRef.invokeMethodAsync('OnResize', elementId, delta);
     };
 
-    const onMouseUp = () => {
-        if (!isDragging) return;
+    const onPointerUp = (e) => {
+        if (!isDragging || e.pointerId !== activePointerId) return;
         isDragging = false;
+        activePointerId = null;
         document.body.style.cursor = '';
         document.body.style.userSelect = '';
+        try { el.releasePointerCapture(e.pointerId); } catch { /* fallthrough */ }
         dotnetRef.invokeMethodAsync('OnResizeEnd', elementId);
     };
 
-    el.addEventListener('mousedown', onMouseDown);
-    document.addEventListener('mousemove', onMouseMove);
-    document.addEventListener('mouseup', onMouseUp);
+    // pointermove + pointerup go on the element itself: setPointerCapture
+    // guarantees subsequent events route to it even when the finger drifts
+    // off the (visually 1 px wide) divider during a fast drag.
+    el.addEventListener('pointerdown', onPointerDown);
+    el.addEventListener('pointermove', onPointerMove);
+    el.addEventListener('pointerup', onPointerUp);
+    el.addEventListener('pointercancel', onPointerUp);
 
-    resizeHandlers.set(elementId, { onMouseDown, onMouseMove, onMouseUp });
+    resizeHandlers.set(elementId, { onPointerDown, onPointerMove, onPointerUp });
 }
 
 export function unregisterResizeHandle(elementId) {
@@ -1189,10 +1210,11 @@ export function unregisterResizeHandle(elementId) {
     if (handlers) {
         const el = document.getElementById(elementId);
         if (el) {
-            el.removeEventListener('mousedown', handlers.onMouseDown);
+            el.removeEventListener('pointerdown', handlers.onPointerDown);
+            el.removeEventListener('pointermove', handlers.onPointerMove);
+            el.removeEventListener('pointerup', handlers.onPointerUp);
+            el.removeEventListener('pointercancel', handlers.onPointerUp);
         }
-        document.removeEventListener('mousemove', handlers.onMouseMove);
-        document.removeEventListener('mouseup', handlers.onMouseUp);
         resizeHandlers.delete(elementId);
     }
 }


### PR DESCRIPTION
## Summary

Touch-readiness audit follow-up plus a mobile-drawer UX fix. Three issues, all phone-only.

### 1. `ResizableHandle` silently desktop-only

`registerResizeHandle` in `components.js` listened to `mousedown` / `mousemove` / `mouseup` on `document`. Touch users could not drag the divider at all — mouse events are only synthesised *after* a touch sequence ends, never during. Migrated to pointer events with `setPointerCapture` and `touch-action: none` on the handle, matching the pattern Splitter / Window / AudioPlayer already use.

### 2. RichTextEditor + Mention toolbar buttons lost the editor selection on touch

`BubbleMenu` (5×), `TriggerDropdown`, `AiActionMenu` and `Mention` used `@onmousedown:preventDefault` to stop the toolbar button from stealing focus from the editor — without it, clicking "Bold" would collapse the selection and apply bold to nothing. `mousedown` doesn't fire during a touch sequence, so on phones the selection was cleared regardless of the call. Switched to `@onpointerdown:preventDefault` which fires for mouse, pen and touch. 8 call sites across 4 files.

### 3. Mobile drawer was empty on home + bare catalog — "Docs" tab now pre-selected

Opening the hamburger menu on `/` or `/components` rendered an empty body. Those routes' `SidebarSection` is `"none"`, so the drawer's `@switch` fell through to no-op. Phone visitors had no way to browse the docs tree from those landing surfaces.

Added `MobileSidebarSection` + `MobileNavLinkClass` helpers that diverge from the desktop sidebar mapping in exactly two spots:

| Route | Mobile drawer sidebar | Highlighted tab |
| --- | --- | --- |
| `/` | `DocsSidebar` | Docs |
| `/components` (bare catalog) | Components list | Components |
| every other route | unchanged from desktop | unchanged |

Desktop floating navbar is untouched — it still uses `NavLinkClass` which leaves no tab active on home.

## Audit punch list — verified clean

| Class | Status |
| --- | --- |
| HTML5 D&D outside Kanban (Tabs reorder, SortableList, FileUpload, DataGrid row/column drag) | ✅ Covered by the 3.2.1 polyfill |
| Splitter, Window, Rating, AudioPlayer, SwipeActions, PullToRefresh, TouchRipple | ✅ Already use pointer events correctly |
| Slider, Switch, NumberInput | ✅ Native `<input>` handles touch |
| HoverCard, Menubar / DropdownMenu / ContextMenu submenu triggers | ✅ `@onclick` fallback present — hover is graceful-degradation, not load-bearing |

## Version

Bumped `Directory.Build.props` 3.2.1 → 3.2.2 and added the matching docs changelog entry.

## Test plan

- [ ] CI green
- [ ] Phone: open a Resizable demo, drag the divider with finger — panels resize
- [ ] Phone: open the RichTextEditor demo, select text, tap "Bold" — bold applies to the selection (not nothing)
- [ ] Phone: open the hamburger menu on the home page — Docs tab highlighted, DocsSidebar visible below
- [ ] Phone: same menu on `/components` — Components tab highlighted, component list visible below
- [ ] Desktop: layouts unchanged
- [ ] After merge: tag `v3.2.2`, GitHub release, NuGet publish