### PR TITLE
perf(docs): enable AOT compilation for the published WASM build

### DIFF
--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -60,8 +60,15 @@ jobs:
           npm ci --no-audit --no-fund
           node run-all.mjs
 
-      - name: Publish Blazor WASM
-        run: dotnet publish docs/Lumeo.Docs/Lumeo.Docs.csproj -c Release -o release
+      - name: Publish Blazor WASM (AOT)
+        # RunAOTCompilation is enabled here (not in the csproj) so `dotnet build`
+        # in CI / E2E / dev — which don't have the wasm-tools workload installed —
+        # never sees the property and never trips the workload-required check.
+        # WasmStripILAfterAOT drops the original IL bytecode after native
+        # compilation, recovering ~30% of the AOT size cost. Trade-off: any
+        # System.Reflection.Emit usage will throw at runtime; we don't use
+        # Emit in Lumeo or its docs deps as of this commit.
+        run: dotnet publish docs/Lumeo.Docs/Lumeo.Docs.csproj -c Release -o release -p:RunAOTCompilation=true -p:WasmStripILAfterAOT=true
 
       - name: Rebuild Tailwind bundles into release
         # Overwrites the stale CSS that dotnet publish's static-web-asset pipeline

--- a/docs/Lumeo.Docs/Lumeo.Docs.csproj
+++ b/docs/Lumeo.Docs/Lumeo.Docs.csproj
@@ -20,20 +20,6 @@
     <NoWarn>$(NoWarn);WASM0001</NoWarn>
   </PropertyGroup>
 
-  <!-- AOT compilation: only kicks in on `dotnet publish` (no impact on `dotnet build`
-       / dev / bUnit). Trades ~1.5–2× transferred WASM size for ~2–3× faster runtime
-       once the app boots. With lazy-loading already in place, AOT only inflates the
-       eager set (Lumeo + Lumeo.Charts/DataGrid/Maps/Motion); lazy DLLs are AOT'd too
-       but only paid for on the routes that pull them in.
-       WasmStripILAfterAOT removes the original IL bytecode after AOT compilation,
-       recovering ~30 % of the size cost. The downside: reflection that synthesises
-       IL on-the-fly (rare in our code, but check System.Reflection.Emit usage if
-       a runtime ExecutionEngineException starts appearing) will fail. -->
-  <PropertyGroup>
-    <RunAOTCompilation>true</RunAOTCompilation>
-    <WasmStripILAfterAOT>true</WasmStripILAfterAOT>
-  </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="Blazicons.Bootstrap" Version="3.0.1" />
     <PackageReference Include="Blazicons.Devicon" Version="2.1.9" />

--- a/docs/Lumeo.Docs/Lumeo.Docs.csproj
+++ b/docs/Lumeo.Docs/Lumeo.Docs.csproj
@@ -20,6 +20,20 @@
     <NoWarn>$(NoWarn);WASM0001</NoWarn>
   </PropertyGroup>
 
+  <!-- AOT compilation: only kicks in on `dotnet publish` (no impact on `dotnet build`
+       / dev / bUnit). Trades ~1.5–2× transferred WASM size for ~2–3× faster runtime
+       once the app boots. With lazy-loading already in place, AOT only inflates the
+       eager set (Lumeo + Lumeo.Charts/DataGrid/Maps/Motion); lazy DLLs are AOT'd too
+       but only paid for on the routes that pull them in.
+       WasmStripILAfterAOT removes the original IL bytecode after AOT compilation,
+       recovering ~30 % of the size cost. The downside: reflection that synthesises
+       IL on-the-fly (rare in our code, but check System.Reflection.Emit usage if
+       a runtime ExecutionEngineException starts appearing) will fail. -->
+  <PropertyGroup>
+    <RunAOTCompilation>true</RunAOTCompilation>
+    <WasmStripILAfterAOT>true</WasmStripILAfterAOT>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Blazicons.Bootstrap" Version="3.0.1" />
     <PackageReference Include="Blazicons.Devicon" Version="2.1.9" />


### PR DESCRIPTION
## Summary
Enables AOT compilation for the published docs WASM build. Pairs with #50's lazy-loading and the existing Puppeteer prerender step (`scripts/prerender/prerender.mjs` in `deploy-cloudflare.yml` writes per-route HTML snapshots so first paint is HTML, not WASM).

With those two in place the remaining bottleneck is the **runtime cost between WASM boot and the page becoming interactive** — exactly what AOT addresses.

## Wiring
The first commit put `<RunAOTCompilation>true</RunAOTCompilation>` in `Lumeo.Docs.csproj` and CI immediately rejected it (14 s build failure): `ci.yml` and `e2e.yml` both run `dotnet build` on the docs project without the `wasm-tools` workload, so MSBuild's workload-required warning fired and `-warnaserror` promoted it to a hard failure.

Fix: keep the property out of the csproj and pass `-p:RunAOTCompilation=true -p:WasmStripILAfterAOT=true` on the `dotnet publish` line in `deploy-cloudflare.yml`. `wasm-tools` is already installed in that workflow. CI / E2E never see the property and stay green.

## Trade-offs

| | Before | After |
|---|---|---|
| Transferred WASM size (eager set) | IL only | ~1.5–2× larger (native code) |
| Runtime perf after boot | JIT-interpreted | ~2–3× faster |
| Lighthouse TBT | high (hydration JS competes with browser idle) | should drop noticeably |
| CI publish step duration | ~3–5 min | ~10–20 min |

## Caveat
`WasmStripILAfterAOT` drops the original IL bytecode after native compilation to recover ~30% of the size inflation. Any reflection that synthesises IL on the fly (`System.Reflection.Emit`) will throw at runtime. We don't use `Emit` anywhere in Lumeo or its docs deps that I've reviewed — flagging in case a runtime `ExecutionEngineException` ever surfaces post-deploy.

## Test plan
- [ ] Deploy workflow runs to completion (wall time will be much longer).
- [ ] After deploy, verify the docs site still mounts and routes correctly — `/components/icon`, `/components/scheduler` (lazy-loaded DLLs go through AOT as well as eager ones).
- [ ] Compare Lighthouse Mobile Performance on `/` before/after — expect TBT to drop a few more points beyond the +10–20 win from #50.

## Follow-ups (separate PRs)
- Brotli-11 for non-framework assets, font `preconnect`, social-preview.png compression — smaller per-PR wins now that the architectural moves are in.