### PR TITLE
feat: Lumeo.FileViewer satellite + auto-discover satellites in registry/MCP

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -45,6 +45,7 @@ jobs:
           dotnet restore src/Lumeo.CodeEditor/Lumeo.CodeEditor.csproj
           dotnet restore src/Lumeo.DataGrid/Lumeo.DataGrid.csproj
           dotnet restore src/Lumeo.Editor/Lumeo.Editor.csproj
+          dotnet restore src/Lumeo.FileViewer/Lumeo.FileViewer.csproj
           dotnet restore src/Lumeo.Scheduler/Lumeo.Scheduler.csproj
           dotnet restore src/Lumeo.Gantt/Lumeo.Gantt.csproj
           dotnet restore src/Lumeo.Motion/Lumeo.Motion.csproj
@@ -60,6 +61,7 @@ jobs:
           dotnet build src/Lumeo.CodeEditor/Lumeo.CodeEditor.csproj -c Release --no-restore -warnaserror
           dotnet build src/Lumeo.DataGrid/Lumeo.DataGrid.csproj -c Release --no-restore -warnaserror
           dotnet build src/Lumeo.Editor/Lumeo.Editor.csproj -c Release --no-restore -warnaserror
+          dotnet build src/Lumeo.FileViewer/Lumeo.FileViewer.csproj -c Release --no-restore -warnaserror
           dotnet build src/Lumeo.Scheduler/Lumeo.Scheduler.csproj -c Release --no-restore -warnaserror
           dotnet build src/Lumeo.Gantt/Lumeo.Gantt.csproj -c Release --no-restore -warnaserror
           dotnet build src/Lumeo.Motion/Lumeo.Motion.csproj -c Release --no-restore -warnaserror
@@ -80,6 +82,7 @@ jobs:
           dotnet pack src/Lumeo.CodeEditor/Lumeo.CodeEditor.csproj -c Release --no-build -o ./nupkg /p:Version=${{ steps.ver.outputs.version }}
           dotnet pack src/Lumeo.DataGrid/Lumeo.DataGrid.csproj -c Release --no-build -o ./nupkg /p:Version=${{ steps.ver.outputs.version }}
           dotnet pack src/Lumeo.Editor/Lumeo.Editor.csproj -c Release --no-build -o ./nupkg /p:Version=${{ steps.ver.outputs.version }}
+          dotnet pack src/Lumeo.FileViewer/Lumeo.FileViewer.csproj -c Release --no-build -o ./nupkg /p:Version=${{ steps.ver.outputs.version }}
           dotnet pack src/Lumeo.Scheduler/Lumeo.Scheduler.csproj -c Release --no-build -o ./nupkg /p:Version=${{ steps.ver.outputs.version }}
           dotnet pack src/Lumeo.Gantt/Lumeo.Gantt.csproj -c Release --no-build -o ./nupkg /p:Version=${{ steps.ver.outputs.version }}
           dotnet pack src/Lumeo.Motion/Lumeo.Motion.csproj -c Release --no-build -o ./nupkg /p:Version=${{ steps.ver.outputs.version }}

--- a/.github/workflows/sync-mcp-registry.yml
+++ b/.github/workflows/sync-mcp-registry.yml
@@ -20,20 +20,14 @@ on:
   push:
     branches: [master]
     paths:
-      - 'src/Lumeo/UI/**/*.razor'
-      - 'src/Lumeo/UI/**/*.cs'
-      - 'src/Lumeo.Charts/UI/**/*.razor'
-      - 'src/Lumeo.Charts/UI/**/*.cs'
-      - 'src/Lumeo.DataGrid/UI/**/*.razor'
-      - 'src/Lumeo.DataGrid/UI/**/*.cs'
-      - 'src/Lumeo.Editor/UI/**/*.razor'
-      - 'src/Lumeo.Editor/UI/**/*.cs'
-      - 'src/Lumeo.Scheduler/UI/**/*.razor'
-      - 'src/Lumeo.Scheduler/UI/**/*.cs'
-      - 'src/Lumeo.Gantt/UI/**/*.razor'
-      - 'src/Lumeo.Gantt/UI/**/*.cs'
-      - 'src/Lumeo.Motion/UI/**/*.razor'
-      - 'src/Lumeo.Motion/UI/**/*.cs'
+      # Glob over every Lumeo* package's UI/ folder so a new satellite
+      # (e.g. Lumeo.FileViewer, Lumeo.PdfViewer, future packages) triggers
+      # the regen without anyone remembering to add an explicit pattern
+      # here. Previously this list was hand-maintained and drifted: the
+      # PdfViewer/Maps additions both shipped before their entries landed
+      # in this filter, so the committed MCP registry trailed master.
+      - 'src/Lumeo*/UI/**/*.razor'
+      - 'src/Lumeo*/UI/**/*.cs'
       - 'tools/Lumeo.RegistryGen/**/*.cs'
       - 'Directory.Build.props'
   workflow_dispatch:

--- a/Lumeo.slnx
+++ b/Lumeo.slnx
@@ -5,6 +5,7 @@
     <Project Path="src/Lumeo.CodeEditor/Lumeo.CodeEditor.csproj" />
     <Project Path="src/Lumeo.DataGrid/Lumeo.DataGrid.csproj" />
     <Project Path="src/Lumeo.Editor/Lumeo.Editor.csproj" />
+    <Project Path="src/Lumeo.FileViewer/Lumeo.FileViewer.csproj" />
     <Project Path="src/Lumeo.Gantt/Lumeo.Gantt.csproj" />
     <Project Path="src/Lumeo.Maps/Lumeo.Maps.csproj" />
     <Project Path="src/Lumeo.Motion/Lumeo.Motion.csproj" />

--- a/docs/Lumeo.Docs/Lumeo.Docs.csproj
+++ b/docs/Lumeo.Docs/Lumeo.Docs.csproj
@@ -49,6 +49,7 @@
     <ProjectReference Include="..\..\src\Lumeo.Charts\Lumeo.Charts.csproj" />
     <ProjectReference Include="..\..\src\Lumeo.DataGrid\Lumeo.DataGrid.csproj" />
     <ProjectReference Include="..\..\src\Lumeo.Editor\Lumeo.Editor.csproj" />
+    <ProjectReference Include="..\..\src\Lumeo.FileViewer\Lumeo.FileViewer.csproj" />
     <ProjectReference Include="..\..\src\Lumeo.Scheduler\Lumeo.Scheduler.csproj" />
     <ProjectReference Include="..\..\src\Lumeo.Gantt\Lumeo.Gantt.csproj" />
     <ProjectReference Include="..\..\src\Lumeo.Motion\Lumeo.Motion.csproj" />

