### PR TITLE
fix(overlay): scrollable body in Sheet path + docs(file-viewer): local samples & fixed-footprint demos

### DIFF
--- a/docs/Lumeo.Docs/Pages/Components/FileViewerPage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/FileViewerPage.razor
@@ -41,29 +41,34 @@
 
 <Stack Gap="8" Class="mt-8">
 
-    <ComponentDemo Title="Auto-detection" Code="@_autoCode">
-        <Stack Gap="4">
-            <div>
-                <p class="text-xs text-muted-foreground mb-2">PDF — extension <Code>.pdf</Code></p>
-                <FileViewer Src="@SamplePdfUrl" Class="h-[420px]" />
-            </div>
-            <div>
-                <p class="text-xs text-muted-foreground mb-2">Image — extension <Code>.png</Code></p>
-                <FileViewer Src="@SampleImageUrl" Class="h-[320px]" />
-            </div>
-            <div>
-                <p class="text-xs text-muted-foreground mb-2">Markdown — extension <Code>.md</Code></p>
-                <FileViewer Src="@SampleMarkdownUrl" Class="h-[420px]" />
-            </div>
-            <div>
-                <p class="text-xs text-muted-foreground mb-2">CSV — extension <Code>.csv</Code></p>
-                <FileViewer Src="@SampleCsvUrl" Class="h-[360px]" />
-            </div>
-            <div>
-                <p class="text-xs text-muted-foreground mb-2">Source code — extension <Code>.cs</Code></p>
-                <FileViewer Src="@SampleCodeUrl" FileName="Program.cs" Class="h-[360px]" />
-            </div>
-        </Stack>
+    <ComponentDemo Title="Auto-detection — Image" Code="@_imageAutoCode">
+        <div class="@DemoBoxClass">
+            <FileViewer Src="sample-files/sample.svg" Class="h-full" />
+        </div>
+    </ComponentDemo>
+
+    <ComponentDemo Title="Auto-detection — Markdown" Code="@_markdownAutoCode">
+        <div class="@DemoBoxClass">
+            <FileViewer Src="sample-files/README.md" Class="h-full" />
+        </div>
+    </ComponentDemo>
+
+    <ComponentDemo Title="Auto-detection — CSV" Code="@_csvAutoCode">
+        <div class="@DemoBoxClass">
+            <FileViewer Src="sample-files/data.csv" Class="h-full" />
+        </div>
+    </ComponentDemo>
+
+    <ComponentDemo Title="Auto-detection — source code" Code="@_codeAutoCode">
+        <div class="@DemoBoxClass">
+            <FileViewer Src="sample-files/Program.cs" Class="h-full" />
+        </div>
+    </ComponentDemo>
+
+    <ComponentDemo Title="Auto-detection — PDF" Code="@_pdfAutoCode">
+        <div class="@DemoBoxClass">
+            <FileViewer Src="@SamplePdfUrl" Class="h-full" />
+        </div>
     </ComponentDemo>
 
     <ComponentDemo Title="Explicit Kind override" Code="@_kindOverrideCode">
@@ -71,10 +76,12 @@
             <p class="text-xs text-muted-foreground">
                 Force a kind when the URL has no extension (typical for blob / signed URLs).
             </p>
-            <FileViewer Src="@SamplePdfUrl"
-                        Kind="FileKind.Pdf"
-                        FileName="report.pdf"
-                        Class="h-[400px]" />
+            <div class="@DemoBoxClass">
+                <FileViewer Src="@SamplePdfUrl"
+                            Kind="FileKind.Pdf"
+                            FileName="report.pdf"
+                            Class="h-full" />
+            </div>
         </Stack>
     </ComponentDemo>
 
@@ -83,18 +90,22 @@
             <p class="text-xs text-muted-foreground">
                 Provide MIME from your backend metadata response — most reliable for opaque URLs.
             </p>
-            <FileViewer Src="@SampleImageUrl"
-                        MimeType="image/png"
-                        FileName="screenshot.png"
-                        Class="h-[320px]" />
+            <div class="@DemoBoxClass">
+                <FileViewer Src="sample-files/sample.svg"
+                            MimeType="image/svg+xml"
+                            FileName="screenshot.svg"
+                            Class="h-full" />
+            </div>
         </Stack>
     </ComponentDemo>
 
     <ComponentDemo Title="Kind detected callback" Code="@_kindCallbackCode">
         <Stack Gap="3">
