### PR TITLE
fix: multi-select checkbox toggles + docs TOC deep-links

### DIFF
--- a/docs/Lumeo.Docs/wwwroot/js/docs.js
+++ b/docs/Lumeo.Docs/wwwroot/js/docs.js
@@ -10,9 +10,16 @@ window.lumeo.signalBlazorReady = function () {
 
 // Scroll a heading into view from the OnThisPage sidebar. Using a dedicated
 // function instead of eval() avoids CSP issues and keeps interop auditable.
+// Also reflects the section into the URL hash so right-click "copy link"
+// and browser-share produce a deep link like /components/datagrid#full-featured-datagrid
+// instead of the bare route. replaceState (not pushState) keeps the back
+// button focused on real route changes rather than TOC scrolls.
 window.lumeo.navScrollActiveIntoView = function (id) {
     var el = document.getElementById(id);
-    if (el) el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    if (el) {
+        el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+        try { history.replaceState(null, '', '#' + id); } catch (_) { /* SSR / sandboxed */ }
+    }
 };
 
 // Reset the scrollTop of an element by id. Avoids `eval()` for CSP compatibility.

--- a/src/Lumeo.DataGrid/UI/DataGrid/DataGridRow.razor
+++ b/src/Lumeo.DataGrid/UI/DataGrid/DataGridRow.razor
@@ -32,7 +32,12 @@
            left:0 so it stays visible during horizontal scroll and doesn't slide
            behind the pinned data column. Matches the z-index of DataGridHeaderCell
            pinned headers (z-20 on thead, z-10 on body cells). *@
-        <td role="gridcell" class="@(Context.HasPinnedLeft ? "px-3 py-2 w-10 sticky left-0 z-10 group-hover/row:bg-muted/50" : "px-3 py-2 w-10")" style="@SelectionPinStyle">
+        @* stopPropagation is required: without it, clicking the checkbox toggles
+           selection (via OnCheckChanged) AND the click bubbles to <tr>'s HandleClick
+           which toggles selection again — net no-op. The single-select cell below
+           already does this on its <button>. *@
+        <td role="gridcell" class="@(Context.HasPinnedLeft ? "px-3 py-2 w-10 sticky left-0 z-10 group-hover/row:bg-muted/50" : "px-3 py-2 w-10")" style="@SelectionPinStyle"
+            @onclick:stopPropagation="true">
             <Checkbox Checked="@IsSelected" CheckedChanged="@OnCheckChanged" />
         </td>
     }

--- a/tests/Lumeo.Tests/Components/DataGrid/DataGridTests.cs
+++ b/tests/Lumeo.Tests/Components/DataGrid/DataGridTests.cs
@@ -313,6 +313,32 @@ public class DataGridTests : IAsyncLifetime
         Assert.Equal("Alice", capturedSelection![0].Name);
     }
 
+    [Fact]
+    public void DataGrid_Multiple_Mode_Checkbox_Click_Toggles_Selection_Without_Double_Fire()
+    {
+        // Regression: clicking the row's selection checkbox in Multiple mode used to
+        // double-toggle (checkbox OnCheckChanged toggled, then the click bubbled to
+        // <tr> HandleClick which toggled again → net no-op). The selection cell's <td>
+        // now stops propagation; this test locks that in.
+        IReadOnlyList<TestItem>? capturedSelection = null;
+
+        var cut = _ctx.Render<DataGrid<TestItem>>(p => p
+            .Add(x => x.Items, GetTestData())
+            .Add(x => x.Columns, GetColumns())
+            .Add(x => x.SelectionMode, DataGridSelectionMode.Multiple)
+            .Add(x => x.SelectedItemsChanged, EventCallback.Factory.Create<IReadOnlyList<TestItem>>(
+                this, list => capturedSelection = list)));
+
+        // First <button role="checkbox"> in the body is the first data row's selector
+        // (header select-all sits in <thead> and isn't matched here).
+        var checkbox = cut.FindAll("tbody [role='checkbox']")[0];
+        checkbox.Click();
+
+        Assert.NotNull(capturedSelection);
+        Assert.Single(capturedSelection);
+        Assert.Equal("Alice", capturedSelection![0].Name);
+    }
+
     // ===========================================================================
     // LOADING STATE
     // ===========================================================================


### PR DESCRIPTION
## Summary

Two bugs surfaced in Reddit feedback on the public docs.

- **DataGrid multi-select checkbox was a no-op.** In Multiple mode, clicking the row's selection checkbox toggled selection once (via `Checkbox.OnCheckChanged`) and then the click bubbled to `<tr>`'s `HandleClick` which toggled it again — net no change. The selection `<td>` now stops propagation, matching what the single-select cell already did on its button. New bUnit regression test asserts a checkbox click yields exactly one selected item.
- **Docs "On this page" sidebar didn't update the URL hash.** `OnThisPage` cancelled the default anchor navigation and called `scrollIntoView` only, so right-click "copy link" produced the bare route (e.g. `/components/datagrid`) instead of the deep link users expected (e.g. `/components/datagrid#full-featured-datagrid`). `navScrollActiveIntoView` now also calls `history.replaceState('#' + id)` — `replaceState` (not `pushState`) so back-button focus stays on real route changes.

## Test plan

- [ ] `dotnet test tests/Lumeo.Tests` — new `DataGrid_Multiple_Mode_Checkbox_Click_Toggles_Selection_Without_Double_Fire` passes; existing row-click selection tests still pass.
- [ ] Manual: open `/components/datagrid`, click a checkbox in the "Multi-Select with Checkboxes" demo — the Selection alert should now show `1 row(s) selected.`
- [ ] Manual: open any docs page with an "On this page" sidebar, click a section title — URL hash updates; right-click → copy link yields a full deep link.

---
_Generated by [Claude Code](https://claude.ai/code/session_0162NNVHveeL63TTM773mcU1)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed DataGrid multiple-selection checkbox that was incorrectly firing selection changes twice per click in multiple-selection mode.
  * Enhanced documentation navigation to update URL hash when scrolling through sidebar sections with graceful fallback support for restricted environments.

* **Tests**
  * Added regression test to validate correct DataGrid checkbox selection behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Brain2k-0005/Lumeo/pull/42?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->