### PR TITLE
chore: release 3.2.8

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
   <!-- Lockstep version shared by all Lumeo packages.
        Update this single property to version all packages in unison. -->
   <PropertyGroup>
-    <Version>3.2.7</Version>
+    <Version>3.2.8</Version>
   </PropertyGroup>
 
   <!-- Shared NuGet README packing lives in Directory.Build.targets, NOT here.

--- a/docs/Lumeo.Docs/Pages/Docs/Changelog.razor
+++ b/docs/Lumeo.Docs/Pages/Docs/Changelog.razor
@@ -15,6 +15,42 @@
 
     <Separator Class="my-4" />
 
+    <!-- v3.2.8 -->
+    <Stack Gap="4">
+        <div class="flex items-center gap-3">
+            <Badge>v3.2.8</Badge>
+            <Lumeo.Text Size="sm" Color="muted">May 2026</Lumeo.Text>
+        </div>
+
+        <Lumeo.Text Size="base" Color="muted" Leading="relaxed">
+            Accessibility polish across 12 components from a static a11y scan. No API changes — only added <code class="rounded bg-muted px-1 text-xs">role</code> / <code class="rounded bg-muted px-1 text-xs">aria-*</code> attributes and one missing dispose guard. Safe drop-in upgrade.
+        </Lumeo.Text>
+
+        <Stack Gap="3">
+            <Heading Level="3" Size="sm" Class="font-semibold">Accessibility</Heading>
+            <ul class="space-y-1.5 text-sm list-disc list-inside text-muted-foreground">
+                <li><strong>ContextMenuContent</strong> now renders with <code class="rounded bg-muted px-1 text-xs">role="menu"</code> + <code class="rounded bg-muted px-1 text-xs">aria-orientation="vertical"</code>, so AT exposes it as a menu instead of a bare div.</li>
+                <li><strong>AccordionContent / CollapsibleContent</strong> emit <code class="rounded bg-muted px-1 text-xs">role="region"</code> on the collapsible body for the standard disclosure-widget pattern.</li>
+                <li><strong>SplitterDivider</strong> exposes <code class="rounded bg-muted px-1 text-xs">aria-orientation</code> reflecting the parent Splitter's orientation, so AT knows which axis the handle moves on.</li>
+                <li><strong>Spinner</strong> (all three variants) advertises <code class="rounded bg-muted px-1 text-xs">role="status"</code> + <code class="rounded bg-muted px-1 text-xs">aria-live="polite"</code> + <code class="rounded bg-muted px-1 text-xs">aria-busy="true"</code> with an <code class="rounded bg-muted px-1 text-xs">aria-label</code> default of "Loading"; the decorative svg / dots / bars are now <code class="rounded bg-muted px-1 text-xs">aria-hidden</code>.</li>
+                <li><strong>EmptyState / Result</strong> emit <code class="rounded bg-muted px-1 text-xs">role="status"</code> so dynamic transitions are announced.</li>
+                <li><strong>Skeleton</strong> emits <code class="rounded bg-muted px-1 text-xs">role="status"</code> + <code class="rounded bg-muted px-1 text-xs">aria-busy="true"</code> + <code class="rounded bg-muted px-1 text-xs">aria-label="Loading"</code> on both Wave and Pulse paths.</li>
+                <li><strong>StreamingText</strong> wraps the streamed content in an <code class="rounded bg-muted px-1 text-xs">aria-live="polite"</code> region with <code class="rounded bg-muted px-1 text-xs">aria-atomic="false"</code> so AT reads additive chunks instead of re-reading the whole buffer on every token.</li>
+                <li><strong>AgentMessageList</strong> is now a <code class="rounded bg-muted px-1 text-xs">role="log"</code> + <code class="rounded bg-muted px-1 text-xs">aria-live="polite"</code> region announcing newly-added messages.</li>
+                <li><strong>Watermark</strong>'s decorative overlay is marked <code class="rounded bg-muted px-1 text-xs">aria-hidden="true"</code> (it was already pointer-events-none but AT was still walking into it).</li>
+            </ul>
+        </Stack>
+
+        <Stack Gap="3">
+            <Heading Level="3" Size="sm" Class="font-semibold">Fixed</Heading>
+            <ul class="space-y-1.5 text-sm list-disc list-inside text-muted-foreground">
+                <li><strong>TabsList.DisposeAsync</strong> wraps the <code class="rounded bg-muted px-1 text-xs">UnregisterSortableTouch</code> JS interop in <code class="rounded bg-muted px-1 text-xs">try/catch (JSDisconnectedException)</code> — matches the pattern used elsewhere in the file. Without it, disposing the component during a circuit drop logged an unhandled exception.</li>
+            </ul>
+        </Stack>
+    </Stack>
+
+    <Separator Class="my-4" />
+
     <!-- v3.2.4 -->
     <Stack Gap="4">
         <div class="flex items-center gap-3">


### PR DESCRIPTION
## Summary
Patch bump for the a11y additions that landed in #49 — `role` / `aria-*` attributes on 12 components plus one missing `JSDisconnectedException` catch in `TabsList.DisposeAsync`. No API changes, safe drop-in.

## Bumped
- `Directory.Build.props` — `3.2.7` → `3.2.8`

## Changelog
Added a `v3.2.8` block at the top of `docs/Lumeo.Docs/Pages/Docs/Changelog.razor`, formatted to match the existing entries (Accessibility + Fixed sections).

## What's NOT in this PR
Per the project rule on releases: the annotated tag and NuGet publish step both require explicit owner confirmation. This PR just bumps the version + records the changelog. Once you say "tag it", I'll:
1. Create the `3.2.8` annotated tag locally on the merge commit
2. Push the tag
3. You then trigger / approve the GitHub release + NuGet publish workflow

PRs #50 and #60 are docs-only / CI-only changes and don't warrant a version bump on their own.