### PR TITLE
perf(docs): lazy-load icon packs + 6 satellite component packages

### DIFF
--- a/docs/Lumeo.Docs/App.razor
+++ b/docs/Lumeo.Docs/App.razor
@@ -1,6 +1,86 @@
-﻿<Router AppAssembly="@typeof(App).Assembly" NotFoundPage="typeof(Pages.NotFound)">
+﻿@using System.Reflection
+@using Microsoft.AspNetCore.Components.Routing
+@using Microsoft.AspNetCore.Components.WebAssembly.Services
+@inject LazyAssemblyLoader LazyLoader
+
+<Router AppAssembly="@typeof(App).Assembly" OnNavigateAsync="OnNavigateAsync" NotFoundPage="typeof(Pages.NotFound)" AdditionalAssemblies="_loadedAssemblies">
     <Found Context="routeData">
         <RouteView RouteData="@routeData" DefaultLayout="@typeof(MainLayout)"/>
         <FocusOnNavigate RouteData="@routeData" Selector="h1" />
     </Found>
 </Router>
+
+@code {
+    // Tracks lazy assemblies already pulled across the wire so we don't
+    // re-fetch on every navigation. The Router also reads this list so
+    // route resolution can find page types declared inside lazy DLLs.
+    private readonly List<Assembly> _loadedAssemblies = new();
+    private readonly HashSet<string> _loadedNames = new(StringComparer.OrdinalIgnoreCase);
+
+    // Route-prefix → DLL list. Each entry maps a navigation path PREFIX
+    // (matched with StartsWith / ordinal-ignore-case) to the set of lazy
+    // assemblies required to render that route. Keep in sync with the
+    // BlazorWebAssemblyLazyLoad items in Lumeo.Docs.csproj — when a new
+    // satellite is split out, both lists need updating.
+    //
+    // The 8 Blazicons packs are bundled together under one /components/icon
+    // entry: the icon showcase page references types from all of them via
+    // static field access (Blazicons.BootstrapIcon.Archive, …), so loading
+    // them as a group is correct.
+    private static readonly (string PathPrefix, string[] Assemblies)[] _lazyMap = new[]
+    {
+        ("/components/icon", new[]
+        {
+            "Blazicons.Bootstrap.dll",
+            "Blazicons.Devicon.dll",
+            "Blazicons.FlagIcons.dll",
+            "Blazicons.FluentUI.dll",
+            "Blazicons.FontAwesome.dll",
+            "Blazicons.GoogleMaterialDesign.dll",
+            "Blazicons.Ionicons.dll",
+            "Blazicons.MaterialDesignIcons.dll",
+        }),
+        ("/components/code-editor",      new[] { "Lumeo.CodeEditor.dll" }),
+        ("/components/rich-text-editor", new[] { "Lumeo.Editor.dll" }),
+        ("/components/file-viewer",      new[] { "Lumeo.FileViewer.dll" }),
+        ("/components/gantt",            new[] { "Lumeo.Gantt.dll" }),
+        ("/components/pdf-viewer",       new[] { "Lumeo.PdfViewer.dll" }),
+        ("/components/scheduler",        new[] { "Lumeo.Scheduler.dll" }),
+    };
+
+    private async Task OnNavigateAsync(NavigationContext context)
+    {
+        // context.Path is the path component of the URL (no scheme/host/query).
+        // Blazor normalises it without a leading slash; prepend one so our
+        // _lazyMap prefixes (which DO start with "/") match.
+        var path = "/" + (context.Path ?? string.Empty).TrimStart('/');
+
+        // Collect the DLLs needed for this route, filtering out ones already
+        // loaded so subsequent visits are zero-cost.
+        var needed = new List<string>();
+        foreach (var (prefix, dlls) in _lazyMap)
+        {
+            if (!path.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)) continue;
+            foreach (var dll in dlls)
+            {
+                if (_loadedNames.Add(dll)) needed.Add(dll);
+            }
+        }
+        if (needed.Count == 0) return;
+
+        try
+        {
+            var assemblies = await LazyLoader.LoadAssembliesAsync(needed);
+            _loadedAssemblies.AddRange(assemblies);
+        }
+        catch
+        {
+            // Best-effort: a failed fetch leaves the assemblies un-marked so
+            // the next navigation tries again. We intentionally swallow here
+            // rather than crash the router — the page itself will surface a
+            // meaningful error when its types can't resolve.
+            foreach (var dll in needed) _loadedNames.Remove(dll);
+            throw;
+        }
+    }
+}

--- a/docs/Lumeo.Docs/Lumeo.Docs.csproj
+++ b/docs/Lumeo.Docs/Lumeo.Docs.csproj
@@ -62,4 +62,38 @@
                       ReferenceOutputAssembly="false" />
   </ItemGroup>
 