--- a/docs/Lumeo.Docs/Pages/Components/FileViewerPage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/FileViewerPage.razor
@@ -1,0 +1,297 @@
+@page "/components/file-viewer"
+
+<PageTitle>File Viewer — Lumeo</PageTitle>
+
+<PageHeader Title="File Viewer"
+            Description="Universal preview surface — detects the file type from MIME / extension and renders inline: PDF, images, video, audio, Markdown, source code, JSON, CSV, and plain text. Unknown types fall back to a download CTA. One component replaces a stack of bespoke per-type renderers." />
+
+<Alert Variant="Alert.AlertVariant.Info" ShowIcon="true" Class="mt-6">
+    <ChildContent>
+        <strong>Satellite package.</strong> The FileViewer lives in
+        <Code>Lumeo.FileViewer</Code> — install it alongside the core <Code>Lumeo</Code>
+        package. It transitively pulls <Code>Lumeo.PdfViewer</Code>
+        (for the PDF kind) and <Code>Lumeo.CodeEditor</Code> (for the Code / JSON
+        kinds), so a single install covers every supported preview.
+    </ChildContent>
+</Alert>
+
+<div class="mt-10 space-y-3">
+    <Heading Id="when-to-use" Level="2" Class="scroll-mt-20">When to Use</Heading>
+    <ul class="list-disc list-inside space-y-1 text-muted-foreground text-sm">
+        <li>Document or attachment lists where each row links to a heterogeneous file (PDF report, screenshot, CSV export, README)</li>
+        <li>File managers / DMS surfaces that need a quick preview pane next to the tree</li>
+        <li>Audit / compliance flows where the user has to inspect the actual content before approving an action</li>
+        <li>Ticketing systems where customers attach mixed-format evidence</li>
+        <li>Anywhere consumers would otherwise build a switch over Pdf / Image / Video / Markdown viewers by hand</li>
+    </ul>
+</div>
+
+<div class="mt-10 space-y-3">
+    <Heading Id="how-detection-works" Level="2" Class="scroll-mt-20">How Detection Works</Heading>
+    <p class="text-sm text-muted-foreground">
+        Resolution runs in this order — each step wins over the next:
+    </p>
+    <ol class="list-decimal list-inside space-y-1 text-muted-foreground text-sm">
+        <li>Explicit <Code>Kind</Code> parameter (anything other than <Code>Auto</Code> short-circuits)</li>
+        <li>Explicit <Code>MimeType</Code> parameter (most reliable for blob URLs / signed URLs where the extension is hidden)</li>
+        <li>Optional <Code>HEAD</Code> request <Code>Content-Type</Code> — off by default (<Code>AutoHead="true"</Code> to enable) because many CDNs reject HEAD with 405</li>
+        <li>URL extension — the last-resort guess from the path segment</li>
+    </ol>
+</div>
+
+<Stack Gap="8" Class="mt-8">
+
+    <ComponentDemo Title="Auto-detection" Code="@_autoCode">
+        <Stack Gap="4">
+            <div>
+                <p class="text-xs text-muted-foreground mb-2">PDF — extension <Code>.pdf</Code></p>
+                <FileViewer Src="@SamplePdfUrl" Class="h-[420px]" />
+            </div>
+            <div>
+                <p class="text-xs text-muted-foreground mb-2">Image — extension <Code>.png</Code></p>
+                <FileViewer Src="@SampleImageUrl" Class="h-[320px]" />
+            </div>
+            <div>
+                <p class="text-xs text-muted-foreground mb-2">Markdown — extension <Code>.md</Code></p>
+                <FileViewer Src="@SampleMarkdownUrl" Class="h-[420px]" />
+            </div>
+            <div>
+                <p class="text-xs text-muted-foreground mb-2">CSV — extension <Code>.csv</Code></p>
+                <FileViewer Src="@SampleCsvUrl" Class="h-[360px]" />
+            </div>
+            <div>
+                <p class="text-xs text-muted-foreground mb-2">Source code — extension <Code>.cs</Code></p>
+                <FileViewer Src="@SampleCodeUrl" FileName="Program.cs" Class="h-[360px]" />
+            </div>
+        </Stack>
+    </ComponentDemo>
+
+    <ComponentDemo Title="Explicit Kind override" Code="@_kindOverrideCode">
+        <Stack Gap="3">
+            <p class="text-xs text-muted-foreground">
+                Force a kind when the URL has no extension (typical for blob / signed URLs).
+            </p>
+            <FileViewer Src="@SamplePdfUrl"
+                        Kind="FileKind.Pdf"
+                        FileName="report.pdf"
+                        Class="h-[400px]" />
+        </Stack>
+    </ComponentDemo>
+
+    <ComponentDemo Title="Explicit MimeType" Code="@_mimeOverrideCode">
+        <Stack Gap="3">
+            <p class="text-xs text-muted-foreground">
+                Provide MIME from your backend metadata response — most reliable for opaque URLs.
+            </p>
+            <FileViewer Src="@SampleImageUrl"
+                        MimeType="image/png"
+                        FileName="screenshot.png"
+                        Class="h-[320px]" />
+        </Stack>
+    </ComponentDemo>
+
+    <ComponentDemo Title="Kind detected callback" Code="@_kindCallbackCode">
+        <Stack Gap="3">
+            <FileViewer Src="@_callbackSrc"
+                        OnKindDetected="HandleKindDetected"
+                        Class="h-[320px]" />
+            @if (_lastDetectedKind is not null)
+            {
+                <Alert Variant="Alert.AlertVariant.Info" ShowIcon="true">
+                    <ChildContent>
+                        Detected kind: <Code>FileKind.@_lastDetectedKind</Code>
+                    </ChildContent>
+                </Alert>
+            }
+        </Stack>
+    </ComponentDemo>
+
+    <ComponentDemo Title="Unknown type falls back to download" Code="@_unknownCode">
+        <FileViewer Src="https://example.com/archive.zip"
+                    FileName="archive.zip"
+                    Class="h-[320px]" />
+    </ComponentDemo>
+
+    <ComponentDemo Title="Error handling" Code="@_errorCode">
+        <Stack Gap="3">
+            <FileViewer Src="https://lumeo.invalid/does-not-exist.csv"
+                        OnError="HandleError"
+                        Class="h-[280px]" />
+            @if (_errorMessage is not null)
+            {
+                <Alert Variant="Alert.AlertVariant.Destructive" ShowIcon="true">
+                    <ChildContent>
+                        <div class="font-medium">Error caught by parent</div>
+                        <div class="text-xs opacity-80 mt-1 font-mono break-all line-clamp-2">@TruncateError(_errorMessage)</div>
+                    </ChildContent>
+                </Alert>
+            }
+        </Stack>
+    </ComponentDemo>
+
+    <ComponentDemo Title="Chromeless embed (toolbar hidden)" Code="@_chromelessCode">
+        <FileViewer Src="@SampleImageUrl"
+                    ShowToolbar="false"
+                    Class="h-[320px]" />
+    </ComponentDemo>
+
+    <ComponentDemo Title="Custom renderer for a kind" Code="@_customRendererCode">
+        <FileViewer Src="@SampleImageUrl"
+                    CustomRenderers="_imageRenderer"
+                    Class="h-[320px]" />
+    </ComponentDemo>
+
+</Stack>
+
+<div class="mt-10 space-y-3">
+    <Heading Id="auth-and-fetch" Level="2" Class="scroll-mt-20">Auth-Aware Fetching</Heading>
+    <p class="text-sm text-muted-foreground">
+        Text-based kinds (Markdown, Code, JSON, CSV, Text) are fetched via <Code>HttpClient</Code>.
+        For signed-but-not-presigned URLs you have three knobs:
+    </p>
+    <ul class="list-disc list-inside space-y-1 text-muted-foreground text-sm">
+        <li><Code>HttpClient="..."</Code> — pass a pre-configured client (with handlers attached) directly</li>
+        <li><Code>ConfigureRequest="..."</Code> — mutate the outgoing <Code>HttpRequestMessage</Code> per call (typical for <Code>Authorization</Code> headers)</li>
+        <li>Register <Code>HttpClient</Code> in DI — picked up automatically (the standard Blazor WASM pattern)</li>
+    </ul>
+
+    <Heading Id="safety-limits" Level="2" Class="scroll-mt-20 mt-8">Safety Limits</Heading>
+    <ul class="list-disc list-inside space-y-1 text-muted-foreground text-sm">
+        <li><Code>MaxBytes</Code> (default 10 MB) — refused upfront via <Code>Content-Length</Code> when known, truncated mid-stream otherwise. No 100 MB OOMs.</li>
+        <li><Code>MaxCsvRows</Code> (default 1000) — CSV parser stops after this many rows and adds a truncation notice.</li>
+        <li>Markdown is rendered with <Code>.DisableHtml()</Code> — raw <Code>&lt;script&gt;</Code> / <Code>&lt;iframe&gt;</Code> in user-supplied <Code>.md</Code> never reach the DOM.</li>
+        <li>SVG renders via <Code>&lt;img&gt;</Code> (not inline) — embedded scripts in SVG can't execute.</li>
+        <li>In-flight fetches are cancelled via <Code>CancellationToken</Code> when <Code>Src</Code> changes.</li>
+    </ul>
+
+    <Heading Id="accessibility" Level="2" Class="scroll-mt-20 mt-8">Accessibility</Heading>
+    <ul class="list-disc list-inside space-y-1 text-muted-foreground text-sm">
+        <li>Body region wears <Code>role="document"</Code> with an <Code>aria-label</Code> derived from the file name or kind.</li>
+        <li>Loading + error states announce via the default <Code>Spinner</Code> / <Code>EmptyState</Code> components (both come pre-wired with <Code>aria-live</Code>).</li>
+        <li>Video / audio kinds use native browser controls with their built-in keyboard handling.</li>
+        <li>The download anchor is keyboard-reachable with a visible focus ring on the toolbar.</li>
+    </ul>
+</div>
+
+@code {
+    // CORS-friendly samples; small enough to keep the demo page snappy.
+    private const string SamplePdfUrl = "https://mozilla.github.io/pdf.js/web/compressed.tracemonkey-pldi-09.pdf";
+    private const string SampleImageUrl = "https://upload.wikimedia.org/wikipedia/commons/thumb/4/47/PNG_transparency_demonstration_1.png/400px-PNG_transparency_demonstration_1.png";
+    private const string SampleMarkdownUrl = "https://raw.githubusercontent.com/octocat/Hello-World/master/README";
+    private const string SampleCsvUrl = "https://raw.githubusercontent.com/datasets/population/master/data/population.csv";
+    private const string SampleCodeUrl = "https://raw.githubusercontent.com/dotnet/runtime/main/src/libraries/System.Linq/src/System/Linq/Enumerable.cs";
+
+    private string _callbackSrc = SamplePdfUrl;
+    private FileKind? _lastDetectedKind;
+    private string? _errorMessage;
+
+    private void HandleKindDetected(FileKind kind) => _lastDetectedKind = kind;
+    private void HandleError(string msg) => _errorMessage = msg;
+
+    private static string TruncateError(string msg)
+    {
+        var firstLine = msg.Split('\n')[0];
+        var idx = firstLine.IndexOf(" at ", StringComparison.Ordinal);
+        if (idx > 0) firstLine = firstLine[..idx];
+        return firstLine.Length > 140 ? firstLine[..140] + "…" : firstLine;
+    }
+
+    // Per-kind override: render images inside a styled frame instead of the
+    // built-in plain <img>. Keys are FileKind, values are RenderFragment<ctx>.
+    private readonly IReadOnlyDictionary<FileKind, RenderFragment<FileViewerRenderContext>> _imageRenderer =
+        new Dictionary<FileKind, RenderFragment<FileViewerRenderContext>>
+        {
+            [FileKind.Image] = ctx => __builder =>
+            {
+                __builder.OpenElement(0, "div");
+                __builder.AddAttribute(1, "class", "flex h-full items-center justify-center bg-gradient-to-br from-primary/10 to-accent/10 p-6");
+                __builder.OpenElement(2, "img");
+                __builder.AddAttribute(3, "src", ctx.Src);
+                __builder.AddAttribute(4, "alt", ctx.FileName ?? "image");
+                __builder.AddAttribute(5, "class", "max-h-full max-w-full rounded-lg shadow-2xl ring-1 ring-border");
+                __builder.CloseElement();
+                __builder.CloseElement();
+            },
+        };
+
+    private const string _autoCode = """
+@* Detection from URL extension *@
+<FileViewer Src="https://example.com/report.pdf"     Class="h-[420px]" />
+<FileViewer Src="https://example.com/photo.png"      Class="h-[320px]" />
+<FileViewer Src="https://example.com/README.md"      Class="h-[420px]" />
+<FileViewer Src="https://example.com/data.csv"       Class="h-[360px]" />
+<FileViewer Src="https://example.com/Program.cs"     FileName="Program.cs" Class="h-[360px]" />
+""";
+
+    private const string _kindOverrideCode = """
+@* Blob URL has no extension — force the kind explicitly *@
+<FileViewer Src="@_blobUrl"
+            Kind="FileKind.Pdf"
+            FileName="report.pdf"
+            Class="h-[400px]" />
+""";
+
+    private const string _mimeOverrideCode = """
+@* Backend already knows the MIME; pass it to skip extension detection *@
+<FileViewer Src="@_url"
+            MimeType="image/png"
+            FileName="screenshot.png"
+            Class="h-[320px]" />
+""";
+
+    private const string _kindCallbackCode = """
+<FileViewer Src="@_url"
+            OnKindDetected="HandleKindDetected"
+            Class="h-[320px]" />
+
+@code {
+    private FileKind? _detected;
+    private void HandleKindDetected(FileKind kind) => _detected = kind;
+}
+""";
+
+    private const string _unknownCode = """
+@* ZIPs aren't previewable — falls back to a Download CTA *@
+<FileViewer Src="https://example.com/archive.zip"
+            FileName="archive.zip"
+            Class="h-[320px]" />
+""";
+
+    private const string _errorCode = """
+<FileViewer Src="https://lumeo.invalid/does-not-exist.csv"
+            OnError="HandleError"
+            Class="h-[280px]" />
+
+@code {
+    private string? _errorMessage;
+    private void HandleError(string msg) => _errorMessage = msg;
+}
+""";
+
+    private const string _chromelessCode = """
+<FileViewer Src="@_imageUrl"
+            ShowToolbar="false"
+            Class="h-[320px]" />
+""";
+
+    private const string _customRendererCode = """
+<FileViewer Src="@_imageUrl"
+            CustomRenderers="_renderers"
+            Class="h-[320px]" />
+
+@code {
+    // Override the Image kind with a styled frame; built-in renderers stay
+    // active for every other kind.
+    private readonly Dictionary<FileKind, RenderFragment<FileViewerRenderContext>> _renderers = new()
+    {
+        [FileKind.Image] = ctx =>
+            @<div class="flex h-full items-center justify-center bg-gradient-to-br from-primary/10 to-accent/10 p-6">
+                <img src="@ctx.Src"
+                     alt="@(ctx.FileName ?? "image")"
+                     class="max-h-full max-w-full rounded-lg shadow-2xl ring-1 ring-border" />
+            </div>,
+    };
+}
+""";
+
+}

--- a/docs/Lumeo.Docs/Pages/Home.razor
+++ b/docs/Lumeo.Docs/Pages/Home.razor
@@ -1219,6 +1219,7 @@ builder.Services.<span style="color: #a78bfa;">AddLumeo</span>();</pre>
             ("component:empty-state",      "EmptyState",        "Illustrated placeholder for empty lists with call-to-action.",                       "Feedback",     "/components/empty-state"),
             ("component:file-manager",     "FileManager",       "Headless file and folder explorer with tree, breadcrumb, and lazy loading.",         "Data Display", "/components/file-manager"),
             ("component:file-upload",      "FileUpload",        "Drag-and-drop file dropzone with progress and validation.",                          "Forms",        "/components/file-upload"),
+            ("component:file-viewer",      "FileViewer",        "Universal file preview — detects PDF, image, video, audio, markdown, code, JSON, CSV by MIME / extension.", "Data Display", "/components/file-viewer"),
             ("component:filter",           "Filter",            "Composable faceted filter builder with chips.",                                      "Data Display", "/components/filter"),
             ("component:flex",             "Flex",              "Flexbox wrapper exposing direction, gap, align, justify as props.",                  "Layout",       "/components/flex"),
             ("component:form",             "Form",              "EditForm wrapper with styled validation, field groups, and submit state.",            "Forms",        "/components/form"),

--- a/docs/Lumeo.Docs/wwwroot/js/docs.js
+++ b/docs/Lumeo.Docs/wwwroot/js/docs.js
@@ -10,9 +10,16 @@ window.lumeo.signalBlazorReady = function () {
 
 // Scroll a heading into view from the OnThisPage sidebar. Using a dedicated
 // function instead of eval() avoids CSP issues and keeps interop auditable.
+// Also reflects the section into the URL hash so right-click "copy link"
+// and browser-share produce a deep link like /components/datagrid#full-featured-datagrid
+// instead of the bare route. replaceState (not pushState) keeps the back
+// button focused on real route changes rather than TOC scrolls.
 window.lumeo.navScrollActiveIntoView = function (id) {
     var el = document.getElementById(id);
-    if (el) el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    if (el) {
+        el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+        try { history.replaceState(null, '', '#' + id); } catch (_) { /* SSR / sandboxed */ }
+    }
 };
 
 // Reset the scrollTop of an element by id. Avoids `eval()` for CSP compatibility.

--- a/src/Lumeo.DataGrid/UI/DataGrid/DataGridRow.razor
+++ b/src/Lumeo.DataGrid/UI/DataGrid/DataGridRow.razor
@@ -32,7 +32,12 @@
            left:0 so it stays visible during horizontal scroll and doesn't slide
            behind the pinned data column. Matches the z-index of DataGridHeaderCell
            pinned headers (z-20 on thead, z-10 on body cells). *@
-        <td role="gridcell" class="@(Context.HasPinnedLeft ? "px-3 py-2 w-10 sticky left-0 z-10 group-hover/row:bg-muted/50" : "px-3 py-2 w-10")" style="@SelectionPinStyle">
+        @* stopPropagation is required: without it, clicking the checkbox toggles
+           selection (via OnCheckChanged) AND the click bubbles to <tr>'s HandleClick
+           which toggles selection again — net no-op. The single-select cell below
+           already does this on its <button>. *@
+        <td role="gridcell" class="@(Context.HasPinnedLeft ? "px-3 py-2 w-10 sticky left-0 z-10 group-hover/row:bg-muted/50" : "px-3 py-2 w-10")" style="@SelectionPinStyle"
+            @onclick:stopPropagation="true">
             <Checkbox Checked="@IsSelected" CheckedChanged="@OnCheckChanged" />
         </td>
     }

