### PR TITLE
fix(a11y): batch trivial accessibility additions across 12 components

### DIFF
--- a/src/Lumeo/UI/Accordion/AccordionContent.razor
+++ b/src/Lumeo/UI/Accordion/AccordionContent.razor
@@ -1,6 +1,6 @@
 @namespace Lumeo
 
-<div class="grid transition-[grid-template-rows] duration-200 ease-out @(IsOpen ? "grid-rows-[1fr] opacity-100" : "grid-rows-[0fr] opacity-0") @CssClass" @attributes="AdditionalAttributes" aria-hidden="@(IsOpen ? "false" : "true")">
+<div role="region" class="grid transition-[grid-template-rows] duration-200 ease-out @(IsOpen ? "grid-rows-[1fr] opacity-100" : "grid-rows-[0fr] opacity-0") @CssClass" @attributes="AdditionalAttributes" aria-hidden="@(IsOpen ? "false" : "true")">
     <div class="overflow-hidden min-h-0">
         <div class="pb-4 pt-0">
             @ChildContent

--- a/src/Lumeo/UI/AgentMessageList/AgentMessageList.razor
+++ b/src/Lumeo/UI/AgentMessageList/AgentMessageList.razor
@@ -2,7 +2,7 @@
 @inject Services.IComponentInteropService Interop
 @implements IAsyncDisposable
 
-<div id="@_listId" class="@RootClass" @attributes="AdditionalAttributes">
+<div id="@_listId" class="@RootClass" role="log" aria-live="polite" aria-relevant="additions" @attributes="AdditionalAttributes">
     <div class="flex flex-col gap-4">
         @ChildContent
     </div>

--- a/src/Lumeo/UI/Collapsible/CollapsibleContent.razor
+++ b/src/Lumeo/UI/Collapsible/CollapsibleContent.razor
@@ -1,6 +1,6 @@
 @namespace Lumeo
 
-<div class="grid transition-[grid-template-rows] duration-200 ease-out @(Context.IsOpen ? "grid-rows-[1fr] opacity-100" : "grid-rows-[0fr] opacity-0") @CssClass" @attributes="AdditionalAttributes" aria-hidden="@(Context.IsOpen ? "false" : "true")">
+<div role="region" class="grid transition-[grid-template-rows] duration-200 ease-out @(Context.IsOpen ? "grid-rows-[1fr] opacity-100" : "grid-rows-[0fr] opacity-0") @CssClass" @attributes="AdditionalAttributes" aria-hidden="@(Context.IsOpen ? "false" : "true")">
     <div class="overflow-hidden min-h-0">
         @ChildContent
     </div>

--- a/src/Lumeo/UI/ContextMenu/ContextMenuContent.razor
+++ b/src/Lumeo/UI/ContextMenu/ContextMenuContent.razor
@@ -3,7 +3,7 @@
 
 @if (Context.IsOpen)
 {
-    <div id="@_contentId" class="@CssClass" style="@PositionStyle" @onkeydown="HandleKeyDown" tabindex="-1" @attributes="AdditionalAttributes">
+    <div id="@_contentId" role="menu" aria-orientation="vertical" class="@CssClass" style="@PositionStyle" @onkeydown="HandleKeyDown" tabindex="-1" @attributes="AdditionalAttributes">
         @ChildContent
     </div>
 }

--- a/src/Lumeo/UI/EmptyState/EmptyState.razor
+++ b/src/Lumeo/UI/EmptyState/EmptyState.razor
@@ -1,6 +1,6 @@
 @namespace Lumeo
 
-<div class="@CssClass" @attributes="AdditionalAttributes">
+<div role="status" class="@CssClass" @attributes="AdditionalAttributes">
     @if (IconContent is not null)
     {
         <div class="mb-4 text-muted-foreground">

--- a/src/Lumeo/UI/Result/Result.razor
+++ b/src/Lumeo/UI/Result/Result.razor
@@ -1,6 +1,6 @@
 @namespace Lumeo
 
-<div class="@CssClass" @attributes="AdditionalAttributes">
+<div role="status" class="@CssClass" @attributes="AdditionalAttributes">
     <div class="flex flex-col items-center text-center">
         <div class="@IconContainerClasses">
             @if (IconContent is not null)

--- a/src/Lumeo/UI/Skeleton/Skeleton.razor
+++ b/src/Lumeo/UI/Skeleton/Skeleton.razor
@@ -8,13 +8,15 @@
             100% { background-position: 200% 0; }
         }
     </style>
