### PR TITLE
feat(datagrid): smoother column resize + FLIP-animated reorder

### DIFF
--- a/src/Lumeo.DataGrid/UI/DataGrid/DataGrid.razor
+++ b/src/Lumeo.DataGrid/UI/DataGrid/DataGrid.razor
@@ -93,7 +93,7 @@
 }
 
 @{
-    RenderFragment gridRoot = @<div data-slot="datagrid" class="@RootCssClass" style="@HeightStyle" @attributes="AdditionalAttributes">
+    RenderFragment gridRoot = @<div data-slot="datagrid" data-grid-id="@_gridId" class="@RootCssClass" style="@HeightStyle" @attributes="AdditionalAttributes">
 
         @* Declarative column definitions *@
         <div class="hidden">@ChildContent</div>
@@ -889,6 +889,12 @@
     private bool _lastIsExpandedParam;
     private bool _fullscreenNeedsFocus;
     private ElementReference _fullscreenRef;
+
+    // FLIP-reorder: set by HandleColumnReorder after the column model has
+    // been mutated; OnAfterRenderAsync sees it set, invokes the JS animator,
+    // and clears it. Kept private — consumers don't need to influence it.
+    private bool _pendingReorderAnimation;
+    private const int ColumnReorderAnimationMs = 220;
     private List<DataGridGroupSection<TItem>> _groupedSections = new();
     private HashSet<string> _expandedGroups = new();
     private HashSet<string> _knownGroupKeys = new();
@@ -1245,6 +1251,19 @@
         {
             _fullscreenNeedsFocus = false;
             try { await _fullscreenRef.FocusAsync(); } catch { /* element may not be ready */ }
+        }
+
+        // FLIP-animate the columns that just moved. HandleColumnReorder
+        // captured their pre-reorder rects before mutating _orderedColumns;
+        // now that the new layout has rendered, JS computes deltas and
+        // slides each column from its old to new position. Best-effort —
+        // a failed JS call must never wedge subsequent reorders, so it's
+        // wrapped in a try/catch and the flag is cleared unconditionally.
+        if (_pendingReorderAnimation)
+        {
+            _pendingReorderAnimation = false;
+            try { await Interop.AnimateColumnReorder(_gridId, ColumnReorderAnimationMs); }
+            catch (JSDisconnectedException) { }
         }
     }
 
@@ -2423,10 +2442,21 @@
         if (args.OldIndex < 0 || args.NewIndex < 0 || args.OldIndex >= _orderedColumns.Count || args.NewIndex >= _orderedColumns.Count)
             return;
 
+        // FLIP "First": snapshot each header's viewport rect BEFORE we
+        // mutate the column order. Reordering is followed by a Blazor
+        // re-render that snaps columns to their new positions; the
+        // matching AnimateColumnReorder call in OnAfterRenderAsync reads
+        // the new positions, computes deltas, and slides each column
+        // (header + its body cells, captured by index at snapshot time)
+        // from its old visual position to its new one.
+        try { await Interop.CaptureColumnRects(_gridId); }
+        catch (JSDisconnectedException) { }
+
         var col = _orderedColumns[args.OldIndex];
         _orderedColumns.RemoveAt(args.OldIndex);
         _orderedColumns.Insert(args.NewIndex, col);
         RefreshVisibleColumns();
+        _pendingReorderAnimation = true;
 
         // Await consumer handler so async handlers complete before we re-render.
         // Previously the returned Task was discarded which let the next

--- a/src/Lumeo.DataGrid/UI/DataGrid/DataGridHeaderCell.razor
+++ b/src/Lumeo.DataGrid/UI/DataGrid/DataGridHeaderCell.razor
@@ -5,6 +5,7 @@
 
 <th data-slot="datagrid-header-cell" class="@CssClass" style="@StyleString"
     id="@CellId"
+    data-col-id="@Column.Id"
     role="columnheader"
     aria-colindex="@AriaColIndex"
     aria-sort="@AriaSort"