--- a/src/Lumeo.FileViewer/Lumeo.FileViewer.csproj
+++ b/src/Lumeo.FileViewer/Lumeo.FileViewer.csproj
@@ -1,0 +1,61 @@
+<Project Sdk="Microsoft.NET.Sdk.Razor">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <SupportedPlatform>browser</SupportedPlatform>
+    <!-- RootNamespace must be "Lumeo" (matching @namespace in .razor files), NOT "Lumeo.FileViewer"
+         (which would be the SDK default derived from the project name). Diverging the two
+         causes the Razor SDK source generator to emit duplicate types (CS0101). -->
+    <RootNamespace>Lumeo</RootNamespace>
+    <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
+    <CompilerGeneratedFilesOutputPath>$(BaseIntermediateOutputPath)GeneratedFiles</CompilerGeneratedFilesOutputPath>
+
+    <!-- NuGet Package Metadata -->
+    <PackageId>Lumeo.FileViewer</PackageId>
+    <!-- Version is inherited from /Directory.Build.props (lockstep with all Lumeo packages) -->
+    <Title>Lumeo.FileViewer</Title>
+    <Authors>nativ.sh</Authors>
+    <Description>Universal file viewer for Lumeo — detects file type from MIME / extension and renders inline: PDF (via Lumeo.PdfViewer), images, video, audio, Markdown, JSON, CSV, source code (via Lumeo.CodeEditor) and plain text. Pluggable renderer registry; auth-aware via configurable HttpClient. Unknown types fall back to a Download CTA.</Description>
+    <PackageTags>blazor;components;ui;file-viewer;preview;document-viewer;markdown;csv;lumeo</PackageTags>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <PackageProjectUrl>https://github.com/Brain2k-0005/Lumeo</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/Brain2k-0005/Lumeo</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+
+    <!-- NuGet health -->
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <Deterministic>true</Deterministic>
+    <ContinuousIntegrationBuild Condition="'$(GITHUB_ACTIONS)' == 'true'">true</ContinuousIntegrationBuild>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- Expose internal CSV parser to the test project for direct coverage
+         without promoting it to the public API surface. -->
+    <InternalsVisibleTo Include="Lumeo.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Blazicons.Lucide" Version="2.1.3" />
+    <PackageReference Include="Markdig" Version="0.37.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="10.0.6" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- Core for shared types (ComponentInteropService, theme primitives, Spinner / EmptyState),
+         PdfViewer for the PDF kind, CodeEditor for the Code kind. Both satellites are
+         hard dependencies — consumers who want only a subset of kinds still pay the
+         transitive package size, but the alternative (reflection-based soft-dep) is too
+         fragile for an enterprise viewer. -->
+    <ProjectReference Include="..\Lumeo\Lumeo.csproj" />
+    <ProjectReference Include="..\Lumeo.PdfViewer\Lumeo.PdfViewer.csproj" />
+    <ProjectReference Include="..\Lumeo.CodeEditor\Lumeo.CodeEditor.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Lumeo.FileViewer/UI/FileViewer/FileKind.cs
+++ b/src/Lumeo.FileViewer/UI/FileViewer/FileKind.cs
@@ -1,0 +1,22 @@
+namespace Lumeo;
+
+/// <summary>
+/// Kind of content <see cref="FileViewer"/> renders. Drives which renderer is
+/// invoked and which icon / aria-label is shown in the toolbar.
+/// <c>Auto</c> is the default and triggers detection from MIME / extension /
+/// HEAD content-type; everything else short-circuits detection.
+/// </summary>
+public enum FileKind
+{
+    Auto,
+    Pdf,
+    Image,
+    Video,
+    Audio,
+    Markdown,
+    Code,
+    Json,
+    Csv,
+    Text,
+    Unknown,
+}

--- a/src/Lumeo.FileViewer/UI/FileViewer/FileTypeDetector.cs
+++ b/src/Lumeo.FileViewer/UI/FileViewer/FileTypeDetector.cs
@@ -1,0 +1,156 @@
+using System.Collections.Generic;
+
+namespace Lumeo;
+
+/// <summary>
+/// Pure-logic helpers for inferring <see cref="FileKind"/> from a URL / file
+/// name extension or from an HTTP <c>Content-Type</c>. No I/O — callers do the
+/// HEAD request and pass the value in.
+/// </summary>
+public static class FileTypeDetector
+{
+    // Extension → kind. Listed lower-case; lookup is case-insensitive.
+    // Curated to avoid false positives on the boundary kinds (.txt vs .log:
+    // both are Text; .yaml is Code via highlighter rather than Text so the
+    // CodeEditor renders syntax instead of a plain <pre>).
+    public static readonly IReadOnlyDictionary<string, FileKind> ByExtension = new Dictionary<string, FileKind>(StringComparer.OrdinalIgnoreCase)
+    {
+        // PDF
+        [".pdf"] = FileKind.Pdf,
+        // Images
+        [".png"] = FileKind.Image, [".jpg"] = FileKind.Image, [".jpeg"] = FileKind.Image,
+        [".gif"] = FileKind.Image, [".webp"] = FileKind.Image, [".avif"] = FileKind.Image,
+        [".bmp"] = FileKind.Image, [".ico"] = FileKind.Image, [".svg"] = FileKind.Image,
+        [".heic"] = FileKind.Image, [".heif"] = FileKind.Image,
+        // Video
+        [".mp4"] = FileKind.Video, [".webm"] = FileKind.Video, [".ogv"] = FileKind.Video,
+        [".mov"] = FileKind.Video, [".m4v"] = FileKind.Video,
+        // Audio
+        [".mp3"] = FileKind.Audio, [".wav"] = FileKind.Audio, [".ogg"] = FileKind.Audio,
+        [".oga"] = FileKind.Audio, [".m4a"] = FileKind.Audio, [".flac"] = FileKind.Audio,
+        [".aac"] = FileKind.Audio,
+        // Markdown
+        [".md"] = FileKind.Markdown, [".markdown"] = FileKind.Markdown, [".mdx"] = FileKind.Markdown,
+        // CSV / TSV
+        [".csv"] = FileKind.Csv, [".tsv"] = FileKind.Csv,
+        // JSON
+        [".json"] = FileKind.Json, [".jsonc"] = FileKind.Json, [".json5"] = FileKind.Json,
+        // Code (handled by Lumeo.CodeEditor with detected language)
+        [".cs"] = FileKind.Code, [".razor"] = FileKind.Code,
+        [".ts"] = FileKind.Code, [".tsx"] = FileKind.Code,
+        [".js"] = FileKind.Code, [".jsx"] = FileKind.Code, [".mjs"] = FileKind.Code, [".cjs"] = FileKind.Code,
+        [".py"] = FileKind.Code, [".rb"] = FileKind.Code, [".go"] = FileKind.Code,
+        [".rs"] = FileKind.Code, [".java"] = FileKind.Code, [".kt"] = FileKind.Code,
+        [".swift"] = FileKind.Code, [".c"] = FileKind.Code, [".cpp"] = FileKind.Code,
+        [".cc"] = FileKind.Code, [".cxx"] = FileKind.Code,
+        [".h"] = FileKind.Code, [".hpp"] = FileKind.Code,
+        [".php"] = FileKind.Code, [".sh"] = FileKind.Code, [".bash"] = FileKind.Code,
+        [".zsh"] = FileKind.Code, [".fish"] = FileKind.Code,
+        [".ps1"] = FileKind.Code, [".sql"] = FileKind.Code,
+        [".yaml"] = FileKind.Code, [".yml"] = FileKind.Code, [".toml"] = FileKind.Code,
+        [".xml"] = FileKind.Code, [".html"] = FileKind.Code, [".htm"] = FileKind.Code,
+        [".css"] = FileKind.Code, [".scss"] = FileKind.Code, [".sass"] = FileKind.Code,
+        [".less"] = FileKind.Code,
+        [".dockerfile"] = FileKind.Code,
+        // Text — last resort for human-readable, no syntax to highlight
+        [".txt"] = FileKind.Text, [".log"] = FileKind.Text,
+        [".ini"] = FileKind.Text, [".conf"] = FileKind.Text, [".cfg"] = FileKind.Text,
+        [".env"] = FileKind.Text,
+    };
+
+    // Maps a Code-kind extension to the language token Lumeo.CodeEditor's
+    // CodeMirror wrapper understands (see Lumeo.CodeEditor/wwwroot/js/code-editor.js).
+    // Anything not listed falls back to "plaintext", which still gives a
+    // reasonable monospace render without syntax colors.
+    public static readonly IReadOnlyDictionary<string, string> CodeLanguageByExtension = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+    {
+        [".cs"] = "csharp", [".razor"] = "csharp",
+        [".ts"] = "typescript", [".tsx"] = "typescript",
+        [".js"] = "javascript", [".jsx"] = "javascript", [".mjs"] = "javascript", [".cjs"] = "javascript",
+        [".py"] = "python",
+        [".sql"] = "sql",
+        [".html"] = "html", [".htm"] = "html", [".xml"] = "xml",
+        [".css"] = "css", [".scss"] = "css", [".sass"] = "css", [".less"] = "css",
+        [".md"] = "markdown", [".markdown"] = "markdown", [".mdx"] = "markdown",
+        [".json"] = "json", [".jsonc"] = "json", [".json5"] = "json",
+    };
+
+    // MIME → kind for exact matches. Wildcards (image/*, video/*, audio/*,
+    // text/*) are handled in DetectFromMime below.
+    public static readonly IReadOnlyDictionary<string, FileKind> ByMime = new Dictionary<string, FileKind>(StringComparer.OrdinalIgnoreCase)
+    {
+        ["application/pdf"] = FileKind.Pdf,
+        ["text/markdown"] = FileKind.Markdown,
+        ["text/csv"] = FileKind.Csv,
+        ["text/tab-separated-values"] = FileKind.Csv,
+        ["application/json"] = FileKind.Json,
+        ["application/ld+json"] = FileKind.Json,
+        ["application/xml"] = FileKind.Code,
+        ["text/xml"] = FileKind.Code,
+        ["text/html"] = FileKind.Code,
+        ["text/css"] = FileKind.Code,
+        ["text/javascript"] = FileKind.Code,
+        ["application/javascript"] = FileKind.Code,
+        ["application/typescript"] = FileKind.Code,
+        ["text/x-csharp"] = FileKind.Code,
+        ["text/x-python"] = FileKind.Code,
+        ["text/x-yaml"] = FileKind.Code,
+        ["application/x-yaml"] = FileKind.Code,
+        ["application/sql"] = FileKind.Code,
+    };
+
+    /// <summary>
+    /// Strip query string and fragment from <paramref name="src"/>, then
+    /// return the last path segment's lower-case extension (including the
+    /// leading dot), or empty string if there is none.
+    /// </summary>
+    public static string ExtensionFor(string? src)
+    {
+        if (string.IsNullOrWhiteSpace(src)) return string.Empty;
+        var s = src;
+        var qIdx = s.IndexOfAny(new[] { '?', '#' });
+        if (qIdx >= 0) s = s[..qIdx];
+        // strip trailing slash (directory-style URLs)
+        s = s.TrimEnd('/');
+        var slash = s.LastIndexOf('/');
+        var name = slash >= 0 ? s[(slash + 1)..] : s;
+        var dot = name.LastIndexOf('.');
+        return dot >= 0 ? name[dot..].ToLowerInvariant() : string.Empty;
+    }
+
+    /// <summary>Best-guess <see cref="FileKind"/> from a URL / file name's extension.</summary>
+    public static FileKind DetectFromExtension(string? src)
+    {
+        var ext = ExtensionFor(src);
+        if (ext.Length == 0) return FileKind.Unknown;
+        return ByExtension.TryGetValue(ext, out var k) ? k : FileKind.Unknown;
+    }
+
+    /// <summary>
+    /// Map an HTTP <c>Content-Type</c> header (with optional parameters) to a
+    /// <see cref="FileKind"/>. Parameters like <c>;charset=utf-8</c> are
+    /// stripped before lookup.
+    /// </summary>
+    public static FileKind DetectFromMime(string? mime)
+    {
+        if (string.IsNullOrWhiteSpace(mime)) return FileKind.Unknown;
+        var bare = mime.Split(';', 2)[0].Trim();
+        if (ByMime.TryGetValue(bare, out var k)) return k;
+        if (bare.StartsWith("image/", StringComparison.OrdinalIgnoreCase)) return FileKind.Image;
+        if (bare.StartsWith("video/", StringComparison.OrdinalIgnoreCase)) return FileKind.Video;
+        if (bare.StartsWith("audio/", StringComparison.OrdinalIgnoreCase)) return FileKind.Audio;
+        if (bare.StartsWith("text/", StringComparison.OrdinalIgnoreCase)) return FileKind.Text;
+        return FileKind.Unknown;
+    }
+
+    /// <summary>
+    /// CodeMirror language token for a code file, derived from its extension.
+    /// Returns <c>"plaintext"</c> for anything not in
+    /// <see cref="CodeLanguageByExtension"/>.
+    /// </summary>
+    public static string CodeLanguageFor(string? src)
+    {
+        var ext = ExtensionFor(src);
+        return CodeLanguageByExtension.TryGetValue(ext, out var lang) ? lang : "plaintext";
+    }
+}

