### PR TITLE
chore(release): 3.2.4

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
   <!-- Lockstep version shared by all Lumeo packages.
        Update this single property to version all packages in unison. -->
   <PropertyGroup>
-    <Version>3.2.3</Version>
+    <Version>3.2.4</Version>
   </PropertyGroup>
 
   <!-- Shared NuGet README packing lives in Directory.Build.targets, NOT here.

--- a/docs/Lumeo.Docs/Pages/Docs/Changelog.razor
+++ b/docs/Lumeo.Docs/Pages/Docs/Changelog.razor
@@ -15,6 +15,27 @@
 
     <Separator Class="my-4" />
 
+    <!-- v3.2.4 -->
+    <Stack Gap="4">
+        <div class="flex items-center gap-3">
+            <Badge>v3.2.4</Badge>
+            <Lumeo.Text Size="sm" Color="muted">May 2026</Lumeo.Text>
+        </div>
+
+        <Lumeo.Text Size="base" Color="muted" Leading="relaxed">
+            Single-bug patch: DataGrid multi-select checkbox in <code class="rounded bg-muted px-1 text-xs">Lumeo.DataGrid</code>. No API changes.
+        </Lumeo.Text>
+
+        <Stack Gap="3">
+            <Heading Level="3" Size="sm" Class="font-semibold">DataGrid</Heading>
+            <ul class="space-y-1.5 text-sm list-disc list-inside text-muted-foreground">
+                <li><strong>Multi-select checkbox click no longer double-toggles.</strong> The selection-cell <code class="rounded bg-muted px-1 text-xs">&lt;td&gt;</code> now stops click propagation, matching what the single-select cell already did on its button. Previously, clicking the row's checkbox in <code class="rounded bg-muted px-1 text-xs">SelectionMode="Multiple"</code> toggled selection via <code class="rounded bg-muted px-1 text-xs">CheckedChanged</code>, then the click bubbled to <code class="rounded bg-muted px-1 text-xs">&lt;tr&gt;</code>'s row-click handler which toggled it again — net no-op. Row-body clicks were unaffected and continue to work. New bUnit regression test (<code class="rounded bg-muted px-1 text-xs">DataGrid_Multiple_Mode_Checkbox_Click_Toggles_Selection_Without_Double_Fire</code>) locks the invariant in.</li>
+            </ul>
+        </Stack>
+    </Stack>
+
+    <Separator Class="my-4" />
+
     <!-- v3.2.3 -->
     <Stack Gap="4">
         <div class="flex items-center gap-3">


### PR DESCRIPTION
## Summary

Patch release for the DataGrid multi-select checkbox propagation fix merged in #42. No API changes.

- Bump `Directory.Build.props` Version 3.2.3 → 3.2.4 (lockstep across `Lumeo`, `Lumeo.DataGrid`, `Lumeo.Charts`, `Lumeo.Editor`, `Lumeo.Scheduler`, `Lumeo.Gantt`, `Lumeo.Motion`, `Lumeo.PdfViewer`, `Lumeo.CodeEditor`, `Lumeo.Maps`).
- Add v3.2.4 entry to `docs/Lumeo.Docs/Pages/Docs/Changelog.razor`.

The docs-only TOC deep-link fix that landed alongside #42 is not strictly a library change, but rides with this release since it shipped in the same PR.

## Test plan

- [ ] CI: build-and-test, e2e, bom-check all green.
- [ ] After merge: tag `3.2.4` annotated, push, then trigger NuGet publish workflow.

---
_Generated by [Claude Code](https://claude.ai/code/session_0162NNVHveeL63TTM773mcU1)_