@@ -12,6 +13,7 @@
     @onkeydown="HandleKeyDown"
     draggable="@(IsDraggable ? "true" : "false")"
     @ondragstart="HandleDragStart"
+    @ondragend="HandleDragEnd"
     @ondragover="HandleDragOver"
     @ondragover:preventDefault="true"
     @ondrop="HandleDrop"
@@ -111,8 +113,14 @@
 
     @if (_isDragOver && EffectiveReorderable && _dropSide is not null)
     {
-        <div class="lumeo-datagrid-drop-indicator absolute top-0 bottom-0 w-0.5 bg-primary pointer-events-none"
-             style="@(_dropSide == "left" ? "left: 0;" : "right: 0;")"></div>
+        @* Drop indicator: a 4px vertical bar with primary glow that
+           materializes between the dragged column and its prospective
+           neighbour. Centred over the gap (translate -50%) so the bar
+           sits ON the seam, not flush with the column edge — much
+           easier for users to read as a slot marker than the older
+           0.5px hairline. *@
+        <div class="lumeo-datagrid-drop-indicator absolute top-0 bottom-0 w-1 bg-primary rounded-full pointer-events-none shadow-[0_0_8px_color-mix(in_oklab,var(--primary)_70%,transparent)]"
+             style="@(_dropSide == "left" ? "left: 0; transform: translateX(-50%);" : "right: 0; transform: translateX(50%);") z-index: 10;"></div>
     }
 </th>
 
@@ -201,6 +209,12 @@
     /// </summary>
     private bool EffectiveReorderable => Reorderable && Column.Reorderable;
 
+    /// <summary>True when this header is the source of an in-flight column
+    /// drag (the dragstart fired here and dragend / drop hasn't yet). Used
+    /// to dim the source th so the user can see which column is moving.</summary>
+    private bool IsDragSource =>
+        DragState?.SourceColumnId is { } src && src == Column.Id;
+
     /// <summary>True when this header is HTML5-draggable. Two reasons to drag a
     /// header: reorder columns (Reorderable, drop on another header) or add the
     /// column as a new grouping level (Groupable, drop on the group panel —
@@ -230,6 +244,10 @@
                 // leaving Groupable-only columns with the default arrow cursor that hid
                 // the drag-into-panel UX from users (2.2.2).
                 IsDraggable ? "cursor-grab" : null,
+                // Dim the dragged source header so users see at a glance which
+                // column is moving. Pairs with the drop indicator on the target
+                // to make the gesture's two endpoints visually distinct.
+                IsDragSource ? "opacity-40 transition-opacity" : null,
                 Column.HeaderCssClass,
                 Class
             }.Where(s => !string.IsNullOrWhiteSpace(s)));
@@ -374,6 +392,21 @@
         // decided at the drop site.
         if (!IsDraggable || DragState is null) return;
         DragState.StartColumnDrag(ColumnIndex, Column.Id);
+    }
+
+    private void HandleDragEnd(DragEventArgs e)
+    {
+        // Fires on the SOURCE element regardless of whether the drop
+        // succeeded (drop target → ResetColumn already called) or was
+        // cancelled (Esc, drop outside any target). The handler itself is
+        // intentionally a no-op when there's no leftover state — but its
+        // presence triggers a Blazor re-render of the source cell, which
+        // clears the opacity-40 source-dim that IsDragSource toggled on.
+        // Defensive ResetColumn covers the cancel path where no drop ran.
+        if (DragState is not null && DragState.SourceColumnId == Column.Id)
+        {
+            DragState.ResetColumn();
+        }
     }
 
     private void HandleDragOver(DragEventArgs e)

--- a/src/Lumeo/Services/ComponentInteropService.cs
+++ b/src/Lumeo/Services/ComponentInteropService.cs
@@ -593,6 +593,20 @@ public sealed class ComponentInteropService : IComponentInteropService
     [JSInvokable]
     public async Task OnColumnResizeCommit(string handleId, double finalWidth) => await _resize.OnColumnResizeCommit(handleId, finalWidth);
 