--- a/src/Lumeo.FileViewer/UI/FileViewer/FileViewer.razor
+++ b/src/Lumeo.FileViewer/UI/FileViewer/FileViewer.razor
@@ -37,7 +37,7 @@
     consumer can:
       - Pass a custom HttpClient via HttpClient= (most explicit)
       - Hook ConfigureRequest= to add auth headers on the default client
-      - Register HttpClient / IHttpClientFactory in DI (standard Blazor)
+      - Register HttpClient in DI (the standard Blazor WASM pattern)
 
     All fetches honour MaxBytes (default 10 MB) so a misconfigured signed URL
     can't OOM the browser. Switching Src cancels any in-flight fetch.
@@ -502,13 +502,17 @@
         _ => false,
     };
 
+    // Why no IHttpClientFactory fallback: it lives in the Microsoft.Extensions.Http
+    // package, which the standard Blazor WASM template does NOT pull in by default
+    // (templates register a single HttpClient via builder.Services.AddScoped). Taking
+    // that dep just to support `factory.CreateClient(...)` adds weight that 95% of
+    // consumers wouldn't use. Server / WebApp consumers who want a named client can
+    // pre-create it and pass via the HttpClient parameter.
     private HttpClient GetHttpClient()
     {
         if (HttpClient is not null) return HttpClient;
         var fromDi = Services.GetService(typeof(HttpClient)) as HttpClient;
         if (fromDi is not null) return fromDi;
-        var factory = Services.GetService(typeof(IHttpClientFactory)) as IHttpClientFactory;
-        if (factory is not null) return factory.CreateClient("Lumeo.FileViewer");
         // Last-resort: a transient client. Anti-pattern at scale, but a viewer
         // that throws on missing DI is worse UX than a single allocation.
         return new HttpClient();

--- a/src/Lumeo.FileViewer/UI/FileViewer/FileViewer.razor
+++ b/src/Lumeo.FileViewer/UI/FileViewer/FileViewer.razor
@@ -1,0 +1,715 @@
+@namespace Lumeo
+@using System.Globalization
+@using System.Net.Http
+@using System.Net.Http.Headers
+@using System.Text
+@using System.Text.Json
+@using System.Threading
+@using Markdig
+@implements IAsyncDisposable
+
+@*
+    FileViewer — universal preview component.
+
+    Resolution order for FileKind:
+      1. Explicit Kind parameter (anything other than Auto wins immediately).
+      2. Explicit MimeType parameter (consumer's authoritative MIME, typically
+         from a backend metadata response — most reliable for signed URLs and
+         blob URLs where the extension is hidden).
+      3. HEAD request Content-Type (only when AutoHead=true; off by default
+         because many CDNs and signed URLs reject HEAD with 405).
+      4. URL extension (last-resort guess from the path segment).
+
+    Rendering is by kind:
+      - Pdf      → Lumeo.PdfViewer (full toolbar inside; ShowToolbar=false on this wrapper)
+      - Image    → <img> with object-contain; SVG also via <img> (NOT inline,
+                   to avoid XSS through embedded <script>).
+      - Video    → <video controls>
+      - Audio    → <audio controls>
+      - Markdown → Markdig render with HTML disabled (no raw <script>/<iframe>)
+      - Code     → Lumeo.CodeEditor read-only with detected language
+      - Json     → CodeEditor read-only, pretty-printed when valid
+      - Csv      → simple parsed <table> (caps at MaxCsvRows for safety)
+      - Text     → <pre> with the raw content
+      - Unknown  → EmptyState + Download CTA
+
+    Text-based kinds (Markdown/Code/Json/Csv/Text) fetch via HttpClient. The
+    consumer can:
+      - Pass a custom HttpClient via HttpClient= (most explicit)
+      - Hook ConfigureRequest= to add auth headers on the default client
+      - Register HttpClient / IHttpClientFactory in DI (standard Blazor)
+
+    All fetches honour MaxBytes (default 10 MB) so a misconfigured signed URL
+    can't OOM the browser. Switching Src cancels any in-flight fetch.
+*@
+
+<div class="@RootClass" @attributes="AdditionalAttributes">
+    @if (ShowToolbar && _resolvedKind != FileKind.Pdf)
+    {
+        @* PDF kind delegates to PdfViewer which has its own toolbar.
+           Suppressing this one prevents a double-toolbar stack. *@
+        <div class="flex items-center justify-between gap-2 border-b border-border/40 bg-background/60 px-3 py-2">
+            <div class="flex min-w-0 items-center gap-2">
+                <span class="shrink-0 text-muted-foreground" aria-hidden="true">
+                    <Blazicon Svg="@KindIcon" class="h-4 w-4" />
+                </span>
+                @if (ShowFileName && !string.IsNullOrEmpty(DisplayName))
+                {
+                    <span class="truncate text-sm text-foreground" title="@DisplayName">@DisplayName</span>
+                }
+                else
+                {
+                    <span class="text-sm text-muted-foreground">@KindLabel</span>
+                }
+            </div>
+            <div class="flex items-center gap-1">
+                @if (ShowDownload && !string.IsNullOrEmpty(Src))
+                {
+                    <a href="@Src"
+                       download="@DisplayName"
+                       target="_blank"
+                       rel="noopener"
+                       class="@NavBtnClass"
+                       aria-label="Download file">
+                        <Blazicon Svg="Lucide.Download" class="h-4 w-4" />
+                    </a>
+                }
+            </div>
+        </div>
+    }
+
+    <div class="@BodyClass" role="document" aria-label="@(DisplayName ?? KindLabel)">
+        @if (string.IsNullOrWhiteSpace(Src))
+        {
+            <EmptyState Class="py-12"
+                        Title="No file"
+                        Description="Set the Src parameter to a file URL to display its contents.">
+                <IconContent>
+                    <Blazicon Svg="Lucide.File" class="h-10 w-10" />
+                </IconContent>
+            </EmptyState>
+        }
+        else if (_state == ViewState.Detecting || _state == ViewState.Fetching)
+        {
+            @if (LoadingTemplate is not null)
+            {
+                @LoadingTemplate
+            }
+            else
+            {
+                <div class="flex min-h-[200px] items-center justify-center">
+                    <Spinner />
+                </div>
+            }
+        }
+        else if (_state == ViewState.Error)
+        {
+            <EmptyState Class="py-12"
+                        Title="Could not display file"
+                        Description="@_errorMessage">
+                <IconContent>
+                    <Blazicon Svg="Lucide.FileX" class="h-10 w-10" />
+                </IconContent>
+            </EmptyState>
+        }
+        else if (CustomRenderers is not null && CustomRenderers.TryGetValue(_resolvedKind, out var custom))
+        {
+            @custom(new FileViewerRenderContext(Src!, _resolvedKind, _fetchedText, DisplayName))
+        }
+        else
+        {
+            @switch (_resolvedKind)
+            {
+                case FileKind.Pdf:
+                    <PdfViewer Src="@Src"
+                               ShowToolbar="@ShowToolbar"
+                               ShowDownload="@ShowDownload"
+                               OnError="HandleChildError"
+                               Class="h-full border-0 rounded-none" />
+                    break;
+                case FileKind.Image:
+                    <div class="flex h-full min-h-[200px] items-center justify-center p-4">
+                        <img src="@Src"
+                             alt="@(DisplayName ?? "Image")"
+                             class="max-h-full max-w-full object-contain"
+                             @onerror="HandleImageError" />
+                    </div>
+                    break;
+                case FileKind.Video:
+                    <div class="flex h-full min-h-[200px] items-center justify-center bg-black/90 p-2">
+                        <video src="@Src"
+                               controls
+                               preload="metadata"
+                               class="max-h-full max-w-full"
+                               aria-label="@(DisplayName ?? "Video")">
+                            Your browser does not support video playback.
+                        </video>
+                    </div>
+                    break;
+                case FileKind.Audio:
+                    <div class="flex h-full min-h-[120px] items-center justify-center p-6">
+                        <audio src="@Src"
+                               controls
+                               preload="metadata"
+                               class="w-full max-w-md"
+                               aria-label="@(DisplayName ?? "Audio")">
+                            Your browser does not support audio playback.
+                        </audio>
+                    </div>
+                    break;
+                case FileKind.Markdown:
+                    @* lumeo-markdown wrapper picks up the typography rules in
+                       _content/Lumeo.FileViewer/css/file-viewer.css. Without
+                       that stylesheet the content still renders via the user-
+                       agent stylesheet (headings + spacing) — readable, just
+                       less polished. *@
+                    <div class="lumeo-markdown px-6 py-4 text-sm text-foreground">
+                        @((MarkupString)(_renderedMarkdown ?? string.Empty))
+                    </div>
+                    break;
+                case FileKind.Code:
+                case FileKind.Json:
+                    <CodeEditor Value="@_fetchedText"
+                                Language="@_codeLanguage"
+                                ReadOnly="true"
+                                LineNumbers="true"
+                                Height="100%"
+                                Class="h-full border-0 rounded-none" />
+                    break;
+                case FileKind.Csv:
+                    @RenderCsv()
+                    break;
+                case FileKind.Text:
+                    <pre class="h-full overflow-auto whitespace-pre-wrap break-words bg-background px-4 py-3 text-xs text-foreground">@_fetchedText</pre>
+                    break;
+                default:
+                    <EmptyState Class="py-12"
+                                Title="Preview unavailable"
+                                Description="This file type cannot be previewed inline.">
+                        <IconContent>
+                            <Blazicon Svg="Lucide.File" class="h-10 w-10" />
+                        </IconContent>
+                        <Action>
+                            @if (!string.IsNullOrEmpty(Src))
+                            {
+                                <a href="@Src"
+                                   download="@DisplayName"
+                                   target="_blank"
+                                   rel="noopener"
+                                   class="inline-flex h-9 items-center gap-2 rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90 focus:outline-none focus-visible:ring-[1.5px] focus-visible:ring-ring">
+                                    <Blazicon Svg="Lucide.Download" class="h-4 w-4" />
+                                    <span>Download</span>
+                                </a>
+                            }
+                        </Action>
+                    </EmptyState>
+                    break;
+            }
+        }
+    </div>
+</div>
+
+@inject IServiceProvider Services
+@inject IJSRuntime JS
+
+@code {
+    [Parameter, EditorRequired] public string? Src { get; set; }
+
+    /// <summary>Override detection with an explicit kind. Default <see cref="FileKind.Auto"/>.</summary>
+    [Parameter] public FileKind Kind { get; set; } = FileKind.Auto;
+
+    /// <summary>
+    /// Explicit MIME type from your backend (e.g. <c>"application/pdf"</c>).
+    /// Wins over HEAD and extension detection but loses to an explicit
+    /// <see cref="Kind"/> override.
+    /// </summary>
+    [Parameter] public string? MimeType { get; set; }
+
+    /// <summary>
+    /// Human-readable file name. Used for the toolbar label, the download
+    /// attribute, and the <c>aria-label</c>. Falls back to the last URL path
+    /// segment when not provided.
+    /// </summary>
+    [Parameter] public string? FileName { get; set; }
+
+    /// <summary>
+    /// Issue a HEAD request to inspect <c>Content-Type</c> when neither
+    /// <see cref="Kind"/> nor <see cref="MimeType"/> is set. Off by default
+    /// because many CDNs and signed URLs reject HEAD with 405 / 403.
+    /// </summary>
+    [Parameter] public bool AutoHead { get; set; }
+
+    /// <summary>
+    /// Cap on the number of bytes fetched for text-based kinds (Markdown,
+    /// Code, JSON, CSV, Text). Default 10 MB. Excess content is truncated and
+    /// a one-line notice is appended.
+    /// </summary>
+    [Parameter] public long MaxBytes { get; set; } = 10L * 1024 * 1024;
+
+    /// <summary>Cap on the number of CSV rows rendered. Default 1000.</summary>
+    [Parameter] public int MaxCsvRows { get; set; } = 1000;
+
+    /// <summary>Show the top toolbar (file name + download). Default true.</summary>
+    [Parameter] public bool ShowToolbar { get; set; } = true;
+
+    /// <summary>Show the download button in the toolbar. Default true.</summary>
+    [Parameter] public bool ShowDownload { get; set; } = true;
+
+    /// <summary>Show the file name in the toolbar. Default true.</summary>
+    [Parameter] public bool ShowFileName { get; set; } = true;
+
+    /// <summary>
+    /// Plug a custom <see cref="HttpClient"/> for the text fetches. Use this
+    /// to attach a pre-configured Authorization handler instead of mutating
+    /// the default client. Wins over <see cref="ConfigureRequest"/>.
+    /// </summary>
+    [Parameter] public HttpClient? HttpClient { get; set; }
+
+    /// <summary>
+    /// Hook to mutate the outgoing <see cref="HttpRequestMessage"/> before
+    /// it's sent — typical use is adding an <c>Authorization</c> header for
+    /// signed-but-not-presigned URLs.
+    /// </summary>
+    [Parameter] public Func<HttpRequestMessage, Task>? ConfigureRequest { get; set; }
+
+    /// <summary>
+    /// Per-kind renderer overrides. The fragment receives a
+    /// <see cref="FileViewerRenderContext"/> with the resolved URL, kind, the
+    /// fetched text (when applicable) and the display name. When provided for
+    /// a given kind, the built-in renderer is bypassed for that kind.
+    /// </summary>
+    [Parameter] public IReadOnlyDictionary<FileKind, RenderFragment<FileViewerRenderContext>>? CustomRenderers { get; set; }
+
+    /// <summary>Custom loading view. Default is a centered Spinner.</summary>
+    [Parameter] public RenderFragment? LoadingTemplate { get; set; }
+
+    /// <summary>Fires once detection settles, with the resolved kind.</summary>
+    [Parameter] public EventCallback<FileKind> OnKindDetected { get; set; }
+
+    /// <summary>Fires when the file is fully rendered (text fetched, if any).</summary>
+    [Parameter] public EventCallback OnLoaded { get; set; }
+
+    /// <summary>Fires on any detection or fetch error, with a message.</summary>
+    [Parameter] public EventCallback<string> OnError { get; set; }
+
+    [Parameter] public string? Class { get; set; }
+
+    [Parameter(CaptureUnmatchedValues = true)] public Dictionary<string, object>? AdditionalAttributes { get; set; }
+
+    private enum ViewState { Detecting, Fetching, Loaded, Error }
+
+    private ViewState _state = ViewState.Detecting;
+    private FileKind _resolvedKind = FileKind.Auto;
+    private string? _fetchedText;
+    private string? _renderedMarkdown;
+    private string? _codeLanguage = "plaintext";
+    private string? _errorMessage;
+    private List<List<string>>? _csvRows;
+    private bool _csvTruncated;
+
+    private string? _lastSrc;
+    private FileKind _lastKindParam = FileKind.Auto;
+    private string? _lastMime;
+
+    private CancellationTokenSource? _cts;
+
+    private string RootClass
+        => $"flex flex-col rounded-xl border border-border/40 bg-card overflow-hidden min-h-[400px] {Class}".Trim();
+
+    private string BodyClass
+        => "relative flex-1 overflow-auto bg-muted/30";
+
+    private string NavBtnClass
+        => "inline-flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground hover:bg-accent hover:text-accent-foreground disabled:opacity-40 disabled:pointer-events-none focus:outline-none focus:ring-2 focus:ring-ring transition-colors";
+
+    // Display name precedence: explicit FileName > last segment of URL.
+    private string? DisplayName
+        => !string.IsNullOrWhiteSpace(FileName) ? FileName : LastSegment(Src);
+
+    private static string? LastSegment(string? src)
+    {
+        if (string.IsNullOrWhiteSpace(src)) return null;
+        var s = src;
+        var q = s.IndexOfAny(new[] { '?', '#' });
+        if (q >= 0) s = s[..q];
+        s = s.TrimEnd('/');
+        var slash = s.LastIndexOf('/');
+        return slash >= 0 ? s[(slash + 1)..] : s;
+    }
+
+    // Pipeline is shared across all instances; built once. .DisableHtml()
+    // strips raw <script>/<iframe>/etc. from user-supplied markdown — without
+    // it, a malicious .md served from a same-origin bucket becomes a stored
+    // XSS vector once we MarkupString the output.
+    private static readonly MarkdownPipeline _markdownPipeline =
+        new MarkdownPipelineBuilder()
+            .UseAdvancedExtensions()
+            .DisableHtml()
+            .Build();
+
+    private string KindLabel => _resolvedKind switch
+    {
+        FileKind.Pdf => "PDF document",
+        FileKind.Image => "Image",
+        FileKind.Video => "Video",
+        FileKind.Audio => "Audio",
+        FileKind.Markdown => "Markdown",
+        FileKind.Code => "Source code",
+        FileKind.Json => "JSON",
+        FileKind.Csv => "CSV",
+        FileKind.Text => "Text file",
+        _ => "File",
+    };
+
+    private SvgIcon KindIcon => _resolvedKind switch
+    {
+        FileKind.Pdf => Lucide.FileText,
+        FileKind.Image => Lucide.Image,
+        FileKind.Video => Lucide.Film,
+        FileKind.Audio => Lucide.Music,
+        FileKind.Markdown => Lucide.FileText,
+        FileKind.Code => Lucide.Code,
+        FileKind.Json => Lucide.Braces,
+        FileKind.Csv => Lucide.Table,
+        FileKind.Text => Lucide.FileText,
+        _ => Lucide.File,
+    };
+
+    protected override async Task OnParametersSetAsync()
+    {
+        var srcChanged = !string.Equals(_lastSrc, Src, StringComparison.Ordinal);
+        var kindChanged = _lastKindParam != Kind;
+        var mimeChanged = !string.Equals(_lastMime, MimeType, StringComparison.OrdinalIgnoreCase);
+
+        if (!srcChanged && !kindChanged && !mimeChanged) return;
+
+        _lastSrc = Src;
+        _lastKindParam = Kind;
+        _lastMime = MimeType;
+
+        // Cancel any in-flight work from a previous Src.
+        try { _cts?.Cancel(); } catch { /* swallow */ }
+        _cts?.Dispose();
+        _cts = new CancellationTokenSource();
+        var token = _cts.Token;
+
+        _fetchedText = null;
+        _renderedMarkdown = null;
+        _errorMessage = null;
+        _csvRows = null;
+        _csvTruncated = false;
+
+        if (string.IsNullOrWhiteSpace(Src))
+        {
+            _resolvedKind = FileKind.Unknown;
+            _state = ViewState.Loaded;
+            return;
+        }
+
+        _state = ViewState.Detecting;
+        StateHasChanged();
+
+        await ResolveAndPrepareAsync(token);
+    }
+
+    private async Task ResolveAndPrepareAsync(CancellationToken token)
+    {
+        try
+        {
+            _resolvedKind = await ResolveKindAsync(token);
+            _codeLanguage = _resolvedKind == FileKind.Json
+                ? "json"
+                : _resolvedKind == FileKind.Code
+                    ? FileTypeDetector.CodeLanguageFor(Src)
+                    : "plaintext";
+
+            if (OnKindDetected.HasDelegate)
+                await OnKindDetected.InvokeAsync(_resolvedKind);
+
+            if (RequiresTextFetch(_resolvedKind))
+            {
+                _state = ViewState.Fetching;
+                StateHasChanged();
+
+                var text = await FetchTextAsync(Src!, token);
+                _fetchedText = text;
+
+                if (_resolvedKind == FileKind.Markdown)
+                {
+                    _renderedMarkdown = Markdown.ToHtml(text ?? string.Empty, _markdownPipeline);
+                }
+                else if (_resolvedKind == FileKind.Json)
+                {
+                    _fetchedText = TryPrettyPrintJson(text);
+                }
+                else if (_resolvedKind == FileKind.Csv)
+                {
+                    (_csvRows, _csvTruncated) = ParseCsv(text ?? string.Empty, MaxCsvRows);
+                }
+            }
+
+            _state = ViewState.Loaded;
+            if (OnLoaded.HasDelegate) await OnLoaded.InvokeAsync();
+        }
+        catch (OperationCanceledException)
+        {
+            // Src changed mid-fetch; the new pass will drive the next render.
+            return;
+        }
+        catch (Exception ex)
+        {
+            _errorMessage = ex.Message;
+            _state = ViewState.Error;
+            if (OnError.HasDelegate) await OnError.InvokeAsync(ex.Message);
+        }
+        StateHasChanged();
+    }
+
+    private async Task<FileKind> ResolveKindAsync(CancellationToken token)
+    {
+        if (Kind != FileKind.Auto) return Kind;
+
+        var byMime = FileTypeDetector.DetectFromMime(MimeType);
+        if (byMime != FileKind.Unknown) return byMime;
+
+        if (AutoHead && !string.IsNullOrWhiteSpace(Src))
+        {
+            try
+            {
+                using var req = new HttpRequestMessage(HttpMethod.Head, Src);
+                if (ConfigureRequest is not null) await ConfigureRequest(req);
+                using var client = GetHttpClient();
+                using var resp = await client.SendAsync(req, HttpCompletionOption.ResponseHeadersRead, token);
+                if (resp.IsSuccessStatusCode)
+                {
+                    var ct = resp.Content.Headers.ContentType?.ToString();
+                    var kindFromHead = FileTypeDetector.DetectFromMime(ct);
+                    if (kindFromHead != FileKind.Unknown) return kindFromHead;
+                }
+            }
+            catch
+            {
+                // HEAD failures fall through to extension-based detection.
+            }
+        }
+
+        return FileTypeDetector.DetectFromExtension(Src);
+    }
+
+    private static bool RequiresTextFetch(FileKind k) => k switch
+    {
+        FileKind.Markdown or FileKind.Code or FileKind.Json or FileKind.Csv or FileKind.Text => true,
+        _ => false,
+    };
+
+    private HttpClient GetHttpClient()
+    {
+        if (HttpClient is not null) return HttpClient;
+        var fromDi = Services.GetService(typeof(HttpClient)) as HttpClient;
+        if (fromDi is not null) return fromDi;
+        var factory = Services.GetService(typeof(IHttpClientFactory)) as IHttpClientFactory;
+        if (factory is not null) return factory.CreateClient("Lumeo.FileViewer");
+        // Last-resort: a transient client. Anti-pattern at scale, but a viewer
+        // that throws on missing DI is worse UX than a single allocation.
+        return new HttpClient();
+    }
+
+    private async Task<string> FetchTextAsync(string src, CancellationToken token)
+    {
+        using var req = new HttpRequestMessage(HttpMethod.Get, src);
+        if (ConfigureRequest is not null) await ConfigureRequest(req);
+        var client = GetHttpClient();
+        using var resp = await client.SendAsync(req, HttpCompletionOption.ResponseHeadersRead, token);
+        resp.EnsureSuccessStatusCode();
+
+        var contentLength = resp.Content.Headers.ContentLength;
+        if (contentLength is long cl && cl > MaxBytes)
+        {
+            // Refuse upfront — better than streaming half a giant file into memory.
+            throw new InvalidOperationException($"File exceeds MaxBytes ({cl:N0} > {MaxBytes:N0}).");
+        }
+
+        await using var stream = await resp.Content.ReadAsStreamAsync(token);
+        using var ms = new MemoryStream();
+        var buffer = new byte[8192];
+        long total = 0;
+        int read;
+        while ((read = await stream.ReadAsync(buffer, token)) > 0)
+        {
+            total += read;
+            if (total > MaxBytes)
+            {
+                ms.Write(buffer, 0, (int)Math.Max(0, read - (total - MaxBytes)));
+                var truncated = Encoding.UTF8.GetString(ms.ToArray());
+                return truncated + Environment.NewLine + $"… (truncated at {MaxBytes:N0} bytes)";
+            }
+            ms.Write(buffer, 0, read);
+        }
+        return Encoding.UTF8.GetString(ms.ToArray());
+    }
+
+    // Re-serialize valid JSON with indentation. Invalid JSON is shown verbatim
+    // so consumers can spot syntax errors in their data — silently swallowing
+    // the parse failure would hide the real problem.
+    private static string TryPrettyPrintJson(string? text)
+    {
+        if (string.IsNullOrWhiteSpace(text)) return string.Empty;
+        try
+        {
+            using var doc = JsonDocument.Parse(text);
+            return JsonSerializer.Serialize(doc.RootElement, new JsonSerializerOptions { WriteIndented = true });
+        }
+        catch
+        {
+            return text;
+        }
+    }
+
+    // RFC 4180-ish CSV parser: handles quoted fields, embedded commas, escaped
+    // double-quotes (""), and bare LF / CRLF line endings. Comma is fixed;
+    // tab-separated values are detected by the first row containing a tab and
+    // no comma. Truncates at maxRows to keep huge logs renderable.
+    internal static (List<List<string>> rows, bool truncated) ParseCsv(string text, int maxRows)
+    {
+        var rows = new List<List<string>>();
+        if (string.IsNullOrEmpty(text)) return (rows, false);
+
+        char delim = ',';
+        // Cheap delimiter sniff: scan first newline.
+        var firstNl = text.IndexOfAny(new[] { '\r', '\n' });
+        var firstLine = firstNl >= 0 ? text[..firstNl] : text;
+        if (firstLine.Contains('\t') && !firstLine.Contains(',')) delim = '\t';
+
+        var field = new StringBuilder();
+        var row = new List<string>();
+        bool inQuotes = false;
+        for (int i = 0; i < text.Length; i++)
+        {
+            var c = text[i];
+            if (inQuotes)
+            {
+                if (c == '"')
+                {
+                    if (i + 1 < text.Length && text[i + 1] == '"') { field.Append('"'); i++; }
+                    else inQuotes = false;
+                }
+                else field.Append(c);
+            }
+            else
+            {
+                if (c == '"') inQuotes = true;
+                else if (c == delim) { row.Add(field.ToString()); field.Clear(); }
+                else if (c == '\r')
+                {
+                    if (i + 1 < text.Length && text[i + 1] == '\n') i++;
+                    row.Add(field.ToString()); field.Clear();
+                    rows.Add(row); row = new List<string>();
+                    if (rows.Count >= maxRows) return (rows, i + 1 < text.Length);
+                }
+                else if (c == '\n')
+                {
+                    row.Add(field.ToString()); field.Clear();
+                    rows.Add(row); row = new List<string>();
+                    if (rows.Count >= maxRows) return (rows, i + 1 < text.Length);
+                }
+                else field.Append(c);
+            }
+        }
+        if (field.Length > 0 || row.Count > 0)
+        {
+            row.Add(field.ToString());
+            rows.Add(row);
+        }
+        return (rows, false);
+    }
+
+    private RenderFragment RenderCsv() => builder =>
+    {
+        if (_csvRows is null || _csvRows.Count == 0)
+        {
+            builder.OpenComponent<EmptyState>(0);
+            builder.AddAttribute(1, "Class", "py-12");
+            builder.AddAttribute(2, "Title", "Empty CSV");
+            builder.AddAttribute(3, "Description", "The file contains no rows.");
+            builder.CloseComponent();
+            return;
+        }
+        var maxCols = 0;
+        foreach (var r in _csvRows) if (r.Count > maxCols) maxCols = r.Count;
+        var header = _csvRows[0];
+        var dataStart = 1;
+        // Heuristic: if the first row looks like header (all non-numeric, all
+        // shortish), use it as <thead>. Otherwise treat row 0 as data.
+        bool firstLooksLikeHeader = header.All(c => c.Length <= 64 && !double.TryParse(c, NumberStyles.Any, CultureInfo.InvariantCulture, out _));
+        if (!firstLooksLikeHeader) dataStart = 0;
+
+        builder.OpenElement(0, "div");
+        builder.AddAttribute(1, "class", "overflow-auto");
+
+        builder.OpenElement(2, "table");
+        builder.AddAttribute(3, "class", "min-w-full text-sm");
+
+        if (firstLooksLikeHeader)
+        {
+            builder.OpenElement(10, "thead");
+            builder.AddAttribute(11, "class", "sticky top-0 bg-background");
+            builder.OpenElement(12, "tr");
+            for (int c = 0; c < maxCols; c++)
+            {
+                builder.OpenElement(13, "th");
+                builder.AddAttribute(14, "class", "border-b border-border/60 px-3 py-2 text-left font-medium text-foreground");
+                builder.AddContent(15, c < header.Count ? header[c] : "");
+                builder.CloseElement();
+            }
+            builder.CloseElement(); // tr
+            builder.CloseElement(); // thead
+        }
+
+        builder.OpenElement(20, "tbody");
+        for (int r = dataStart; r < _csvRows.Count; r++)
+        {
+            var row = _csvRows[r];
+            builder.OpenElement(21, "tr");
+            builder.AddAttribute(22, "class", "border-b border-border/30 hover:bg-muted/40");
+            for (int c = 0; c < maxCols; c++)
+            {
+                builder.OpenElement(23, "td");
+                builder.AddAttribute(24, "class", "px-3 py-1.5 align-top text-foreground/90");
+                builder.AddContent(25, c < row.Count ? row[c] : "");
+                builder.CloseElement();
+            }
+            builder.CloseElement();
+        }
+        builder.CloseElement(); // tbody
+
+        builder.CloseElement(); // table
+
+        if (_csvTruncated)
+        {
+            builder.OpenElement(30, "div");
+            builder.AddAttribute(31, "class", "border-t border-border/40 bg-background/60 px-3 py-2 text-xs text-muted-foreground");
+            builder.AddContent(32, $"Truncated at {MaxCsvRows:N0} rows.");
+            builder.CloseElement();
+        }
+
+        builder.CloseElement(); // outer div
+    };
+
+    private Task HandleImageError() => HandleChildError("Image failed to load.");
+
+    private async Task HandleChildError(string message)
+    {
+        _errorMessage = message;
+        _state = ViewState.Error;
+        if (OnError.HasDelegate) await OnError.InvokeAsync(message);
+        StateHasChanged();
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        try { _cts?.Cancel(); } catch { /* swallow */ }
+        _cts?.Dispose();
+        _cts = null;
+        return ValueTask.CompletedTask;
+    }
+}

--- a/src/Lumeo.FileViewer/UI/FileViewer/FileViewerRenderContext.cs
+++ b/src/Lumeo.FileViewer/UI/FileViewer/FileViewerRenderContext.cs
@@ -1,0 +1,13 @@
+namespace Lumeo;
+
+/// <summary>
+/// Argument passed to a <see cref="FileViewer.CustomRenderers"/> fragment. The
+/// fetched <see cref="Text"/> is only populated for text-based kinds
+/// (Markdown, Code, JSON, CSV, Text); for binary kinds (Image, Video, Audio,
+/// PDF) it is <c>null</c> and renderers should consume <see cref="Src"/>.
+/// </summary>
+public sealed record FileViewerRenderContext(
+    string Src,
+    FileKind Kind,
+    string? Text,
+    string? FileName);

--- a/src/Lumeo.FileViewer/_Imports.razor
+++ b/src/Lumeo.FileViewer/_Imports.razor
@@ -1,0 +1,7 @@
+@using Microsoft.AspNetCore.Components
+@using Microsoft.AspNetCore.Components.Forms
+@using Microsoft.AspNetCore.Components.Web
+@using Microsoft.AspNetCore.Components.Web.Virtualization
+@using Microsoft.JSInterop
+@using Blazicons
+@using Lumeo.Services

--- a/src/Lumeo.FileViewer/wwwroot/css/file-viewer.css
+++ b/src/Lumeo.FileViewer/wwwroot/css/file-viewer.css
@@ -1,0 +1,123 @@
+/* Lumeo.FileViewer — markdown typography for the Markdown render kind.
+ *
+ * Optional: served at /_content/Lumeo.FileViewer/css/file-viewer.css for
+ * consumers who want polished markdown. Without it the content still renders
+ * via the user-agent stylesheet, just without our spacing / radius tweaks.
+ *
+ * Scoped to `.lumeo-markdown` so it never bleeds into the host app's own
+ * markdown styles. All colors go through Lumeo's CSS variables so dark mode
+ * follows automatically. */
+
+.lumeo-markdown { line-height: 1.6; }
+
+.lumeo-markdown > :first-child { margin-top: 0; }
+.lumeo-markdown > :last-child  { margin-bottom: 0; }
+
+.lumeo-markdown h1,
+.lumeo-markdown h2,
+.lumeo-markdown h3,
+.lumeo-markdown h4,
+.lumeo-markdown h5,
+.lumeo-markdown h6 {
+  margin-top: 1.5em;
+  margin-bottom: 0.6em;
+  font-weight: 600;
+  line-height: 1.25;
+  color: var(--color-foreground);
+}
+.lumeo-markdown h1 { font-size: 1.5rem; border-bottom: 1px solid var(--color-border); padding-bottom: 0.3em; }
+.lumeo-markdown h2 { font-size: 1.25rem; border-bottom: 1px solid var(--color-border); padding-bottom: 0.25em; }
+.lumeo-markdown h3 { font-size: 1.125rem; }
+.lumeo-markdown h4 { font-size: 1rem; }
+.lumeo-markdown h5 { font-size: 0.95rem; }
+.lumeo-markdown h6 { font-size: 0.9rem; color: var(--color-muted-foreground); }
+
+.lumeo-markdown p { margin: 0.75em 0; }
+
+.lumeo-markdown a {
+  color: var(--color-primary);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+.lumeo-markdown a:hover { text-decoration: none; }
+
+.lumeo-markdown ul,
+.lumeo-markdown ol {
+  margin: 0.75em 0;
+  padding-left: 1.5em;
+}
+.lumeo-markdown ul { list-style: disc; }
+.lumeo-markdown ol { list-style: decimal; }
+.lumeo-markdown li { margin: 0.25em 0; }
+.lumeo-markdown li > ul,
+.lumeo-markdown li > ol { margin: 0.25em 0; }
+
+.lumeo-markdown blockquote {
+  margin: 1em 0;
+  padding: 0.25em 1em;
+  border-left: 4px solid var(--color-border);
+  color: var(--color-muted-foreground);
+}
+
+.lumeo-markdown code {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.875em;
+  padding: 0.15em 0.35em;
+  border-radius: var(--radius, 0.375rem);
+  background: var(--color-muted);
+  color: var(--color-foreground);
+}
+.lumeo-markdown pre {
+  margin: 1em 0;
+  padding: 0.9em 1em;
+  overflow-x: auto;
+  background: var(--color-muted);
+  border-radius: var(--radius, 0.5rem);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.875em;
+  line-height: 1.5;
+}
+.lumeo-markdown pre code {
+  padding: 0;
+  background: transparent;
+  border-radius: 0;
+}
+
+.lumeo-markdown hr {
+  margin: 1.5em 0;
+  border: 0;
+  border-top: 1px solid var(--color-border);
+}
+
+.lumeo-markdown table {
+  width: 100%;
+  margin: 1em 0;
+  border-collapse: collapse;
+  font-size: 0.9em;
+}
+.lumeo-markdown th,
+.lumeo-markdown td {
+  border: 1px solid var(--color-border);
+  padding: 0.4em 0.7em;
+  text-align: left;
+}
+.lumeo-markdown th {
+  background: var(--color-muted);
+  font-weight: 600;
+}
+
+.lumeo-markdown img {
+  max-width: 100%;
+  border-radius: var(--radius, 0.375rem);
+}
+
+.lumeo-markdown kbd {
+  display: inline-block;
+  padding: 0.1em 0.4em;
+  border: 1px solid var(--color-border);
+  border-radius: 0.25rem;
+  background: var(--color-muted);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.8em;
+  vertical-align: middle;
+}

--- a/tests/Lumeo.Tests/Components/DataGrid/DataGridTests.cs
+++ b/tests/Lumeo.Tests/Components/DataGrid/DataGridTests.cs
@@ -313,6 +313,32 @@ public class DataGridTests : IAsyncLifetime
         Assert.Equal("Alice", capturedSelection![0].Name);
     }
 
+    [Fact]
+    public void DataGrid_Multiple_Mode_Checkbox_Click_Toggles_Selection_Without_Double_Fire()
+    {
+        // Regression: clicking the row's selection checkbox in Multiple mode used to
+        // double-toggle (checkbox OnCheckChanged toggled, then the click bubbled to
+        // <tr> HandleClick which toggled again → net no-op). The selection cell's <td>
+        // now stops propagation; this test locks that in.
+        IReadOnlyList<TestItem>? capturedSelection = null;
+
+        var cut = _ctx.Render<DataGrid<TestItem>>(p => p
+            .Add(x => x.Items, GetTestData())
+            .Add(x => x.Columns, GetColumns())
+            .Add(x => x.SelectionMode, DataGridSelectionMode.Multiple)
+            .Add(x => x.SelectedItemsChanged, EventCallback.Factory.Create<IReadOnlyList<TestItem>>(
+                this, list => capturedSelection = list)));
+
+        // First <button role="checkbox"> in the body is the first data row's selector
+        // (header select-all sits in <thead> and isn't matched here).
+        var checkbox = cut.FindAll("tbody [role='checkbox']")[0];
+        checkbox.Click();
+
+        Assert.NotNull(capturedSelection);
+        Assert.Single(capturedSelection);
+        Assert.Equal("Alice", capturedSelection![0].Name);
+    }
+
     // ===========================================================================
     // LOADING STATE
     // ===========================================================================

--- a/tests/Lumeo.Tests/Components/FileViewer/FileTypeDetectorTests.cs
+++ b/tests/Lumeo.Tests/Components/FileViewer/FileTypeDetectorTests.cs
@@ -1,0 +1,118 @@
+using Xunit;
+
+namespace Lumeo.Tests.Components.FileViewerComponent;
+
+public class FileTypeDetectorTests
+{
+    [Theory]
+    // PDF
+    [InlineData("https://cdn.example.com/report.pdf", FileKind.Pdf)]
+    // Images
+    [InlineData("avatar.png", FileKind.Image)]
+    [InlineData("photo.JPG", FileKind.Image)]
+    [InlineData("vector.svg", FileKind.Image)]
+    [InlineData("modern.webp", FileKind.Image)]
+    // Video / audio
+    [InlineData("/clips/demo.mp4", FileKind.Video)]
+    [InlineData("song.flac", FileKind.Audio)]
+    // Markdown / CSV / JSON
+    [InlineData("README.md", FileKind.Markdown)]
+    [InlineData("data.csv", FileKind.Csv)]
+    [InlineData("payload.json", FileKind.Json)]
+    // Code
+    [InlineData("Program.cs", FileKind.Code)]
+    [InlineData("app.tsx", FileKind.Code)]
+    [InlineData("query.sql", FileKind.Code)]
+    [InlineData("script.py", FileKind.Code)]
+    // Text fallbacks
+    [InlineData("debug.log", FileKind.Text)]
+    [InlineData("app.txt", FileKind.Text)]
+    // Unknown
+    [InlineData("archive.zip", FileKind.Unknown)]
+    [InlineData("/folder/", FileKind.Unknown)]
+    [InlineData("", FileKind.Unknown)]
+    public void DetectFromExtension_Maps_Known_Extensions(string src, FileKind expected)
+    {
+        Assert.Equal(expected, FileTypeDetector.DetectFromExtension(src));
+    }
+
+    [Theory]
+    // Path segment has no dot → must NOT mistakenly read "?download" or
+    // "#frag" as the extension.
+    [InlineData("https://api.example.com/files/secret?download=true&token=abc#frag")]
+    [InlineData("/path/to/file#section-1")]
+    public void DetectFromExtension_Ignores_Query_And_Fragment_When_No_Extension(string src)
+    {
+        Assert.Equal(FileKind.Unknown, FileTypeDetector.DetectFromExtension(src));
+    }
+
+    [Theory]
+    // Path segment HAS an extension; query/fragment after it must be stripped.
+    [InlineData("doc.pdf?token=abc", FileKind.Pdf)]
+    [InlineData("image.png#preview", FileKind.Image)]
+    [InlineData("data.json?v=2&pretty=true", FileKind.Json)]
+    public void DetectFromExtension_Strips_Query_And_Fragment(string src, FileKind expected)
+    {
+        Assert.Equal(expected, FileTypeDetector.DetectFromExtension(src));
+    }
+
+    [Fact]
+    public void DetectFromExtension_Uses_Final_Segment_Even_With_Dotted_Path()
+    {
+        // The .com in the host must not be treated as the extension.
+        Assert.Equal(FileKind.Pdf, FileTypeDetector.DetectFromExtension("https://files.example.com/quarterly.pdf"));
+    }
+
+    [Theory]
+    [InlineData("application/pdf", FileKind.Pdf)]
+    [InlineData("application/pdf; charset=binary", FileKind.Pdf)]
+    [InlineData("image/png", FileKind.Image)]
+    [InlineData("image/svg+xml", FileKind.Image)]
+    [InlineData("video/mp4", FileKind.Video)]
+    [InlineData("audio/mpeg", FileKind.Audio)]
+    [InlineData("text/markdown", FileKind.Markdown)]
+    [InlineData("text/csv", FileKind.Csv)]
+    [InlineData("application/json", FileKind.Json)]
+    [InlineData("application/ld+json", FileKind.Json)]
+    [InlineData("text/html", FileKind.Code)]
+    [InlineData("text/plain", FileKind.Text)]
+    [InlineData("text/x-readme", FileKind.Text)]
+    [InlineData(null, FileKind.Unknown)]
+    [InlineData("", FileKind.Unknown)]
+    [InlineData("application/octet-stream", FileKind.Unknown)]
+    public void DetectFromMime_Maps_Common_Types(string? mime, FileKind expected)
+    {
+        Assert.Equal(expected, FileTypeDetector.DetectFromMime(mime));
+    }
+
+    [Theory]
+    [InlineData("File.cs", "csharp")]
+    [InlineData("page.razor", "csharp")]
+    [InlineData("app.ts", "typescript")]
+    [InlineData("app.tsx", "typescript")]
+    [InlineData("server.py", "python")]
+    [InlineData("query.sql", "sql")]
+    [InlineData("style.scss", "css")]
+    [InlineData("doc.md", "markdown")]
+    [InlineData("data.json", "json")]
+    [InlineData("Dockerfile", "plaintext")]   // no extension → plaintext
+    [InlineData("README.go", "plaintext")]    // .go not in language map → plaintext
+    [InlineData(null, "plaintext")]
+    [InlineData("", "plaintext")]
+    public void CodeLanguageFor_Maps_Extensions_To_CodeMirror_Tokens(string? src, string expected)
+    {
+        Assert.Equal(expected, FileTypeDetector.CodeLanguageFor(src));
+    }
+
+    [Theory]
+    [InlineData("report.pdf", ".pdf")]
+    [InlineData("REPORT.PDF", ".pdf")]                  // lower-cased
+    [InlineData("photo.PNG?signature=abc", ".png")]
+    [InlineData("/path/to/file", "")]
+    [InlineData("https://a.b/c.d/e.f", ".f")]
+    [InlineData(null, "")]
+    public void ExtensionFor_Strips_Query_And_LowerCases(string? src, string expected)
+    {
+        Assert.Equal(expected, FileTypeDetector.ExtensionFor(src));
+    }
+}

--- a/tests/Lumeo.Tests/Components/FileViewer/FileViewerCsvTests.cs
+++ b/tests/Lumeo.Tests/Components/FileViewer/FileViewerCsvTests.cs
@@ -1,0 +1,81 @@
+using Xunit;
+
+namespace Lumeo.Tests.Components.FileViewerComponent;
+
+public class FileViewerCsvTests
+{
+    [Fact]
+    public void Parses_Simple_Csv_With_Header()
+    {
+        const string csv = "name,age,city\nAlice,30,Berlin\nBob,25,Munich";
+        var (rows, truncated) = Lumeo.FileViewer.ParseCsv(csv, maxRows: 100);
+
+        Assert.False(truncated);
+        Assert.Equal(3, rows.Count);
+        Assert.Equal(new[] { "name", "age", "city" }, rows[0]);
+        Assert.Equal(new[] { "Alice", "30", "Berlin" }, rows[1]);
+        Assert.Equal(new[] { "Bob", "25", "Munich" }, rows[2]);
+    }
+
+    [Fact]
+    public void Handles_Quoted_Fields_With_Embedded_Commas()
+    {
+        const string csv = "name,address\n\"Doe, John\",\"123 Main St, Apt 4\"";
+        var (rows, _) = Lumeo.FileViewer.ParseCsv(csv, maxRows: 100);
+
+        Assert.Equal(2, rows.Count);
+        Assert.Equal("Doe, John", rows[1][0]);
+        Assert.Equal("123 Main St, Apt 4", rows[1][1]);
+    }
+
+    [Fact]
+    public void Handles_Escaped_DoubleQuotes_Inside_Quoted_Field()
+    {
+        const string csv = "quote\n\"She said \"\"hello\"\"\"";
+        var (rows, _) = Lumeo.FileViewer.ParseCsv(csv, maxRows: 100);
+
+        Assert.Equal(2, rows.Count);
+        Assert.Equal("She said \"hello\"", rows[1][0]);
+    }
+
+    [Fact]
+    public void Detects_Tsv_When_First_Line_Has_Tab_And_No_Comma()
+    {
+        const string tsv = "name\tage\nAlice\t30";
+        var (rows, _) = Lumeo.FileViewer.ParseCsv(tsv, maxRows: 100);
+
+        Assert.Equal(2, rows.Count);
+        Assert.Equal(new[] { "name", "age" }, rows[0]);
+        Assert.Equal(new[] { "Alice", "30" }, rows[1]);
+    }
+
+    [Fact]
+    public void Truncates_At_MaxRows_And_Reports_Truncation()
+    {
+        var csv = "h\n" + string.Join("\n", Enumerable.Range(1, 50).Select(i => i.ToString()));
+        var (rows, truncated) = Lumeo.FileViewer.ParseCsv(csv, maxRows: 10);
+
+        Assert.True(truncated);
+        Assert.Equal(10, rows.Count);
+    }
+
+    [Fact]
+    public void Handles_Crlf_Line_Endings()
+    {
+        const string csv = "a,b\r\n1,2\r\n3,4";
+        var (rows, _) = Lumeo.FileViewer.ParseCsv(csv, maxRows: 100);
+
+        Assert.Equal(3, rows.Count);
+        Assert.Equal(new[] { "1", "2" }, rows[1]);
+        Assert.Equal(new[] { "3", "4" }, rows[2]);
+    }
+
+    [Fact]
+    public void Empty_Input_Yields_No_Rows()
+    {
+        var (rows, truncated) = Lumeo.FileViewer.ParseCsv(string.Empty, maxRows: 100);
+
+        Assert.Empty(rows);
+        Assert.False(truncated);
+    }
+}

--- a/tests/Lumeo.Tests/Lumeo.Tests.csproj
+++ b/tests/Lumeo.Tests/Lumeo.Tests.csproj
@@ -23,6 +23,7 @@
     <ProjectReference Include="..\..\src\Lumeo.Charts\Lumeo.Charts.csproj" />
     <ProjectReference Include="..\..\src\Lumeo.DataGrid\Lumeo.DataGrid.csproj" />
     <ProjectReference Include="..\..\src\Lumeo.Editor\Lumeo.Editor.csproj" />
+    <ProjectReference Include="..\..\src\Lumeo.FileViewer\Lumeo.FileViewer.csproj" />
     <ProjectReference Include="..\..\src\Lumeo.Gantt\Lumeo.Gantt.csproj" />
     <ProjectReference Include="..\..\src\Lumeo.Motion\Lumeo.Motion.csproj" />
     <ProjectReference Include="..\..\src\Lumeo.Scheduler\Lumeo.Scheduler.csproj" />

--- a/tools/Lumeo.RegistryGen/Program.cs
+++ b/tools/Lumeo.RegistryGen/Program.cs
@@ -15,24 +15,36 @@ var repoRoot = FindRepoRoot(Environment.CurrentDirectory)
 // stale rc.NN label across releases — read it instead so they can't.
 var lumeoVersion = ReadLockstepVersion(repoRoot);
 
-// Scan core + every satellite package's UI directory. The 2.0-rc.15 split
-// moved Chart/DataGrid/RichTextEditor/Scheduler/Gantt out of src/Lumeo/UI/
-// into their own satellite folders — without including those, the
-// registry would silently miss 7 components and `lumeo add chart` would
-// fail with a 404.
-var uiRoots = new[]
+// Scan core + every satellite package's UI directory. Discovery is automatic:
+// any directory matching src/Lumeo*/UI is included, so adding a new satellite
+// (e.g. Lumeo.FileViewer) doesn't need a hand-edit here. Before auto-discovery
+// the list was hardcoded — when src/Lumeo.PdfViewer was added without
+// updating this array, its component silently disappeared from the registry
+// and `lumeo add pdf-viewer` returned 404 for two patch versions.
+//
+// Excludes: SourceGenerators (no UI), test/template/tooling projects.
+var srcDir = Path.Combine(repoRoot, "src");
+var uiRoots = Directory
+    .EnumerateDirectories(srcDir, "Lumeo*", SearchOption.TopDirectoryOnly)
+    .Where(d =>
+    {
+        var name = Path.GetFileName(d);
+        if (string.Equals(name, "Lumeo.SourceGenerators", StringComparison.OrdinalIgnoreCase)) return false;
+        return Directory.Exists(Path.Combine(d, "UI"));
+    })
+    .Select(d => Path.Combine(d, "UI"))
+    // Stable ordering: core first, then satellites alphabetically. Keeps
+    // registry diffs reviewable across runs.
+    .OrderBy(p => Path.GetFileName(Path.GetDirectoryName(p)!) == "Lumeo" ? 0 : 1)
+    .ThenBy(p => p, StringComparer.OrdinalIgnoreCase)
+    .ToArray();
+
+if (uiRoots.Length == 0)
 {
-    Path.Combine(repoRoot, "src", "Lumeo", "UI"),
-    Path.Combine(repoRoot, "src", "Lumeo.Charts", "UI"),
-    Path.Combine(repoRoot, "src", "Lumeo.CodeEditor", "UI"),
-    Path.Combine(repoRoot, "src", "Lumeo.DataGrid", "UI"),
-    Path.Combine(repoRoot, "src", "Lumeo.Editor", "UI"),
-    Path.Combine(repoRoot, "src", "Lumeo.Scheduler", "UI"),
-    Path.Combine(repoRoot, "src", "Lumeo.Gantt", "UI"),
-    Path.Combine(repoRoot, "src", "Lumeo.Motion", "UI"),
-    Path.Combine(repoRoot, "src", "Lumeo.PdfViewer", "UI"),
-    Path.Combine(repoRoot, "src", "Lumeo.Maps", "UI"),
-};
+    Console.Error.WriteLine($"No UI roots discovered under {srcDir}.");
+    return 1;
+}
+Console.WriteLine($"Discovered {uiRoots.Length} UI root(s): {string.Join(", ", uiRoots.Select(r => Path.GetRelativePath(repoRoot, r)))}");
 
 var outputDir = Path.Combine(repoRoot, "src", "Lumeo", "registry");
 var outputPath = Path.Combine(outputDir, "registry.json");