-            <FileViewer Src="@_callbackSrc"
-                        OnKindDetected="HandleKindDetected"
-                        Class="h-[320px]" />
+            <div class="@DemoBoxClass">
+                <FileViewer Src="sample-files/README.md"
+                            OnKindDetected="HandleKindDetected"
+                            Class="h-full" />
+            </div>
             @if (_lastDetectedKind is not null)
             {
                 <Alert Variant="Alert.AlertVariant.Info" ShowIcon="true">
@@ -107,16 +118,21 @@
     </ComponentDemo>
 
     <ComponentDemo Title="Unknown type falls back to download" Code="@_unknownCode">
-        <FileViewer Src="https://example.com/archive.zip"
-                    FileName="archive.zip"
-                    Class="h-[320px]" />
+        <div class="@DemoBoxClass">
+            <FileViewer Src="sample-files/data.csv"
+                        Kind="FileKind.Unknown"
+                        FileName="archive.zip"
+                        Class="h-full" />
+        </div>
     </ComponentDemo>
 
     <ComponentDemo Title="Error handling" Code="@_errorCode">
         <Stack Gap="3">
-            <FileViewer Src="https://lumeo.invalid/does-not-exist.csv"
-                        OnError="HandleError"
-                        Class="h-[280px]" />
+            <div class="@DemoBoxClass">
+                <FileViewer Src="sample-files/does-not-exist.csv"
+                            OnError="HandleError"
+                            Class="h-full" />
+            </div>
             @if (_errorMessage is not null)
             {
                 <Alert Variant="Alert.AlertVariant.Destructive" ShowIcon="true">
@@ -130,15 +146,19 @@
     </ComponentDemo>
 
     <ComponentDemo Title="Chromeless embed (toolbar hidden)" Code="@_chromelessCode">
-        <FileViewer Src="@SampleImageUrl"
-                    ShowToolbar="false"
-                    Class="h-[320px]" />
+        <div class="@DemoBoxClass">
+            <FileViewer Src="sample-files/sample.svg"
+                        ShowToolbar="false"
+                        Class="h-full" />
+        </div>
     </ComponentDemo>
 
     <ComponentDemo Title="Custom renderer for a kind" Code="@_customRendererCode">
-        <FileViewer Src="@SampleImageUrl"
-                    CustomRenderers="_imageRenderer"
-                    Class="h-[320px]" />
+        <div class="@DemoBoxClass">
+            <FileViewer Src="sample-files/sample.svg"
+                        CustomRenderers="_imageRenderer"
+                        Class="h-full" />
+        </div>
     </ComponentDemo>
 
 </Stack>
@@ -174,14 +194,16 @@
 </div>
 
 @code {
-    // CORS-friendly samples; small enough to keep the demo page snappy.
-    private const string SamplePdfUrl = "https://mozilla.github.io/pdf.js/web/compressed.tracemonkey-pldi-09.pdf";
-    private const string SampleImageUrl = "https://upload.wikimedia.org/wikipedia/commons/thumb/4/47/PNG_transparency_demonstration_1.png/400px-PNG_transparency_demonstration_1.png";
-    private const string SampleMarkdownUrl = "https://raw.githubusercontent.com/octocat/Hello-World/master/README";
-    private const string SampleCsvUrl = "https://raw.githubusercontent.com/datasets/population/master/data/population.csv";
-    private const string SampleCodeUrl = "https://raw.githubusercontent.com/dotnet/runtime/main/src/libraries/System.Linq/src/System/Linq/Enumerable.cs";
+    // Demos share a fixed footprint so async content (PDF, markdown fetch,
+    // code-editor mount) never causes a Cumulative Layout Shift on the page,
+    // and zoom / resize doesn't reflow the surrounding catalog. Width caps at
+    // 680px and shrinks fluidly below — height is locked.
+    private const string DemoBoxClass = "w-full max-w-[680px] h-[420px]";
 
-    private string _callbackSrc = SamplePdfUrl;
+    // Mozilla's well-known CORS-friendly pdf.js sample. Already exercised by
+    // PdfViewerPage so it's the most reliable PDF source for both demos.
+    private const string SamplePdfUrl = "https://mozilla.github.io/pdf.js/web/compressed.tracemonkey-pldi-09.pdf";
+
     private FileKind? _lastDetectedKind;
     private string? _errorMessage;
 
@@ -197,30 +219,47 @@
     }
 
     // Per-kind override: render images inside a styled frame instead of the
-    // built-in plain <img>. Keys are FileKind, values are RenderFragment<ctx>.
+    // built-in plain <img>. Built via RenderTreeBuilder because Razor doesn't
+    // allow inline RenderFragment<T> literals inside a field initializer.
     private readonly IReadOnlyDictionary<FileKind, RenderFragment<FileViewerRenderContext>> _imageRenderer =
         new Dictionary<FileKind, RenderFragment<FileViewerRenderContext>>
         {
-            [FileKind.Image] = ctx => __builder =>
+            [FileKind.Image] = ctx => builder =>
             {
-                __builder.OpenElement(0, "div");
-                __builder.AddAttribute(1, "class", "flex h-full items-center justify-center bg-gradient-to-br from-primary/10 to-accent/10 p-6");
-                __builder.OpenElement(2, "img");
-                __builder.AddAttribute(3, "src", ctx.Src);
-                __builder.AddAttribute(4, "alt", ctx.FileName ?? "image");
-                __builder.AddAttribute(5, "class", "max-h-full max-w-full rounded-lg shadow-2xl ring-1 ring-border");
-                __builder.CloseElement();
-                __builder.CloseElement();
+                builder.OpenElement(0, "div");
+                builder.AddAttribute(1, "class", "flex h-full items-center justify-center bg-gradient-to-br from-primary/10 to-accent/10 p-6");
+                builder.OpenElement(2, "img");
+                builder.AddAttribute(3, "src", ctx.Src);
+                builder.AddAttribute(4, "alt", ctx.FileName ?? "image");
+                builder.AddAttribute(5, "class", "max-h-full max-w-full rounded-lg shadow-2xl ring-1 ring-border");
+                builder.CloseElement();
+                builder.CloseElement();
             },
         };
 
-    private const string _autoCode = """
-@* Detection from URL extension *@
-<FileViewer Src="https://example.com/report.pdf"     Class="h-[420px]" />
-<FileViewer Src="https://example.com/photo.png"      Class="h-[320px]" />
-<FileViewer Src="https://example.com/README.md"      Class="h-[420px]" />
-<FileViewer Src="https://example.com/data.csv"       Class="h-[360px]" />
-<FileViewer Src="https://example.com/Program.cs"     FileName="Program.cs" Class="h-[360px]" />
+    private const string _imageAutoCode = """
+<FileViewer Src="sample-files/sample.svg"
+            Class="w-full max-w-[680px] h-[420px]" />
+""";
+
+    private const string _markdownAutoCode = """
+<FileViewer Src="sample-files/README.md"
+            Class="w-full max-w-[680px] h-[420px]" />
+""";
+
+    private const string _csvAutoCode = """
+<FileViewer Src="sample-files/data.csv"
+            Class="w-full max-w-[680px] h-[420px]" />
+""";
+
+    private const string _codeAutoCode = """
+<FileViewer Src="sample-files/Program.cs"
+            Class="w-full max-w-[680px] h-[420px]" />
+""";
+
+    private const string _pdfAutoCode = """
+<FileViewer Src="@_pdfUrl"
+            Class="w-full max-w-[680px] h-[420px]" />
 """;
 
     private const string _kindOverrideCode = """
@@ -228,21 +267,21 @@
 <FileViewer Src="@_blobUrl"
             Kind="FileKind.Pdf"
             FileName="report.pdf"
-            Class="h-[400px]" />
+            Class="w-full max-w-[680px] h-[420px]" />
 """;
 
     private const string _mimeOverrideCode = """
 @* Backend already knows the MIME; pass it to skip extension detection *@
 <FileViewer Src="@_url"
-            MimeType="image/png"
-            FileName="screenshot.png"
-            Class="h-[320px]" />
+            MimeType="image/svg+xml"
+            FileName="screenshot.svg"
+            Class="w-full max-w-[680px] h-[420px]" />
 """;
 
     private const string _kindCallbackCode = """
 <FileViewer Src="@_url"
             OnKindDetected="HandleKindDetected"
-            Class="h-[320px]" />
+            Class="w-full max-w-[680px] h-[420px]" />
 
 @code {
     private FileKind? _detected;
@@ -251,16 +290,17 @@
 """;
 
     private const string _unknownCode = """
-@* ZIPs aren't previewable — falls back to a Download CTA *@
-<FileViewer Src="https://example.com/archive.zip"
+@* Forced Kind.Unknown — falls back to a Download CTA *@
+<FileViewer Src="@_url"
+            Kind="FileKind.Unknown"
             FileName="archive.zip"
-            Class="h-[320px]" />
+            Class="w-full max-w-[680px] h-[420px]" />
 """;
 
     private const string _errorCode = """
-<FileViewer Src="https://lumeo.invalid/does-not-exist.csv"
+<FileViewer Src="sample-files/does-not-exist.csv"
             OnError="HandleError"
-            Class="h-[280px]" />
+            Class="w-full max-w-[680px] h-[420px]" />
 
 @code {
     private string? _errorMessage;
@@ -271,13 +311,13 @@
     private const string _chromelessCode = """
 <FileViewer Src="@_imageUrl"
             ShowToolbar="false"
-            Class="h-[320px]" />
+            Class="w-full max-w-[680px] h-[420px]" />
 """;
 
     private const string _customRendererCode = """
 <FileViewer Src="@_imageUrl"
             CustomRenderers="_renderers"
-            Class="h-[320px]" />
+            Class="w-full max-w-[680px] h-[420px]" />
 
 @code {
     // Override the Image kind with a styled frame; built-in renderers stay

--- a/docs/Lumeo.Docs/wwwroot/sample-files/Program.cs
+++ b/docs/Lumeo.Docs/wwwroot/sample-files/Program.cs
@@ -1,0 +1,18 @@
+using Lumeo;
+using Microsoft.AspNetCore.Components.Web;
+using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
+
+var builder = WebAssemblyHostBuilder.CreateDefault(args);
+builder.RootComponents.Add<App>("#app");
+builder.RootComponents.Add<HeadOutlet>("head::after");
+
+// Standard HttpClient registration — FileViewer picks this up automatically
+// for fetching text-based files (Markdown, JSON, CSV, Code, Text).
+builder.Services.AddScoped(sp => new HttpClient
+{
+    BaseAddress = new Uri(builder.HostEnvironment.BaseAddress)
+});
+
+builder.Services.AddLumeo();
+
+await builder.Build().RunAsync();

--- a/docs/Lumeo.Docs/wwwroot/sample-files/README.md
+++ b/docs/Lumeo.Docs/wwwroot/sample-files/README.md
@@ -1,0 +1,32 @@
+# Lumeo FileViewer
+
+A universal preview surface for Blazor — drop in a URL, get the right inline viewer.
+
+## Highlights
+
+- **Auto-detect** by MIME, optional HEAD, or URL extension
+- **Built-in renderers** for PDF, image, video, audio, markdown, source code, JSON, CSV, and plain text
+- **Auth-aware** fetches via `HttpClient` parameter or `ConfigureRequest` delegate
+- **Safety caps** — `MaxBytes` for text fetches, `MaxCsvRows` for tabular data
+- **Pluggable** per-kind overrides via `CustomRenderers`
+
+## Quick start
+
+```razor
+<FileViewer Src="@DocumentUrl"
+            FileName="@Document.Name"
+            OnLoaded="HandleLoaded"
+            Class="h-[480px]" />
+```
+
+## Resolution order
+
+1. Explicit `Kind` parameter (anything other than `Auto` wins)
+2. Explicit `MimeType` parameter
+3. `HEAD` request `Content-Type` (when `AutoHead="true"`)
+4. URL extension
+
+> Markdown is rendered with `.DisableHtml()` — raw `<script>` and `<iframe>` in
+> user-supplied markdown never reach the DOM.
+
+For more, see the [docs site](https://lumeo.nativ.sh/components/file-viewer).

--- a/docs/Lumeo.Docs/wwwroot/sample-files/data.csv
+++ b/docs/Lumeo.Docs/wwwroot/sample-files/data.csv
@@ -1,0 +1,11 @@
+component,category,nuget_package,first_release
+Accordion,Navigation,Lumeo,1.0.0
+DataGrid,Data Display,Lumeo.DataGrid,2.0.0
+FileViewer,Data Display,Lumeo.FileViewer,3.2.5
+Map,Data Display,Lumeo.Maps,3.2.0
+PdfViewer,Data Display,Lumeo.PdfViewer,3.1.0
+QueryBuilder,Forms,Lumeo,2.1.0
+RichTextEditor,Forms,Lumeo.Editor,2.0.0
+Scheduler,Data Display,Lumeo.Scheduler,2.0.0
+Toast,Feedback,Lumeo,1.0.0
+TreeView,Data Display,Lumeo,1.0.0

--- a/docs/Lumeo.Docs/wwwroot/sample-files/sample.svg
+++ b/docs/Lumeo.Docs/wwwroot/sample-files/sample.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240" width="400" height="240" role="img" aria-label="Lumeo sample image">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#7c3aed" />
+      <stop offset="50%" stop-color="#3b82f6" />
+      <stop offset="100%" stop-color="#06b6d4" />
+    </linearGradient>
+    <radialGradient id="glow" cx="0.3" cy="0.3" r="0.7">
+      <stop offset="0%" stop-color="rgba(255,255,255,0.55)" />
+      <stop offset="100%" stop-color="rgba(255,255,255,0)" />
+    </radialGradient>
+  </defs>
+  <rect width="400" height="240" fill="url(#bg)" rx="12" />
+  <rect width="400" height="240" fill="url(#glow)" rx="12" />
+  <g fill="#ffffff" font-family="ui-sans-serif, system-ui, -apple-system, sans-serif" text-anchor="middle">
+    <text x="200" y="118" font-size="44" font-weight="700" letter-spacing="-1">Lumeo</text>
+    <text x="200" y="148" font-size="14" font-weight="500" opacity="0.85">sample image · 400 × 240</text>
+  </g>
+  <g stroke="rgba(255,255,255,0.45)" stroke-width="1.5" fill="none">
+    <circle cx="60"  cy="60"  r="22" />
+    <circle cx="340" cy="60"  r="14" />
+    <circle cx="60"  cy="180" r="14" />
+    <circle cx="340" cy="180" r="22" />
+  </g>
+</svg>

--- a/src/Lumeo/Services/OverlayService.cs
+++ b/src/Lumeo/Services/OverlayService.cs
@@ -197,6 +197,23 @@ public sealed record OverlayOptions
     /// Null = use <see cref="SwipeToClose"/> at all sizes. Typical pattern:
     /// off on desktop, on for mobile bottom-sheet pull-down.</summary>
     public bool? MobileSwipeToClose { get; init; }
+
+    /// <summary>
+    /// Wrap the rendered component in a scrollable body region inside the
+    /// overlay's chrome (Sheet only — Dialog and Drawer manage their own
+    /// scroll). Default <c>true</c> so consumers can pass a long form to
+    /// <see cref="OverlayService.ShowSheetAsync{T}"/> without rolling their
+    /// own <c>overflow-y-auto</c> wrapper — and without hitting the focus-
+    /// ring clip that bare <c>overflow-y: auto</c> introduces (per spec,
+    /// <c>overflow-y: auto</c> promotes <c>overflow-x</c> to <c>auto</c> too,
+    /// which clips inputs' box-shadow focus rings at the left/right edge).
+    /// The built-in wrapper uses the <c>px-1 -mx-1</c> trick to give focus
+    /// rings 4px breathing room without shifting the visual padding. Set to
+    /// <c>false</c> for sheets whose content sets its own scrolling strategy
+    /// (e.g. an embedded <c>PdfViewer</c> that already paints inside a fixed
+    /// canvas).
+    /// </summary>
+    public bool ScrollableBody { get; init; } = true;
 }
 
 public sealed record AlertDialogOptions

--- a/src/Lumeo/UI/Overlay/OverlayProvider.razor
+++ b/src/Lumeo/UI/Overlay/OverlayProvider.razor
@@ -33,11 +33,32 @@
                             <SheetTitle>@overlay.Title</SheetTitle>
                         </SheetHeader>
                     }
-                    <CascadingValue Value="@(new OverlayShellMarker(overlay.Id))" IsFixed="true">
-                        <CascadingValue Value="@GetOrCreateReference(overlay)" IsFixed="true">
-                            <DynamicComponent Type="@GetComponentType(overlay)" Parameters="@GetParameters(overlay)" />
+                    @* Scrollable body wrapper. flex-1 + min-h-0 lets it take
+                       the remaining height of SheetContent's flex column and
+                       scroll independently of the header. The -mx-1 / px-1
+                       trick gives Inputs' box-shadow focus rings 4px of
+                       breathing room before the overflow:auto clip — without
+                       it, edge-touching inputs lose ~2px of their ring on the
+                       left/right edges (CSS spec: overflow-y:auto promotes
+                       overflow-x:auto, which clips outer box-shadows). *@
+                    @if (overlay.Options.ScrollableBody)
+                    {
+                        <div class="flex-1 min-h-0 overflow-y-auto -mx-1 px-1">
+                            <CascadingValue Value="@(new OverlayShellMarker(overlay.Id))" IsFixed="true">
+                                <CascadingValue Value="@GetOrCreateReference(overlay)" IsFixed="true">
+                                    <DynamicComponent Type="@GetComponentType(overlay)" Parameters="@GetParameters(overlay)" />
+                                </CascadingValue>
+                            </CascadingValue>
+                        </div>
+                    }
+                    else
+                    {
+                        <CascadingValue Value="@(new OverlayShellMarker(overlay.Id))" IsFixed="true">
+                            <CascadingValue Value="@GetOrCreateReference(overlay)" IsFixed="true">
+                                <DynamicComponent Type="@GetComponentType(overlay)" Parameters="@GetParameters(overlay)" />
+                            </CascadingValue>
                         </CascadingValue>
-                    </CascadingValue>
+                    }
                 </SheetContent>
             </Sheet>
             break;

--- a/tests/Lumeo.Tests/Components/Overlay/OverlayProviderTests.cs
+++ b/tests/Lumeo.Tests/Components/Overlay/OverlayProviderTests.cs
@@ -127,6 +127,58 @@ public class OverlayProviderTests : IAsyncLifetime
         Assert.Null(options.MobileSwipeToClose);
     }
 
+    // --- Scrollable body wrapper (3.2.6) -----------------------------------
+    //
+    // Sheets opened via OverlayService now wrap the rendered component in a
+    // flex-1 min-h-0 overflow-y-auto -mx-1 px-1 div so consumers don't roll
+    // their own scrollable form wrappers (which trip the box-shadow focus-
+    // ring clip the report flagged). Default ScrollableBody=true; opt-out
+    // via OverlayOptions { ScrollableBody = false } for sheets whose content
+    // sets its own scrolling strategy (e.g. an embedded PdfViewer).
+
+    [Fact]
+    public void OverlayOptions_ScrollableBody_Default_Is_True()
+    {
+        var options = new OverlayOptions();
+        Assert.True(options.ScrollableBody);
+    }
+
+    [Fact]
+    public void ShowSheet_With_ScrollableBody_True_Wraps_Body_In_Overflow_Container()
+    {
+        var service = _ctx.Services.GetRequiredService<OverlayService>();
+        var cut = _ctx.Render<Lumeo.OverlayProvider>();
+
+        _ = service.ShowSheetAsync<DummyOverlayBody>(
+            title: "Form sheet",
+            options: new OverlayOptions { ScrollableBody = true });
+
+        cut.WaitForState(() => cut.Markup.Contains("BODY"));
+
+        // The wrapper carries flex-1 + overflow-y-auto and the -mx-1 px-1
+        // breathing room. Asserting the class string is enough — a typo
+        // here would silently lose the focus-ring fix.
+        Assert.Contains("flex-1 min-h-0 overflow-y-auto -mx-1 px-1", cut.Markup);
+    }
+
+    [Fact]
+    public void ShowSheet_With_ScrollableBody_False_Renders_Without_Overflow_Wrapper()
+    {
+        var service = _ctx.Services.GetRequiredService<OverlayService>();
+        var cut = _ctx.Render<Lumeo.OverlayProvider>();
+
+        _ = service.ShowSheetAsync<DummyOverlayBody>(
+            title: "PDF preview sheet",
+            options: new OverlayOptions { ScrollableBody = false });
+
+        cut.WaitForState(() => cut.Markup.Contains("BODY"));
+
+        // Opt-out path: the body still renders, just without the auto-scroll
+        // chrome — consumer's component handles its own layout.
+        Assert.DoesNotContain("flex-1 min-h-0 overflow-y-auto -mx-1 px-1", cut.Markup);
+        Assert.Contains("BODY", cut.Markup);
+    }
+
     [Fact]
     public void OverlayOptions_With_Null_MobileBreakpoint_Disables_Responsive_Switch()
     {


### PR DESCRIPTION
## Summary

Three fixes — the reported Sheet focus-ring clip, plus FileViewerPage cleanup.

### 1. OverlayProvider Sheet scrollable body (the real fix for the reported clip)

Diagnosis recap: `SheetContent` has no overflow itself, but `OverlayService.ShowSheetAsync` rendered the user's component as a bare flex child of `SheetContent`. Long forms needed an `overflow-y-auto` wrapper — which the consumer rolled themselves — and per CSS spec that promotes `overflow-x` to `auto` too, clipping inputs' box-shadow focus rings at the left/right edge.

Fix lives in `OverlayProvider.razor`:

```razor
<SheetContent ...>
    @if (overlay.Title is not null) { <SheetHeader>...</SheetHeader> }
+   @if (overlay.Options.ScrollableBody)
+   {
+       <div class="flex-1 min-h-0 overflow-y-auto -mx-1 px-1">
            <CascadingValue>...<DynamicComponent ... /></CascadingValue>
+       </div>
+   }
+   else { /* legacy path — no auto-scroll, consumer handles layout */ }
</SheetContent>
```

- `flex-1 min-h-0` → wrapper takes remaining height of SheetContent's flex column and shrinks correctly past content size
- `overflow-y-auto` → only the body scrolls, header stays pinned
- `-mx-1 px-1` → 4px breathing room for focus rings without shifting visible padding

New `OverlayOptions.ScrollableBody` (default `true`). Opt-out for sheets whose content sets its own scrolling strategy (e.g. embedded PdfViewer).

Three test assertions added in `OverlayProviderTests`:
- `ScrollableBody` default is `true`
- True path emits the exact wrapper class string (typo-proof)
- False path skips the wrapper, body still renders

Direct `<Sheet><SheetContent>…</SheetContent></Sheet>` markup is **unaffected** — the wrapper only lands on the OverlayService-driven path.

### 2. FileViewerPage demos render local samples

The earlier page pulled from Wikipedia / `raw.githubusercontent.com`. Wikipedia hot-link CORS blocked the image; one of the raw GitHub URLs pointed at a README without a `.md` extension so detection fell to Unknown. Replaced all flaky third-party URLs with same-origin samples committed under `docs/Lumeo.Docs/wwwroot/sample-files/`:

- `sample.svg` (small Lumeo-branded gradient SVG)
- `README.md` (markdown showcase: headings, list, code block, blockquote, link)
- `data.csv` (Lumeo component catalog rows)
- `Program.cs` (Blazor WASM bootstrap example)

PDF still pulls from Mozilla's CORS-friendly pdf.js sample — same source `PdfViewerPage` already uses, and a binary PDF doesn't belong committed in the repo.

### 3. FileViewerPage demos have a fixed footprint

Every demo box now wears `w-full max-w-[680px] h-[420px]`. Fixed height stops Cumulative Layout Shift when async content arrives (PDF render, markdown fetch, CSV parse, CodeEditor mount). `max-w-[680px]` caps the width on desktop so browser zoom doesn't reflow the surrounding catalog.

## Test plan

- [ ] CI: `build-and-test` + `e2e` green
- [ ] CI: new `ShowSheet_With_ScrollableBody_*` assertions pass
- [ ] Manual: open `/components/file-viewer` — image renders inline, markdown / CSV / code load from same origin, every demo card has a stable footprint as PDF / CodeEditor finish loading
- [ ] Manual: call `OverlayService.ShowSheetAsync<LongForm>(…)` with default options, focus an `<Input>` touching the sheet's left edge — focus ring is no longer clipped
- [ ] Manual: same call with `new OverlayOptions { ScrollableBody = false }` — body renders without auto-scroll chrome (back-compat for PdfViewer-in-sheet)


---
_Generated by [Claude Code](https://claude.ai/code/session_0162NNVHveeL63TTM773mcU1)_