### PR TITLE
ci(publish): add workflow_dispatch fallback

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,6 +10,11 @@ on:
   push:
     tags:
       - 'v*.*.*'
+  # Manual fallback for the case where a release was created by GITHUB_TOKEN
+  # (or any other automation identity), which suppresses the release/push
+  # events that would normally trigger this workflow. Version is read from
+  # Directory.Build.props as in the automatic paths.
+  workflow_dispatch:
 
 jobs:
   publish-lumeo:


### PR DESCRIPTION
## Summary
- Add `workflow_dispatch:` to `publish.yml` so the publish pipeline can be triggered manually from the Actions UI.

## Why
The v3.2.7 release was created by `GITHUB_TOKEN`, which suppresses the downstream `release: published` and `push: tags` events that would normally trigger `publish.yml`. As a result, the publish job never ran for v3.2.7 — even after the `chore(ci): nudge` commit (`16758b8`), which only re-fires push-on-master workflows (ci.yml, e2e.yml), not the tag/release-gated ones.

With `workflow_dispatch` in place, the owner can run the publish job manually from the Actions UI for v3.2.7 (and as a fallback for any future case where the automatic triggers are swallowed). Version is still read from `Directory.Build.props`, which is currently at 3.2.7, so no input is required.

## Test plan
- [ ] After merge, open Actions → "Publish 2.0 packages" → "Run workflow" against `master` and confirm the publish-lumeo / publish-cli / publish-templates / publish-mcp jobs run and push to NuGet/npm.
- [ ] Confirm `--skip-duplicate` / npm "already published" handling lets the run succeed cleanly if any of the 3.2.7 packages are already on the registries.