@@ -228,6 +240,7 @@ var categoryMap = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCas
     ["Highlighter"] = "Typography",
     ["FileManager"] = "Data Display",
     ["PdfViewer"] = "Data Display",
+    ["FileViewer"] = "Data Display",
     ["QueryBuilder"] = "Forms",
     // Navigation
     ["Tabs"] = "Navigation",
@@ -317,6 +330,7 @@ var descriptions = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCa
     ["Highlighter"] = "Wraps occurrences of one or more search terms in the text with highlight marks.",
     ["FileManager"] = "Headless file and folder explorer — folder tree, breadcrumb path, list/grid views, lazy loading, inline rename, context-menu operations.",
     ["PdfViewer"] = "Inline PDF document viewer powered by pdf.js — page navigation, zoom controls, optional text search, and download.",
+    ["FileViewer"] = "Universal file preview — auto-detects type from MIME / extension and renders PDF, images, video, audio, Markdown, JSON, CSV, source code (CodeMirror), and plain text inline; unknown types fall back to a download CTA. Pluggable per-kind renderer overrides; auth-aware HttpClient hook.",
     ["QueryBuilder"] = "Visual AND/OR predicate-tree builder; serializes to JSON or a LINQ predicate.",
     ["Toolbar"] = "Horizontal toolbar container with separator, spacer, and group sub-components.",
     ["AppBar"] = "Top application bar with start, center, and end slots; sticky and elevated variants.",
