### PR TITLE
revert(docs-aot): drop AOT — output exceeds Cloudflare Pages 25MB per-file limit

### DIFF
--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -60,15 +60,16 @@ jobs:
           npm ci --no-audit --no-fund
           node run-all.mjs
 
-      - name: Publish Blazor WASM (AOT)
-        # RunAOTCompilation is enabled here (not in the csproj) so `dotnet build`
-        # in CI / E2E / dev — which don't have the wasm-tools workload installed —
-        # never sees the property and never trips the workload-required check.
-        # WasmStripILAfterAOT drops the original IL bytecode after native
-        # compilation, recovering ~30% of the AOT size cost. Trade-off: any
-        # System.Reflection.Emit usage will throw at runtime; we don't use
-        # Emit in Lumeo or its docs deps as of this commit.
-        run: dotnet publish docs/Lumeo.Docs/Lumeo.Docs.csproj -c Release -o release -p:RunAOTCompilation=true -p:WasmStripILAfterAOT=true
+      - name: Publish Blazor WASM
+        # AOT was tried in #60 and reverted: AOT-compiled output produced a
+        # dotnet.native.wasm of ~30+ MB, which exceeds Cloudflare Pages'
+        # 25 MB per-file upload limit. Lazy-loading (#50) and the Puppeteer
+        # prerender step further down already cover the perf wins that
+        # mattered most; AOT was only a runtime accelerator on top of those.
+        # If we ever revisit AOT, the path is to either (a) wait for
+        # Cloudflare to raise the per-file limit, or (b) split the AOT'd
+        # output across multiple files via the per-assembly AOT options.
+        run: dotnet publish docs/Lumeo.Docs/Lumeo.Docs.csproj -c Release -o release
 
       - name: Rebuild Tailwind bundles into release
         # Overwrites the stale CSS that dotnet publish's static-web-asset pipeline


### PR DESCRIPTION
## Summary
Reverts the AOT switch added in #60. The AOT-compiled output produced a `dotnet.native.wasm` that exceeded Cloudflare Pages' 25 MB per-file upload limit (~30+ MB observed). Deploy job failed to publish as a result.

Removing `-p:RunAOTCompilation=true -p:WasmStripILAfterAOT=true` from the publish line returns the output to IL-only WASM, which fits within the limit. The other perf wins from this session are unaffected:

- **#50 lazy-loading** of icon packs + 6 satellite component packages — still in place
- **Puppeteer prerender** in `deploy-cloudflare.yml` writing per-route HTML snapshots for first-paint — still in place

AOT was a runtime accelerator on top of those, not the foundation, so reverting it keeps the bulk of the Lighthouse win.

## Future revisit
- Wait for Cloudflare to raise the Pages per-file limit (CF Workers already support 25 MB, this is Pages-specific and historically trends upward)
- Or split AOT output via per-assembly `<RunAOTCompilation>` item targeting so no single output file crosses the cap

## Test plan
- [ ] Merge → `deploy-cloudflare.yml` runs → `dotnet.native.wasm` is back to IL-only size (well under 25 MB) → Cloudflare Pages upload succeeds.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LJmBFYeCdQj2G2epoZaRzQ)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment workflow to streamline the build process. The application now uses standard compilation settings with lazy-loading and prerendering to optimize performance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Brain2k-0005/Lumeo/pull/72?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->