-    <div class="@($"rounded-md bg-gradient-to-r from-primary/10 via-primary/5 to-primary/10 bg-[length:200%_100%] {Class}".Trim())"
+    <div role="status" aria-busy="true" aria-label="Loading"
+         class="@($"rounded-md bg-gradient-to-r from-primary/10 via-primary/5 to-primary/10 bg-[length:200%_100%] {Class}".Trim())"
          style="animation: skeleton-wave 1.5s ease-in-out infinite"
          @attributes="AdditionalAttributes"></div>
 }
 else
 {
-    <div class="@($"{AnimationClass} rounded-md bg-primary/10 {Class}".Trim())" @attributes="AdditionalAttributes"></div>
+    <div role="status" aria-busy="true" aria-label="Loading"
+         class="@($"{AnimationClass} rounded-md bg-primary/10 {Class}".Trim())" @attributes="AdditionalAttributes"></div>
 }
 
 @code {

--- a/src/Lumeo/UI/Spinner/Spinner.razor
+++ b/src/Lumeo/UI/Spinner/Spinner.razor
@@ -2,8 +2,8 @@
 
 @if (Variant == SpinnerVariant.Ring)
 {
-    <div class="@WrapperClass" @attributes="AdditionalAttributes">
-        <svg class="@RingCssClass" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+    <div class="@WrapperClass" role="status" aria-live="polite" aria-busy="true" aria-label="@AriaLabelOrDefault" @attributes="AdditionalAttributes">
+        <svg class="@RingCssClass" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" aria-hidden="true">
             <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
             <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
         </svg>
@@ -15,8 +15,8 @@
 }
 else if (Variant == SpinnerVariant.Dots)
 {
-    <div class="@WrapperClass" @attributes="AdditionalAttributes">
-        <div class="@DotsContainerClass">
+    <div class="@WrapperClass" role="status" aria-live="polite" aria-busy="true" aria-label="@AriaLabelOrDefault" @attributes="AdditionalAttributes">
+        <div class="@DotsContainerClass" aria-hidden="true">
             <div class="@DotClass" style="animation-delay: 0ms"></div>
             <div class="@DotClass" style="animation-delay: 150ms"></div>
             <div class="@DotClass" style="animation-delay: 300ms"></div>
@@ -29,8 +29,8 @@ else if (Variant == SpinnerVariant.Dots)
 }
 else if (Variant == SpinnerVariant.Bars)
 {
-    <div class="@WrapperClass" @attributes="AdditionalAttributes">
-        <div class="@BarsContainerClass">
+    <div class="@WrapperClass" role="status" aria-live="polite" aria-busy="true" aria-label="@AriaLabelOrDefault" @attributes="AdditionalAttributes">
+        <div class="@BarsContainerClass" aria-hidden="true">
             <div class="@BarClass" style="height: 60%; animation-delay: 0ms"></div>
             <div class="@BarClass" style="height: 100%; animation-delay: 150ms"></div>
             <div class="@BarClass" style="height: 60%; animation-delay: 300ms"></div>
@@ -51,6 +51,12 @@ else if (Variant == SpinnerVariant.Bars)
     [Parameter(CaptureUnmatchedValues = true)] public Dictionary<string, object>? AdditionalAttributes { get; set; }
 
     private string WrapperClass => Cx.Join("inline-flex items-center gap-2", Color, Class);
+
+    // Always advertise an accessible name to AT. Falls back to the visible
+    // Label when present, otherwise "Loading" — the SVG/Dots/Bars are marked
+    // aria-hidden because their shapes carry no semantic meaning by
+    // themselves, so without this the spinner is invisible to screen readers.
+    private string AriaLabelOrDefault => string.IsNullOrEmpty(Label) ? "Loading" : Label!;
 
     private string RingCssClass => Cx.Join("animate-spin", SizeClasses);
 

--- a/src/Lumeo/UI/Splitter/SplitterDivider.razor
+++ b/src/Lumeo/UI/Splitter/SplitterDivider.razor
@@ -3,6 +3,7 @@
 
 <div id="@_dividerId"
      role="separator"
+     aria-orientation="@(IsHorizontal ? "horizontal" : "vertical")"
      tabindex="0"
      class="@CssClass"
      @onpointerdown="OnPointerDown"

--- a/src/Lumeo/UI/StreamingText/StreamingText.razor
+++ b/src/Lumeo/UI/StreamingText/StreamingText.razor
@@ -1,6 +1,6 @@
 @namespace Lumeo
 
-<span class="@RootClass" @attributes="AdditionalAttributes">
+<span class="@RootClass" role="status" aria-live="polite" aria-atomic="false" @attributes="AdditionalAttributes">
     @if (!string.IsNullOrEmpty(_alreadyRendered))
     {
         <span>@_alreadyRendered</span>

--- a/src/Lumeo/UI/Tabs/TabsList.razor
+++ b/src/Lumeo/UI/Tabs/TabsList.razor
@@ -209,7 +209,8 @@ else
     {
         if (_touchRegistered)
         {
-            await Interop.UnregisterSortableTouch(_listId);
+            try { await Interop.UnregisterSortableTouch(_listId); }
+            catch (JSDisconnectedException) { }
             _touchRegistered = false;
         }
     }

--- a/src/Lumeo/UI/Watermark/Watermark.razor
+++ b/src/Lumeo/UI/Watermark/Watermark.razor
@@ -2,7 +2,7 @@
 
 <div class="@CssClass" @attributes="AdditionalAttributes">
     @ChildContent
-    <div class="pointer-events-none absolute inset-0 z-10"
+    <div aria-hidden="true" class="pointer-events-none absolute inset-0 z-10"
          style="background-image: url('data:image/svg+xml,@(EncodedSvg)'); background-repeat: repeat;">
     </div>
 </div>


### PR DESCRIPTION
## Summary
Output of a static bug-scan across ~120 components in `src/Lumeo/UI/`. Cherry-picked the findings that were **verified real** AND fit "trivial" (<5 lines, no API or behaviour change, no test rewrite). Larger findings are being filed as separate issues.

## Per-component changes

| Component | Change | Why |
|---|---|---|
| ContextMenuContent | `role="menu"` + `aria-orientation="vertical"` | bare div with `tabindex="-1"` — AT couldn't see it as a menu |
| AccordionContent / CollapsibleContent | `role="region"` | AT didn't see the body as a landmark associated with the trigger |
| SplitterDivider | `aria-orientation` reflecting `Splitter.Orientation` | `role="separator"` was correct but the axis was unspecified |
| Watermark | `aria-hidden="true"` on the decorative overlay | `pointer-events-none` already; AT was still walking into it |
| Spinner | `role="status"` + `aria-live="polite"` + `aria-busy="true"` + `aria-label` (defaults to "Loading") on all three variants; decorative SVG/dots/bars now `aria-hidden` | spinner was silent to AT |
| EmptyState / Result | `role="status"` on root | dynamic empty / result transitions weren't announced |
| Skeleton | `role="status"` + `aria-busy="true"` + `aria-label="Loading"` on both Wave and Pulse/None paths | loading state wasn't surfaced |
| StreamingText | `role="status"` + `aria-live="polite"` + `aria-atomic="false"` | tokens were rendered silently; `aria-atomic="false"` so AT reads additive chunks instead of re-reading on every token |
| AgentMessageList | `role="log"` + `aria-live="polite"` + `aria-relevant="additions"` | new agent messages weren't announced |
| TabsList.DisposeAsync | wrap `UnregisterSortableTouch` in `try/catch (JSDisconnectedException)` | matches the pattern in the rest of this file; unhandled exception on circuit drop without it |

## Out of scope (will be filed as issues)
A11y findings that require **API additions**, perf-caching for filter LINQ in property getters, and behaviour fixes (Popover `PreventClose` propagation, ConsentBanner focus trap, Window cleanup, MegaMenu `aria-haspopup`).

## Verified-false agent findings (NOT changed)
~17 of the scan's flags turned out to be false positives on verification — dispose catches already in place (Tour / Calendar / Affix / Scrollspy / ResizableHandle), Tabs swipe-bounds already guarded, HoverCard/Tooltip `StateHasChanged` ordering was correct, `<table>` doesn't need `role="table"`, Pagination already has `aria-label`.