@@ -553,6 +567,26 @@ var componentDirs = uiRoots
     .ToArray();
 var knownComponentNames = componentDirs.Select(Path.GetFileName).Where(n => !string.IsNullOrEmpty(n)).Select(n => n!).ToHashSet(StringComparer.OrdinalIgnoreCase);
 
+// Validation: surface orphan entries in the hand-maintained maps. The Motion
+// satellite once had 30+ entries in componentToPackage for components whose
+// UI dirs hadn't been added to src/Lumeo.Motion/UI/ yet — those entries
+// looked like real components in code review but produced no registry rows.
+// Mapping a non-existent name is usually a typo or a stale aspirational
+// entry; warn (don't fail) so the developer can fix or remove it.
+var orphans = componentToPackage.Keys
+    .Concat(categoryMap.Keys)
+    .Concat(descriptions.Keys)
+    .Distinct(StringComparer.OrdinalIgnoreCase)
+    .Where(name => !knownComponentNames.Contains(name))
+    .OrderBy(n => n, StringComparer.OrdinalIgnoreCase)
+    .ToArray();
+if (orphans.Length > 0)
+{
+    Console.Error.WriteLine($"[registry-gen] WARNING: {orphans.Length} hand-maintained map entries point at names with no UI directory:");
+    foreach (var o in orphans) Console.Error.WriteLine($"  - {o}");
+    Console.Error.WriteLine("[registry-gen] Either add the component dir under the satellite's UI/ folder, or remove the stale entry from Program.cs.");
+}
+
 var components = new SortedDictionary<string, object?>(StringComparer.OrdinalIgnoreCase);
 
 foreach (var dir in componentDirs)