+    // --- DataGrid Column Reorder FLIP Animation ---
+
+    public async ValueTask CaptureColumnRects(string gridId)
+    {
+        var module = await GetModuleAsync();
+        await module.InvokeVoidAsync("captureColumnRects", gridId);
+    }
+
+    public async ValueTask AnimateColumnReorder(string gridId, int durationMs)
+    {
+        var module = await GetModuleAsync();
+        await module.InvokeVoidAsync("animateColumnReorder", gridId, durationMs);
+    }
+
     // --- Tour: Element Rect By Selector ---
 
     public async ValueTask<ElementRect?> GetElementRectBySelector(string selector)

--- a/src/Lumeo/Services/IComponentInteropService.cs
+++ b/src/Lumeo/Services/IComponentInteropService.cs
@@ -149,6 +149,11 @@ public interface IComponentInteropService : IAsyncDisposable, IDisposable
     ValueTask RegisterColumnResize(string handleId, double minWidth, double? maxWidth, Func<double, Task> commitHandler);
     ValueTask UnregisterColumnResize(string handleId);
 
+    // DataGrid Column Reorder FLIP — capture column rects before reorder,
+    // animate from old → new positions after Blazor's re-render.
+    ValueTask CaptureColumnRects(string gridId);
+    ValueTask AnimateColumnReorder(string gridId, int durationMs);
+
     // Tour
     ValueTask<ElementRect?> GetElementRectBySelector(string selector);
 