+  <!-- Lazy-loaded assemblies: pulled in by App.OnNavigateAsync on the routes that
+       actually need them. Removing them from the initial blazor.boot.json eager
+       set keeps the Home / general routes light. Each entry below maps 1:1 to a
+       route prefix handled in App.razor's NavigationContext switch — keep the two
+       in sync when adding a new satellite package. -->
+  <ItemGroup>
+    <!-- 7 icon packs (~few hundred KB each) — only the /components/icon route
+         shows examples from them. Blazicons.Lucide stays eager because it is
+         used pervasively across the library. -->
+    <BlazorWebAssemblyLazyLoad Include="Blazicons.Bootstrap.dll" />
+    <BlazorWebAssemblyLazyLoad Include="Blazicons.Devicon.dll" />
+    <BlazorWebAssemblyLazyLoad Include="Blazicons.FlagIcons.dll" />
+    <BlazorWebAssemblyLazyLoad Include="Blazicons.FluentUI.dll" />
+    <BlazorWebAssemblyLazyLoad Include="Blazicons.FontAwesome.dll" />
+    <BlazorWebAssemblyLazyLoad Include="Blazicons.GoogleMaterialDesign.dll" />
+    <BlazorWebAssemblyLazyLoad Include="Blazicons.Ionicons.dll" />
+    <BlazorWebAssemblyLazyLoad Include="Blazicons.MaterialDesignIcons.dll" />
+
+    <!-- Satellite packages — each only needed on its dedicated demo route(s).
+         The following are intentionally NOT lazy because they are used on
+         shared / above-the-fold surfaces:
+           - Lumeo.Motion → home-page hero animations
+           - Lumeo.DataGrid → instantiated on Home.razor and Pages/Catalog
+           - Lumeo.Charts → instantiated on Home + Patterns + Changelog
+                            (via Shared/ChartPatternDemos.razor)
+           - Lumeo.Maps → Home.razor (<Map> in the hero) -->
+    <BlazorWebAssemblyLazyLoad Include="Lumeo.CodeEditor.dll" />
+    <BlazorWebAssemblyLazyLoad Include="Lumeo.Editor.dll" />
+    <BlazorWebAssemblyLazyLoad Include="Lumeo.FileViewer.dll" />
+    <BlazorWebAssemblyLazyLoad Include="Lumeo.Gantt.dll" />
+    <BlazorWebAssemblyLazyLoad Include="Lumeo.PdfViewer.dll" />
+    <BlazorWebAssemblyLazyLoad Include="Lumeo.Scheduler.dll" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
## Summary
Splits the docs WASM boot into eager + lazy assembly sets so visitors only pay for the satellite packages reachable from the route they're on. Biggest win is the landing page — none of the 6 lazy satellites + 8 icon packs are needed there.

## Eager vs lazy mapping

**Eager** (kept eager because instantiated on shared / above-the-fold pages):

| Package | Where it's used |
|---|---|
| `Lumeo.Motion` | Home hero animations |
| `Lumeo.DataGrid` | `Home.razor:166` + Catalog |
| `Lumeo.Charts` | `Home.razor:119` + Patterns + Changelog (via `Shared/ChartPatternDemos.razor`) |
| `Lumeo.Maps` | `Home.razor:133` hero `<Map>` |
| `Blazicons.Lucide` | Pervasive across the main component library |

**Lazy** (only referenced from a single dedicated route):

| Package | Route |
|---|---|
| `Lumeo.CodeEditor` | `/components/code-editor` |
| `Lumeo.Editor` | `/components/rich-text-editor` |
| `Lumeo.FileViewer` | `/components/file-viewer` |
| `Lumeo.Gantt` | `/components/gantt` |
| `Lumeo.PdfViewer` | `/components/pdf-viewer` |
| `Lumeo.Scheduler` | `/components/scheduler` |
| 8× `Blazicons.{Bootstrap,Devicon,FlagIcons,FluentUI,FontAwesome,GoogleMaterialDesign,Ionicons,MaterialDesignIcons}` | `/components/icon` (loaded as one group — IconPage references all 8 via static fields) |

## How it works
- `Lumeo.Docs.csproj` declares the lazy DLLs via `<BlazorWebAssemblyLazyLoad>`. The publish pipeline drops them from the eager boot list but keeps them under `_framework/` for on-demand fetch.
- `App.razor` wires the Router's `OnNavigateAsync` to a path-prefix → DLL map. `LazyAssemblyLoader.LoadAssembliesAsync` resolves the DLLs before the route's `RouteView` mounts, so static field references inside the page resolve normally.
- `_loadedNames` set guards against re-fetching on subsequent visits.
- Errors during fetch un-mark the names so the next navigation retries instead of staying permanently broken; the original exception still bubbles so the page surfaces it visibly.

## Follow-ups (separate PRs)
- AOT compilation for hot paths (`<RunAOTCompilation>true</RunAOTCompilation>`)
- Static HTML pre-render of `/` for sub-2s LCP
- Brotli-11 for non-framework assets, font `preconnect`, image optimization