@@ -644,7 +678,17 @@ foreach (var dir in componentDirs)
         ["description"] = description,
         ["thumbnail"] = $"/preview-cards/{ToKebabCase(name)}.png",
         ["hasDocsPage"] = hasDocsPage,
-        ["nugetPackage"] = componentToPackage.TryGetValue(name, out var pkg) ? pkg : "Lumeo",
+        // Resolution order:
+        //   1. Explicit componentToPackage override (legacy / cross-cutting cases).
+        //   2. Derived from the satellite folder name — anything under
+        //      src/Lumeo.Foo/UI/ maps to "Lumeo.Foo" automatically, so adding a
+        //      new satellite needs no edit here.
+        //   3. Fallback "Lumeo" (core).
+        ["nugetPackage"] = componentToPackage.TryGetValue(name, out var pkg)
+            ? pkg
+            : (Path.GetFileName(packageSrcRoot) is { Length: > 0 } folder && folder.StartsWith("Lumeo.", StringComparison.Ordinal)
+                ? folder
+                : "Lumeo"),
         ["files"] = files,
         ["dependencies"] = deps.OrderBy(x => x, StringComparer.Ordinal).ToArray(),
         ["packageDependencies"] = packageDeps.OrderBy(x => x, StringComparer.OrdinalIgnoreCase).ToArray(),