--- a/src/Lumeo/wwwroot/js/components.js
+++ b/src/Lumeo/wwwroot/js/components.js
@@ -1541,6 +1541,13 @@ export function registerColumnResize(handleId, dotnetRef, minWidth, maxWidth) {
     let currentWidth = 0;
     let isDragging = false;
     let colBodyCells = [];
+    // rAF throttle: coalesce successive pointermoves into one DOM mutation
+    // per frame. Without this, a high-frequency pointer (120-240 Hz on modern
+    // touch/trackpad) triggers a full table reflow per event — visible as
+    // micro-stuttering on wide grids. One write per frame matches the
+    // refresh rate and lets the browser batch layout/paint naturally.
+    let rafId = 0;
+    let pendingWidth = 0;
 
     const min = Math.max(1, Number(minWidth) || 50);
     const max = Number(maxWidth) > 0 ? Number(maxWidth) : Number.POSITIVE_INFINITY;
@@ -1590,6 +1597,7 @@ export function registerColumnResize(handleId, dotnetRef, minWidth, maxWidth) {
         startX = e.clientX;
         startWidth = th.getBoundingClientRect().width;
         currentWidth = startWidth;
+        pendingWidth = startWidth;
         colBodyCells = gatherBodyCells();
         document.body.style.cursor = 'col-resize';
         document.body.style.userSelect = 'none';
@@ -1599,21 +1607,37 @@ export function registerColumnResize(handleId, dotnetRef, minWidth, maxWidth) {
         e.preventDefault();
         e.stopPropagation();
     };
+    const flushPendingWidth = () => {
+        rafId = 0;
+        if (!isDragging) return;
+        currentWidth = pendingWidth;
+        applyWidth(pendingWidth);
+    };
     const onPointerMove = (e) => {
         if (!isDragging || e.pointerId !== activePointerId) return;
         const delta = e.clientX - startX;
         let w = startWidth + delta;
         if (w < min) w = min;
         else if (w > max) w = max;
-        if (w === currentWidth) return;
-        currentWidth = w;
-        applyWidth(w);
+        if (w === pendingWidth) {
+            if (e.cancelable) e.preventDefault();
+            return;
+        }
+        pendingWidth = w;
+        if (!rafId) rafId = requestAnimationFrame(flushPendingWidth);
         // Block scroll on touch devices while actively dragging.
         if (e.cancelable) e.preventDefault();
     };
     const onPointerUp = (e) => {
         if (!isDragging || e.pointerId !== activePointerId) return;
         isDragging = false;
+        if (rafId) { cancelAnimationFrame(rafId); rafId = 0; }
+        // Apply any pending frame synchronously so the committed width
+        // matches what the user released on (no half-frame visual snap).
+        if (pendingWidth !== currentWidth) {
+            currentWidth = pendingWidth;
+            applyWidth(pendingWidth);
+        }
         document.body.style.cursor = '';
         document.body.style.userSelect = '';
         try { handle.releasePointerCapture(e.pointerId); } catch (_) { }
@@ -1623,6 +1647,7 @@ export function registerColumnResize(handleId, dotnetRef, minWidth, maxWidth) {
     const onPointerCancel = (e) => {
         if (!isDragging || e.pointerId !== activePointerId) return;
         isDragging = false;
+        if (rafId) { cancelAnimationFrame(rafId); rafId = 0; }
         document.body.style.cursor = '';
         document.body.style.userSelect = '';
         try { handle.releasePointerCapture(e.pointerId); } catch (_) { }
@@ -1649,6 +1674,116 @@ export function unregisterColumnResize(handleId) {
         }
         columnResizeHandlers.delete(handleId);
     }
+}
+
+// --- DataGrid Column Reorder FLIP Animation ---
+//
+// FLIP (First-Last-Invert-Play): the technique for animating layout changes
+// that the browser can't smooth on its own. Blazor rerenders the table after
+// a reorder and the columns just snap to their new positions; with this in
+// place, the consumer can capture the old positions BEFORE the rerender and
+// animate from old → new AFTER, so users see neighbour columns smoothly slide
+// into place rather than the destination just appearing.
+//
+// Stable identity for each column is the `data-col-id` attribute on the <th>
+// (the DOM `id` is index-based and changes on reorder, so it's unusable here).
+// We also pick up body cells in the same visual column by their index in the
+// header row at capture time, so they tag along with the header's animation.
+
+const columnReorderSnapshots = new Map(); // gridId -> { colId: { left, cells: [el,...] } }
+const columnReorderInFlight = new Map();  // gridId -> Set<HTMLElement> (cells with inline FLIP styles)
+
+function clearFlipStyles(cell) {
+    cell.style.transition = '';
+    cell.style.transform = '';
+    cell.style.willChange = '';
+}
+
+export function captureColumnRects(gridId) {
+    const grid = document.querySelector(`[data-grid-id="${CSS.escape(gridId)}"]`);
+    if (!grid) return;
+    // If a previous FLIP for this grid is still mid-flight, force its
+    // cells back to identity BEFORE measuring — otherwise the rects we
+    // capture include the in-flight translateX and the next animation
+    // starts from a wrong "First". Reorders triggered faster than the
+    // animation duration are uncommon but possible (rapid drag).
+    const inFlight = columnReorderInFlight.get(gridId);
+    if (inFlight) {
+        for (const cell of inFlight) clearFlipStyles(cell);
+        columnReorderInFlight.delete(gridId);
+    }
+    const headers = grid.querySelectorAll('th[data-col-id]');
+    if (!headers.length) return;
+    const headerRow = headers[0].parentElement;
+    const tbody = grid.querySelector('table tbody');
+    const snapshot = {};
+    headers.forEach((th) => {
+        const colId = th.dataset.colId;
+        if (!colId) return;
+        const colIdx = Array.prototype.indexOf.call(headerRow.children, th);
+        const cells = [th];
+        if (tbody && colIdx >= 0) {
+            for (const row of tbody.rows) {
+                if (row.children[colIdx]) cells.push(row.children[colIdx]);
+            }
+        }
+        snapshot[colId] = { left: th.getBoundingClientRect().left, cells };
+    });
+    columnReorderSnapshots.set(gridId, snapshot);
+}
+
+export function animateColumnReorder(gridId, durationMs) {
+    const snapshot = columnReorderSnapshots.get(gridId);
+    columnReorderSnapshots.delete(gridId);
+    if (!snapshot) return;
+    const grid = document.querySelector(`[data-grid-id="${CSS.escape(gridId)}"]`);
+    if (!grid) return;
+    const duration = Number(durationMs) > 0 ? Number(durationMs) : 200;
+
+    const headers = grid.querySelectorAll('th[data-col-id]');
+    const inFlight = new Set();
+    headers.forEach((th) => {
+        const colId = th.dataset.colId;
+        const snap = snapshot[colId];
+        if (!snap) return;
+        const newLeft = th.getBoundingClientRect().left;
+        const delta = snap.left - newLeft;
+        if (Math.abs(delta) < 1) return;
+
+        // Inverse-translate header + cached body cells to their previous
+        // visual position, then animate transform back to 0 on the next
+        // frame. The cells array was captured at snapshot time, so it
+        // refers to the SAME DOM nodes — the column's body cells move with
+        // their header even though the DOM order under tbody changed.
+        for (const cell of snap.cells) {
+            cell.style.transition = 'none';
+            cell.style.transform = `translateX(${delta}px)`;
+            cell.style.willChange = 'transform';
+            inFlight.add(cell);
+        }
+        // Force layout flush so the inverse transform is registered before
+        // we kick off the transition. Reading offsetWidth from any one cell
+        // is enough — it's a synchronous reflow trigger.
+        // eslint-disable-next-line no-unused-expressions
+        th.offsetWidth;
+        for (const cell of snap.cells) {
+            cell.style.transition = `transform ${duration}ms cubic-bezier(0.22, 1, 0.36, 1)`;
+            cell.style.transform = '';
+        }
+    });
+    if (inFlight.size === 0) return;
+    columnReorderInFlight.set(gridId, inFlight);
+    // Clear inline styles after the transition so they don't leak into
+    // the next reorder. setTimeout (not transitionend) keeps the cleanup
+    // O(1) listeners regardless of cell count.
+    window.setTimeout(() => {
+        // Only clear cells we still own — captureColumnRects may have
+        // pre-emptively cleared them already if a new reorder kicked in.
+        const owned = columnReorderInFlight.get(gridId);
+        if (owned !== inFlight) return;
+        for (const cell of inFlight) clearFlipStyles(cell);
+        columnReorderInFlight.delete(gridId);
+    }, duration + 50);
 }
 
 // --- File Download ---

--- a/tests/Lumeo.Docs.Tests/Helpers/DocsTestContext.cs
+++ b/tests/Lumeo.Docs.Tests/Helpers/DocsTestContext.cs
@@ -117,6 +117,10 @@ internal sealed class NoopInteropService : IComponentInteropService
     public ValueTask RegisterColumnResize(string handleId, double minWidth, double? maxWidth, Func<double, Task> commitHandler) => ValueTask.CompletedTask;
     public ValueTask UnregisterColumnResize(string handleId) => ValueTask.CompletedTask;
 
+    // DataGrid Column Reorder FLIP
+    public ValueTask CaptureColumnRects(string gridId) => ValueTask.CompletedTask;
+    public ValueTask AnimateColumnReorder(string gridId, int durationMs) => ValueTask.CompletedTask;
+
     // Tour
     public ValueTask<ElementRect?> GetElementRectBySelector(string selector) => ValueTask.FromResult<ElementRect?>(null);
 

--- a/tests/Lumeo.Tests/Components/DataGrid/DataGridReorderFlipTests.cs
+++ b/tests/Lumeo.Tests/Components/DataGrid/DataGridReorderFlipTests.cs
@@ -1,0 +1,67 @@
+using Bunit;
+using Lumeo.Services;
+using Lumeo.Tests.Helpers;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Lumeo.Tests.Components.DataGrid;
+
+/// <summary>
+/// Structural invariants for the FLIP-reorder pipeline: the grid root carries
+/// a stable <c>data-grid-id</c>, and every header cell carries a stable
+/// <c>data-col-id</c>. JS captureColumnRects / animateColumnReorder rely on
+/// these attributes to look up the right grid and to identify columns across
+/// the reorder (the DOM <c>id</c> on header cells is index-based and can't
+/// survive a reorder).
+/// </summary>
+public class DataGridReorderFlipTests : IAsyncLifetime
+{
+    private readonly BunitContext _ctx = new();
+    private readonly TrackingInteropService _interop = new();
+
+    public DataGridReorderFlipTests()
+    {
+        _ctx.AddLumeoServices();
+        _ctx.Services.AddScoped<IComponentInteropService>(_ => _interop);
+    }
+
+    public Task InitializeAsync() => Task.CompletedTask;
+    public async Task DisposeAsync() => await _ctx.DisposeAsync();
+
+    private record Row(int Id, string Name);
+
+    [Fact]
+    public void Grid_Root_Has_Data_Grid_Id_Attribute()
+    {
+        var cols = new List<DataGridColumn<Row>>
+        {
+            new() { Field = "Id",   Title = "ID" },
+            new() { Field = "Name", Title = "Name" },
+        };
+
+        var cut = _ctx.Render<Lumeo.DataGrid<Row>>(p => p
+            .Add(g => g.Items, new List<Row> { new(1, "Alice") })
+            .Add(g => g.Columns, cols));
+
+        var root = cut.Find("[data-slot='datagrid']");
+        Assert.True(root.HasAttribute("data-grid-id"));
+        Assert.False(string.IsNullOrWhiteSpace(root.GetAttribute("data-grid-id")));
+    }
+
+    [Fact]
+    public void Header_Cells_Carry_Data_Col_Id_Matching_Column_Id()
+    {
+        var idCol = new DataGridColumn<Row> { Field = "Id", Title = "ID" };
+        var nameCol = new DataGridColumn<Row> { Field = "Name", Title = "Name" };
+
+        var cut = _ctx.Render<Lumeo.DataGrid<Row>>(p => p
+            .Add(g => g.Items, new List<Row> { new(1, "Alice") })
+            .Add(g => g.Columns, new List<DataGridColumn<Row>> { idCol, nameCol }));
+
+        var headers = cut.FindAll("th[data-slot='datagrid-header-cell']");
+        Assert.Equal(2, headers.Count);
+        // Order: cols list order → ID first, Name second
+        Assert.Equal(idCol.Id, headers[0].GetAttribute("data-col-id"));
+        Assert.Equal(nameCol.Id, headers[1].GetAttribute("data-col-id"));
+    }
+}

--- a/tests/Lumeo.Tests/Helpers/TrackingInteropService.cs
+++ b/tests/Lumeo.Tests/Helpers/TrackingInteropService.cs
@@ -125,6 +125,22 @@ public sealed class TrackingInteropService : IComponentInteropService
         _columnResizeUnregistrations.Add(handleId);
         return ValueTask.CompletedTask;
     }
+
+    private readonly List<string> _captureColumnRectsCalls = new();
+    private readonly List<(string gridId, int durationMs)> _animateColumnReorderCalls = new();
+    public IReadOnlyList<string> CaptureColumnRectsGridIds => _captureColumnRectsCalls;
+    public IReadOnlyList<(string gridId, int durationMs)> AnimateColumnReorderCalls => _animateColumnReorderCalls;
+    public ValueTask CaptureColumnRects(string gridId)
+    {
+        _captureColumnRectsCalls.Add(gridId);
+        return ValueTask.CompletedTask;
+    }
+    public ValueTask AnimateColumnReorder(string gridId, int durationMs)
+    {
+        _animateColumnReorderCalls.Add((gridId, durationMs));
+        return ValueTask.CompletedTask;
+    }
+
     public ValueTask<ElementRect?> GetElementRectBySelector(string selector) => ValueTask.FromResult<ElementRect?>(null);
     public ValueTask RegisterAffix(string elementId, int offsetTop, int? offsetBottom, string? target, Func<bool, Task> handler) => ValueTask.CompletedTask;
     public ValueTask UnregisterAffix(string elementId) => ValueTask.CompletedTask;

--- a/tests/Lumeo.Tests/Services/ResponsiveServiceTests.cs
+++ b/tests/Lumeo.Tests/Services/ResponsiveServiceTests.cs
@@ -170,6 +170,8 @@ public class ResponsiveServiceTests
         public ValueTask UnregisterOtpPaste(string baseId, int length) => ValueTask.CompletedTask;
         public ValueTask RegisterColumnResize(string handleId, double minWidth, double? maxWidth, Func<double, Task> commitHandler) => ValueTask.CompletedTask;
         public ValueTask UnregisterColumnResize(string handleId) => ValueTask.CompletedTask;
+        public ValueTask CaptureColumnRects(string gridId) => ValueTask.CompletedTask;
+        public ValueTask AnimateColumnReorder(string gridId, int durationMs) => ValueTask.CompletedTask;
         public ValueTask<ElementRect?> GetElementRectBySelector(string selector) => ValueTask.FromResult<ElementRect?>(null);
         public ValueTask RegisterAffix(string elementId, int offsetTop, int? offsetBottom, string? target, Func<bool, Task> handler) => ValueTask.CompletedTask;
         public ValueTask UnregisterAffix(string elementId) => ValueTask.CompletedTask;


### PR DESCRIPTION
## Summary
Two UX improvements on the DataGrid column-edit surface that felt abrupt:

**1. Column resize — RAF throttle**
The pointermove handler was writing `th.style.width` plus every visible body cell's width on every event. With 120–240 Hz pointers and many rows that's a full table reflow per event, visible as micro-stuttering. Coalesce successive moves into one DOM mutation per `requestAnimationFrame`; flush any pending frame synchronously on pointerup so the committed width matches the cursor's release.

**2. Column reorder — visual feedback + FLIP animation**
- Drop indicator promoted from a 0.5 px hairline to a 4 px primary-coloured bar centred on the seam with a soft glow.
- The drag source `<th>` is dimmed (`opacity-40`) so the two endpoints of the gesture are visually distinct.
- On drop, FLIP-animate from old → new positions: `HandleColumnReorder` captures each header's pre-mutation viewport rect via a new `captureColumnRects` JS hook; `OnAfterRenderAsync` calls `animateColumnReorder`, which inverse-translates each `th` and its body cells back to their old visual position and transitions them to identity over 220 ms with an ease-out curve.

Stable identity comes from a new `data-col-id` on each `<th>` (the existing index-based DOM `id` changes on reorder) and a `data-grid-id` on the grid root for JS lookup. Both keyed-cell paths in `DataGridHeader` / `DataGridRow` already use `Column.Id` as the Blazor `@key`, so the DOM nodes captured at snapshot time survive the re-render and animate in place.

A rapid-reorder guard clears any in-flight FLIP styles at the start of the next capture so the next animation's "First" rect is the true layout position, not a transformed one.

## Test plan
- [ ] Build + existing test suite green (TrackingInteropService + DocsTestContext now implement the new interface methods).
- [ ] New `DataGridReorderFlipTests` covers the structural invariants (`data-grid-id` on root, `data-col-id` on header cells).
- [ ] Manual: drag a resize handle on a wide grid with many rows — motion should feel buttery vs. previous step-by-step jitter.
- [ ] Manual: drag a column header onto another — the drop indicator should be clearly visible as a vertical bar; on drop the columns should slide into their new positions instead of snapping.
- [ ] Manual: confirm drag-to-group (when `ShowGroupPanel="true"` and column is `Groupable`) still works — `IsDraggable` covers both reorder and drag-to-group; the new `data-col-id` and the source-dim cosmetics are non-disruptive to that path.