### PR TITLE
fix: datagrid resize first-drag (#40) + docs TOC anchor URL under base href (#41)

### DIFF
--- a/docs/Lumeo.Docs/Shared/OnThisPage.razor
+++ b/docs/Lumeo.Docs/Shared/OnThisPage.razor
@@ -12,7 +12,13 @@
                  style="scrollbar-width: thin;">
                 @foreach (var h in _headings)
                 {
-                    <a href="@($"#{h.Id}")"
+                    @* href must embed the current path. With <base href="/">, a bare
+                       "#id" resolves against the base URL — i.e. right-click → "Copy
+                       Link Address" shows "/#id" instead of "/components/datagrid#id".
+                       Click-time scroll still goes through @onclick (preventDefault),
+                       so the visible href is only used by the browser's copy-link
+                       affordance and crawlers. *@
+                    <a href="@($"{LocalPath}#{h.Id}")"
                        @onclick:preventDefault
                        @onclick="() => ScrollTo(h.Id)"
                        class="@LinkClass(h)"
@@ -37,6 +43,27 @@
     private CancellationTokenSource? _scanCts;
 
     [Inject] NavigationManager Nav { get; set; } = default!;
+
+    // Absolute-from-origin path of the current document — used to build the
+    // TOC anchor hrefs explicitly so the browser's "Copy Link Address" gives
+    // the deep link instead of the base-resolved "/#section" form (see #41).
+    private string LocalPath
+    {
+        get
+        {
+            try
+            {
+                var uri = new Uri(Nav.Uri);
+                var path = uri.AbsolutePath;
+                if (string.IsNullOrEmpty(path)) path = "/";
+                return path + uri.Query;
+            }
+            catch
+            {
+                return "/";
+            }
+        }
+    }
 
     protected override void OnInitialized()
     {

--- a/docs/Lumeo.Docs/wwwroot/js/docs.js
+++ b/docs/Lumeo.Docs/wwwroot/js/docs.js
@@ -14,11 +14,22 @@ window.lumeo.signalBlazorReady = function () {
 // and browser-share produce a deep link like /components/datagrid#full-featured-datagrid
 // instead of the bare route. replaceState (not pushState) keeps the back
 // button focused on real route changes rather than TOC scrolls.
+//
+// IMPORTANT: build the URL absolutely, not as bare '#id'. index.html sets
+// <base href="/">, and per the HTML spec the third argument to replaceState
+// is parsed against the document's *API base URL* (which reflects <base>),
+// so passing '#id' resolves to '/#id' — dropping users on the bare domain
+// when they later copied the URL out of a component page. Issue #41
+// reported this. Concatenating pathname + search + '#id' bypasses the
+// base-href resolution and writes the URL the comment above promises.
 window.lumeo.navScrollActiveIntoView = function (id) {
     var el = document.getElementById(id);
     if (el) {
         el.scrollIntoView({ behavior: 'smooth', block: 'start' });
-        try { history.replaceState(null, '', '#' + id); } catch (_) { /* SSR / sandboxed */ }
+        try {
+            var pathQuery = (window.location.pathname || '/') + (window.location.search || '');
+            history.replaceState(null, '', pathQuery + '#' + id);
+        } catch (_) { /* SSR / sandboxed */ }
     }
 };
 

--- a/src/Lumeo.DataGrid/UI/DataGrid/DataGridHeaderCell.razor
+++ b/src/Lumeo.DataGrid/UI/DataGrid/DataGridHeaderCell.razor
@@ -98,12 +98,15 @@
 
     @if (Column.Resizable)
     {
+        @* No Blazor pointerdown binding here — the JS listener attached via
+           RegisterColumnResize() in OnAfterRenderAsync owns this event end to
+           end (capture, move tracking via setPointerCapture, prevent the page
+           from initiating a touch-scroll, commit on pointerup). Wiring a
+           Blazor handler too would double-fire the pointerdown handling and
+           recreate the lazy-register race from before. *@
         <div id="@_resizeHandleId"
              class="absolute right-0 top-0 bottom-0 w-1 cursor-col-resize hover:bg-primary/30 active:bg-primary/50"
-             style="touch-action: none;"
-             @onpointerdown="OnResizeStart"
-             @onpointerdown:stopPropagation="true"
-             @onpointerdown:preventDefault="true"></div>
+             style="touch-action: none;"></div>
     }
 
     @if (_isDragOver && EffectiveReorderable && _dropSide is not null)
@@ -117,7 +120,11 @@
     [CascadingParameter] private DataGridContext<TItem>? Context { get; set; }
     [CascadingParameter] private DataGrid<TItem>? ParentGrid { get; set; }
     [CascadingParameter] private DataGridDragState? DragState { get; set; }
-    [Inject] private ComponentInteropService Interop { get; set; } = default!;
+    @* Inject the interface, not the concrete service, so tests can substitute
+       a TrackingInteropService for the interop surface — every method used by
+       this component (PositionFixed, RegisterClickOutside, RegisterColumnResize,
+       …) is on the interface, so the switch is a pure DI tidy-up. *@
+    [Inject] private IComponentInteropService Interop { get; set; } = default!;
 
     [Parameter] public DataGridColumn<TItem> Column { get; set; } = default!;
     [Parameter] public int ColumnIndex { get; set; }
@@ -269,6 +276,25 @@
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
+        // Resize: register the JS pointer listeners ON the resize handle the
+        // moment it's in the DOM. Lazy-registering inside OnResizeStart meant
+        // the FIRST pointerdown ran the Blazor handler (which then asked JS to
+        // wire up its own pointerdown listener) — but that listener wasn't
+        // attached yet at the time of the originating event, so the first
+        // drag attempt was a no-op. Users had to release and press again
+        // before resize actually started. Registering on firstRender flips
+        // that: by the time the user's first pointerdown lands, the JS
+        // handler is already listening.
+        // Re-check on every render — not just firstRender — so columns whose
+        // Resizable flag flips on after mount (e.g. parent unlocks edit mode)
+        // still pick up the listener. _resizeRegistered short-circuits when
+        // the handler is already attached, so the cost is one bool check per
+        // render.
+        if (Column.Resizable && !_resizeRegistered)
+        {
+            await EnsureResizeRegistered();
+        }
+
         if (!Column.Filterable) return;
 
         if (IsFilterOpen && !_filterPositionRegistered)
@@ -309,26 +335,26 @@
         await OnFilterApply.InvokeAsync(args);
     }
 
-    private async Task OnResizeStart(PointerEventArgs e)
+    // Register-once helper. Called from OnAfterRenderAsync(firstRender) so the
+    // JS pointerdown listener is live before the user's first drag attempt.
+    // The previous lazy-on-first-pointerdown path is gone — that handler's
+    // sole job was registration, and it lost the originating pointerdown.
+    private async Task EnsureResizeRegistered()
     {
-        if (!Column.Resizable) return;
-
-        if (!_resizeRegistered)
-        {
-            // Register once, pass the column's min/max constraints up-front. JS drags the
-            // header + body cells in the DOM directly (smooth, no Blazor round-trips per
-            // pixel) and invokes the commit callback with the final width on mouseup.
-            await Interop.RegisterColumnResize(
-                _resizeHandleId,
-                Column.MinWidth ?? 50,
-                Column.MaxWidth,
-                async finalWidth =>
-                {
-                    ParentGrid?.UpdateColumnWidth(Column.Id, finalWidth);
-                    await InvokeAsync(StateHasChanged);
-                });
-            _resizeRegistered = true;
-        }
+        if (_resizeRegistered) return;
+        // JS drags the header + body cells in the DOM directly (smooth, no
+        // Blazor round-trips per pixel) and invokes the commit callback with
+        // the final width on pointerup.
+        await Interop.RegisterColumnResize(
+            _resizeHandleId,
+            Column.MinWidth ?? 50,
+            Column.MaxWidth,
+            async finalWidth =>
+            {
+                ParentGrid?.UpdateColumnWidth(Column.Id, finalWidth);
+                await InvokeAsync(StateHasChanged);
+            });
+        _resizeRegistered = true;
     }
 
     // --- Column Drag & Drop Reordering ---

--- a/tests/Lumeo.Tests/Components/DataGrid/DataGridColumnResizeRegistrationTests.cs
+++ b/tests/Lumeo.Tests/Components/DataGrid/DataGridColumnResizeRegistrationTests.cs
@@ -1,0 +1,102 @@
+using Bunit;
+using Lumeo.Services;
+using Lumeo.Tests.Helpers;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Lumeo.Tests.Components.DataGrid;
+
+/// <summary>
+/// Regression for #40: column resize did nothing on the first drag attempt
+/// because the JS pointerdown listener was lazy-registered inside Blazor's
+/// own pointerdown handler — by the time JS attached its listener, the
+/// originating event had already been dispatched, so the user had to release
+/// and press again before resize actually started. Registration now happens
+/// on the first OnAfterRenderAsync (before any pointer interaction) which
+/// makes the very first drag work.
+///
+/// This test asserts the structural invariant: a DataGrid with N resizable
+/// columns calls RegisterColumnResize N times before any user interaction
+/// occurs. We don't try to simulate the drag itself — bUnit can't drive
+/// setPointerCapture and we already cover the JS handler via the e2e suite.
+/// </summary>
+public class DataGridColumnResizeRegistrationTests : IAsyncLifetime
+{
+    private readonly BunitContext _ctx = new();
+    private readonly TrackingInteropService _interop = new();
+
+    public DataGridColumnResizeRegistrationTests()
+    {
+        _ctx.AddLumeoServices();
+        // AddLumeoServices binds IComponentInteropService → ComponentInteropService.
+        // Last-registration-wins for the interface so DataGridHeaderCell (which
+        // now injects the interface) resolves to the tracking impl. The
+        // concrete ComponentInteropService binding is left intact for any
+        // sibling component that still injects the concrete type.
+        _ctx.Services.AddScoped<IComponentInteropService>(_ => _interop);
+    }
+
+    public Task InitializeAsync() => Task.CompletedTask;
+    public async Task DisposeAsync() => await _ctx.DisposeAsync();
+
+    private record Row(int Id, string Name);
+
+    private static List<Row> Data() => new()
+    {
+        new(1, "Alice"),
+        new(2, "Bob"),
+    };
+
+    [Fact]
+    public void Resizable_Columns_Register_Resize_Handler_On_First_Render()
+    {
+        var cols = new List<DataGridColumn<Row>>
+        {
+            new() { Field = "Id",   Title = "ID",   Resizable = true  },
+            new() { Field = "Name", Title = "Name", Resizable = true  },
+        };
+
+        _ctx.Render<Lumeo.DataGrid<Row>>(p => p
+            .Add(g => g.Items, Data())
+            .Add(g => g.Columns, cols));
+
+        // No pointerdown simulated — registration MUST land at first render,
+        // not deferred until the user interacts.
+        Assert.Equal(2, _interop.RegisterColumnResizeCallCount);
+        // Each handle id is unique per column instance.
+        Assert.Equal(_interop.RegisterColumnResizeHandleIds.Distinct().Count(),
+                     _interop.RegisterColumnResizeCallCount);
+    }
+
+    [Fact]
+    public void Non_Resizable_Columns_Do_Not_Register()
+    {
+        var cols = new List<DataGridColumn<Row>>
+        {
+            new() { Field = "Id",   Title = "ID",   Resizable = false },
+            new() { Field = "Name", Title = "Name", Resizable = false },
+        };
+
+        _ctx.Render<Lumeo.DataGrid<Row>>(p => p
+            .Add(g => g.Items, Data())
+            .Add(g => g.Columns, cols));
+
+        Assert.Equal(0, _interop.RegisterColumnResizeCallCount);
+    }
+
+    [Fact]
+    public void Mixed_Resizable_Flags_Only_Register_The_Resizable_Columns()
+    {
+        var cols = new List<DataGridColumn<Row>>
+        {
+            new() { Field = "Id",   Title = "ID",   Resizable = false },
+            new() { Field = "Name", Title = "Name", Resizable = true  },
+        };
+
+        _ctx.Render<Lumeo.DataGrid<Row>>(p => p
+            .Add(g => g.Items, Data())
+            .Add(g => g.Columns, cols));
+
+        Assert.Equal(1, _interop.RegisterColumnResizeCallCount);
+    }
+}

--- a/tests/Lumeo.Tests/Helpers/TrackingInteropService.cs
+++ b/tests/Lumeo.Tests/Helpers/TrackingInteropService.cs
@@ -106,8 +106,25 @@ public sealed class TrackingInteropService : IComponentInteropService
     public ValueTask SetupAutoResize(string elementId, int maxRows) => ValueTask.CompletedTask;
     public ValueTask RegisterOtpPaste(string baseId, int length, Func<string, Task> handler) => ValueTask.CompletedTask;
     public ValueTask UnregisterOtpPaste(string baseId, int length) => ValueTask.CompletedTask;
-    public ValueTask RegisterColumnResize(string handleId, double minWidth, double? maxWidth, Func<double, Task> commitHandler) => ValueTask.CompletedTask;
-    public ValueTask UnregisterColumnResize(string handleId) => ValueTask.CompletedTask;
+    // Column resize tracking — used to assert that the JS pointerdown listener
+    // is wired during the first render, not lazily on the first pointerdown
+    // (the lazy path lost the originating event so the first drag was a no-op).
+    private readonly List<string> _columnResizeRegistrations = new();
+    private readonly List<string> _columnResizeUnregistrations = new();
+    public int RegisterColumnResizeCallCount => _columnResizeRegistrations.Count;
+    public IReadOnlyList<string> RegisterColumnResizeHandleIds => _columnResizeRegistrations;
+    public int UnregisterColumnResizeCallCount => _columnResizeUnregistrations.Count;
+
+    public ValueTask RegisterColumnResize(string handleId, double minWidth, double? maxWidth, Func<double, Task> commitHandler)
+    {
+        _columnResizeRegistrations.Add(handleId);
+        return ValueTask.CompletedTask;
+    }
+    public ValueTask UnregisterColumnResize(string handleId)
+    {
+        _columnResizeUnregistrations.Add(handleId);
+        return ValueTask.CompletedTask;
+    }
     public ValueTask<ElementRect?> GetElementRectBySelector(string selector) => ValueTask.FromResult<ElementRect?>(null);
     public ValueTask RegisterAffix(string elementId, int offsetTop, int? offsetBottom, string? target, Func<bool, Task> handler) => ValueTask.CompletedTask;
     public ValueTask UnregisterAffix(string elementId) => ValueTask.CompletedTask;


### PR DESCRIPTION
## Summary

Two fixes from external bug reports.

### 1. `fix(datagrid)`: column resize ignored on first drag attempt (#40)

JS pointerdown listener was lazy-registered **inside** Blazor's own `@onpointerdown="OnResizeStart"` handler. Sequence:

1. User pointerdowns on the resize handle
2. Blazor's handler runs → calls `Interop.RegisterColumnResize(...)` which `addEventListener('pointerdown', …)` on the handle
3. But the originating pointerdown event has already finished dispatching — the freshly-attached listener never receives it
4. User releases without anything happening; press-release-press-again before resize actually started

**Fix:** Move registration to `OnAfterRenderAsync`, gated on `Column.Resizable && !_resizeRegistered`. The handle is in the DOM by then and the JS listener is wired before any user interaction. The Blazor `@onpointerdown` binding on the resize handle is removed entirely — the JS handler owns the event end to end (capture via `setPointerCapture`, move tracking, prevent touch-scroll, commit on pointerup).

Drive-by cleanup: `DataGridHeaderCell` now injects `IComponentInteropService` instead of the concrete `ComponentInteropService`, matching the rest of the codebase (`TabsContent`, etc.) and letting tests substitute a `TrackingInteropService`.

Three bUnit assertions in `DataGridColumnResizeRegistrationTests`:
- N resizable columns → exactly N `RegisterColumnResize` calls **before any user interaction**
- 0 resizable columns → 0 calls
- Mixed flags → only the resizable columns register

### 2. `fix(docs)`: TOC anchor URLs no longer resolve to root under `<base href>` (#41)

The reporter wasn't hypothesising — the bug was real on every component page.

**Root cause:** `index.html` sets `<base href="/">`. Per the HTML spec, the URL argument to `history.replaceState` (and a plain `<a href="#id">`) is parsed against the document's *API base URL* — which reflects `<base>`, not the current `location`. So clicking a TOC entry, or right-clicking one and choosing "Copy Link Address", produced `https://lumeo.nativ.sh/#section` instead of `/components/datagrid#section`. The 3.2.4 TOC-deep-link patch missed this because it called `replaceState(null, '', '#id')` — exactly the form that base-resolves to root.

**Two fixes:**

1. `docs.js navScrollActiveIntoView`: build the URL as `pathname + search + '#' + id` before passing to replaceState. The concrete URL bypasses base-href resolution.

2. `OnThisPage.razor`: render anchors with `href="{currentPath}#{id}"` instead of bare `"#id"`. Click path is still intercepted via `@onclick:preventDefault`, so the href value only matters for the browser's "Copy Link Address" affordance and crawlers — and now produces the deep link directly. Path is read from `NavigationManager.Uri` so each route gets the right prefix.

## Test plan

- [ ] CI: `build-and-test` green (new `DataGridColumnResizeRegistrationTests` pass)
- [ ] Manual: open `/components/datagrid` → "Resizable Columns" demo. Drag a column edge **once**, see the column resize on the first drag.
- [ ] Manual: open any component page (`/components/datagrid`), click a TOC link in OnThisPage. Address bar shows `/components/datagrid#section-id`, not `/#section-id`.
- [ ] Manual: right-click a TOC link → "Copy Link Address". Pasted URL is `/components/datagrid#section-id`.