### PR DESCRIPTION
## Summary

Two things, separate commits:

### 1. New `Lumeo.FileViewer` satellite — universal preview component

Detects file type from MIME / extension and picks the right inline renderer. No more 12 different `<PdfViewer>` / `<img>` / `<video>` switches in consumer code:

```razor
<FileViewer Src="@url" />
```

| Kind | Renderer | Notes |
|------|----------|-------|
| PDF | `Lumeo.PdfViewer` passthrough | its toolbar wins |
| Image | `<img>` | SVG also via `<img>`, not inline (XSS) |
| Video / Audio | `<video>` / `<audio>` controls | preload=metadata |
| Markdown | Markdig with `.DisableHtml()` | no raw `<script>` / `<iframe>` |
| Code / JSON | `Lumeo.CodeEditor` read-only | language inferred from extension |
| CSV / TSV | in-component RFC-4180-ish parser | capped at `MaxCsvRows` |
| Text | `<pre>` | wraps + truncates at `MaxBytes` |
| Unknown | EmptyState + Download CTA | |

**Resolution order:** `Kind` param → `MimeType` param → optional HEAD `Content-Type` (`AutoHead`, off by default) → URL extension.

**Enterprise hooks:**
- `HttpClient` param **or** `ConfigureRequest` delegate for auth-aware fetches; DI `HttpClient` / `IHttpClientFactory` picked up automatically when registered
- `MaxBytes` cap (default 10 MB) — rejected upfront via `Content-Length` when known, truncated mid-stream otherwise. No 100 MB OOMs.
- `CancellationTokenSource` cancels in-flight fetches when `Src` changes
- `CustomRenderers` per-kind `RenderFragment` overrides
- `OnKindDetected` / `OnLoaded` / `OnError` callbacks

**Office is intentionally not in v1** — privacy: a default-on Office Online viewer iframe would leak file URLs to Microsoft. Add later as opt-in.

**Markdown styling:** ships an optional `_content/Lumeo.FileViewer/css/file-viewer.css` with `.lumeo-markdown` typography rules. Without it the content still renders via the UA stylesheet — readable, just less polished.

**Tests:** pure-logic coverage on `FileTypeDetector` (extension, MIME, query/fragment stripping, code-language map) and on the internal CSV parser (quoted fields with embedded commas, escaped `""`, TSV detection, CRLF, truncation).

### 2. Registry / MCP infra: auto-discover satellites

Two drift bugs that ate two patch versions each, fixed structurally:

- **`tools/Lumeo.RegistryGen/Program.cs`**: hand-maintained `uiRoots` array meant a new satellite's components silently disappeared from the registry until someone remembered to edit the array. Replaced with `Directory.EnumerateDirectories("src", "Lumeo*")`. New satellites (this PR's FileViewer, future ones) are picked up automatically.
- **`.github/workflows/sync-mcp-registry.yml`**: hand-maintained `paths:` filter had the same drift mode. Replaced with `src/Lumeo*/UI/**` globs.

Plus a validation pass: any name in `componentToPackage` / `categoryMap` / `descriptions` that has no matching UI directory is now flagged as a warning during regen. Surfaces the kind of aspirational entries Motion shipped for three patch releases without anyone noticing they didn't back any code.

Component-to-package resolution now defaults to the folder name (`src/Lumeo.X/UI/Foo/` → `Lumeo.X`) without an explicit `componentToPackage` entry.

## Test plan

- [ ] CI: `dotnet build src/Lumeo.FileViewer/Lumeo.FileViewer.csproj -c Release -warnaserror` is green
- [ ] CI: full test suite green (new FileTypeDetector + CSV parser tests pass)
- [ ] CI: regen step in `publish-mcp` picks up FileViewer and writes it to `tools/lumeo-mcp/src/components-api.json` + `registry.json`
- [ ] Manual: `<FileViewer Src="some.pdf" />` renders the embedded PdfViewer; `<FileViewer Src="image.png" />` renders the `<img>`; `<FileViewer Src="data.csv" />` shows the table.
- [ ] Manual: switching `Src` while the previous fetch is in flight does not leak rendered text from the previous file.


---
_Generated by [Claude Code](https://claude.ai/code/session_0162NNVHveeL63TTM773mcU1)_