### PR TITLE
fix(crit): JS interop listener leaks + Confetti rAF leak + lockScroll incomplete

### DIFF
--- a/src/Lumeo.Motion/UI/Confetti/Confetti.razor
+++ b/src/Lumeo.Motion/UI/Confetti/Confetti.razor
@@ -60,9 +60,8 @@
 
     public async ValueTask DisposeAsync()
     {
-        if (_registered)
-        {
-            await Interop.MotionDisposeConfetti(_elementId);
-        }
+        if (!_registered) return;
+        try { await Interop.MotionDisposeConfetti(_elementId); }
+        catch (Microsoft.JSInterop.JSDisconnectedException) { }
     }
 }

--- a/src/Lumeo.Motion/wwwroot/js/motion.js
+++ b/src/Lumeo.Motion/wwwroot/js/motion.js
@@ -349,6 +349,15 @@ export const motion = {
         let canvas = document.getElementById(elementId + '-canvas');
         if (!canvas) return;
 
+        // Cancel any in-flight rAF loop for this confetti before starting a
+        // fresh one. Repeated Fire() calls otherwise stack parallel loops
+        // that each run until their particles fade — each loop costs CPU
+        // until then, and the loops keep running even after the component
+        // is disposed (only this tracker is consulted by disposeConfetti).
+        const tickerKey = elementId + '-confetti';
+        const prev = motionTickers.get(tickerKey);
+        if (prev) cancelAnimationFrame(prev);
+
         const particleCount = (options && options.particleCount) || 80;
         const spread = (options && options.spread) || 70;
         const colors = (options && options.colors) || ['#ff595e','#ffca3a','#6a4c93','#1982c4','#8ac926'];
@@ -416,16 +425,28 @@ export const motion = {
             }
             if (alive) {
                 rafId = requestAnimationFrame(animate);
+                motionTickers.set(tickerKey, rafId);
             } else {
                 ctx.clearRect(0, 0, canvas.width, canvas.height);
+                motionTickers.delete(tickerKey);
             }
         };
         rafId = requestAnimationFrame(animate);
+        motionTickers.set(tickerKey, rafId);
     },
 
     disposeConfetti(elementId) {
-        const ref = motionObservers.get(elementId + '-confetti');
-        if (ref) { ref.disconnect(); motionObservers.delete(elementId + '-confetti'); }
+        // Cancel any in-flight burst before tearing down the observer record.
+        // Without this, a Confetti.Fire() call that's still mid-animation
+        // would keep its rAF loop running after the component dispose, and
+        // the loop would only stop when the last particle's alpha drops to 0.
+        const tickerKey = elementId + '-confetti';
+        const id = motionTickers.get(tickerKey);
+        if (id) cancelAnimationFrame(id);
+        motionTickers.delete(tickerKey);
+
+        const ref = motionObservers.get(tickerKey);
+        if (ref) { ref.disconnect(); motionObservers.delete(tickerKey); }
     },
 
 };

--- a/src/Lumeo/Services/ComponentInteropService.cs
+++ b/src/Lumeo/Services/ComponentInteropService.cs
@@ -553,6 +553,12 @@ public sealed class ComponentInteropService : IComponentInteropService
         await _utility.SetupAutoResize(module, elementId, maxRows);
     }
 
+    public async ValueTask UnregisterAutoResize(string elementId)
+    {
+        var module = await GetModuleAsync();
+        await _utility.UnregisterAutoResize(module, elementId);
+    }
+
     // --- OTP Paste ---
 
     public async ValueTask RegisterOtpPaste(string baseId, int length, Func<string, Task> handler)

--- a/src/Lumeo/Services/IComponentInteropService.cs
+++ b/src/Lumeo/Services/IComponentInteropService.cs
@@ -139,6 +139,7 @@ public interface IComponentInteropService : IAsyncDisposable, IDisposable
 
     // Auto Resize
     ValueTask SetupAutoResize(string elementId, int maxRows);
+    ValueTask UnregisterAutoResize(string elementId);
 
     // OTP Paste
     ValueTask RegisterOtpPaste(string baseId, int length, Func<string, Task> handler);

--- a/src/Lumeo/Services/Interop/UtilityInterop.cs
+++ b/src/Lumeo/Services/Interop/UtilityInterop.cs
@@ -41,6 +41,11 @@ internal sealed class UtilityInterop
         await module.InvokeVoidAsync("setupAutoResize", elementId, maxRows);
     }
 
+    public async ValueTask UnregisterAutoResize(IJSObjectReference module, string elementId)
+    {
+        await module.InvokeVoidAsync("unregisterAutoResize", elementId);
+    }
+
     // --- File Download ---
 
     public async ValueTask DownloadFile(

--- a/src/Lumeo/UI/Textarea/Textarea.razor
+++ b/src/Lumeo/UI/Textarea/Textarea.razor
@@ -1,4 +1,5 @@
 @namespace Lumeo
+@implements IAsyncDisposable
 
 @if (Label is not null && !InsideFormField)
 {
@@ -89,6 +90,13 @@
             await Interop.SetupAutoResize(_elementId, MaxRows);
             _autoResizeSetup = true;
         }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (!_autoResizeSetup) return;
+        try { await Interop.UnregisterAutoResize(_elementId); }
+        catch (Microsoft.JSInterop.JSDisconnectedException) { }
     }
 
     private async Task HandleInput(ChangeEventArgs e)

--- a/src/Lumeo/wwwroot/js/components.js
+++ b/src/Lumeo/wwwroot/js/components.js
@@ -166,10 +166,15 @@ export function focusElementById(id) {
 
 let scrollLockCount = 0;
 
+// Setting overflow:hidden on <body> alone is insufficient on iOS Safari and
+// some Firefox configurations — the page still scrolls because the scroll
+// chain reaches <html>. We lock both elements together (and restore both on
+// unlock) so the modal/sheet/overlay actually traps scroll across browsers.
 export function lockScroll() {
     scrollLockCount++;
     if (scrollLockCount === 1) {
         document.body.style.overflow = 'hidden';
+        document.documentElement.style.overflow = 'hidden';
     }
 }
 
@@ -177,6 +182,7 @@ export function unlockScroll() {
     scrollLockCount = Math.max(0, scrollLockCount - 1);
     if (scrollLockCount === 0) {
         document.body.style.overflow = '';
+        document.documentElement.style.overflow = '';
     }
 }
 
@@ -1422,9 +1428,20 @@ export function registerToastSwipe(elementId, toastId, dotnetRef) {
 
 // --- Auto Resize ---
 
+// elementId -> input-listener function reference. Stored so
+// unregisterAutoResize can pass the exact callback to removeEventListener
+// (anonymous closures can't be removed) and so a repeat setupAutoResize call
+// on the same element doesn't stack handlers.
+const autoResizeHandlers = new Map();
+
 export function setupAutoResize(elementId, maxRows) {
     const el = document.getElementById(elementId);
     if (!el) return;
+
+    // De-dupe: tear down any prior listener before installing a fresh one.
+    const existing = autoResizeHandlers.get(elementId);
+    if (existing) el.removeEventListener('input', existing);
+
     el.style.overflow = 'hidden';
     el.style.resize = 'none';
     const lineHeight = parseInt(window.getComputedStyle(el).lineHeight) || 20;
@@ -1441,7 +1458,16 @@ export function setupAutoResize(elementId, maxRows) {
     };
 
     el.addEventListener('input', resize);
+    autoResizeHandlers.set(elementId, resize);
     resize(); // initial
+}
+
+export function unregisterAutoResize(elementId) {
+    const handler = autoResizeHandlers.get(elementId);
+    if (!handler) return;
+    const el = document.getElementById(elementId);
+    if (el) el.removeEventListener('input', handler);
+    autoResizeHandlers.delete(elementId);
 }
 
 export function unregisterToastSwipe(elementId) {

--- a/tests/Lumeo.Docs.Tests/Helpers/DocsTestContext.cs
+++ b/tests/Lumeo.Docs.Tests/Helpers/DocsTestContext.cs
@@ -108,6 +108,7 @@ internal sealed class NoopInteropService : IComponentInteropService
 
     // Auto Resize
     public ValueTask SetupAutoResize(string elementId, int maxRows) => ValueTask.CompletedTask;
+    public ValueTask UnregisterAutoResize(string elementId) => ValueTask.CompletedTask;
 
     // OTP Paste
     public ValueTask RegisterOtpPaste(string baseId, int length, Func<string, Task> handler) => ValueTask.CompletedTask;

--- a/tests/Lumeo.Tests/Helpers/TrackingInteropService.cs
+++ b/tests/Lumeo.Tests/Helpers/TrackingInteropService.cs
@@ -104,6 +104,7 @@ public sealed class TrackingInteropService : IComponentInteropService
     public ValueTask RegisterToastSwipe(string elementId, string toastId, Func<string, Task> handler) => ValueTask.CompletedTask;
     public ValueTask UnregisterToastSwipe(string toastId, string elementId) => ValueTask.CompletedTask;
     public ValueTask SetupAutoResize(string elementId, int maxRows) => ValueTask.CompletedTask;
+    public ValueTask UnregisterAutoResize(string elementId) => ValueTask.CompletedTask;
     public ValueTask RegisterOtpPaste(string baseId, int length, Func<string, Task> handler) => ValueTask.CompletedTask;
     public ValueTask UnregisterOtpPaste(string baseId, int length) => ValueTask.CompletedTask;
     // Column resize tracking — used to assert that the JS pointerdown listener

--- a/tests/Lumeo.Tests/Services/ResponsiveServiceTests.cs
+++ b/tests/Lumeo.Tests/Services/ResponsiveServiceTests.cs
@@ -166,6 +166,7 @@ public class ResponsiveServiceTests
         public ValueTask RegisterToastSwipe(string elementId, string toastId, Func<string, Task> handler) => ValueTask.CompletedTask;
         public ValueTask UnregisterToastSwipe(string toastId, string elementId) => ValueTask.CompletedTask;
         public ValueTask SetupAutoResize(string elementId, int maxRows) => ValueTask.CompletedTask;
+        public ValueTask UnregisterAutoResize(string elementId) => ValueTask.CompletedTask;
         public ValueTask RegisterOtpPaste(string baseId, int length, Func<string, Task> handler) => ValueTask.CompletedTask;
         public ValueTask UnregisterOtpPaste(string baseId, int length) => ValueTask.CompletedTask;
         public ValueTask RegisterColumnResize(string handleId, double minWidth, double? maxWidth, Func<double, Task> commitHandler) => ValueTask.CompletedTask;


### PR DESCRIPTION
## Summary
Three CRIT-/HIGH-severity findings from the deep static bug-scan (filed as #63 + #69). All three are in the JS interop or Motion JS layer.

## Fixes

### 1. `setupAutoResize` listener leak (CRIT, #63)
**File**: `src/Lumeo/wwwroot/js/components.js`

The `input` listener attached by `setupAutoResize` had no matching unregister export. The handler stayed attached for the lifetime of the element, and a repeat `SetupAutoResize` call on the same id stacked handlers.

- `autoResizeHandlers` Map tracks handler refs per `elementId`.
- `setupAutoResize` tears down any prior handler before installing the fresh one (de-dupe).
- New `unregisterAutoResize` export removes the tracked handler.
- Plumbed through `IComponentInteropService` / `ComponentInteropService` / `UtilityInterop`, and called from `Textarea.DisposeAsync`. Textarea also gains `IAsyncDisposable` which it was missing entirely.
- Three test mocks updated to satisfy the interface addition (`TrackingInteropService`, `DocsTestContext.NoOpInterop`, `ResponsiveServiceTests.NoOpInterop`).

### 2. `lockScroll` only mutated `document.body` (HIGH, #63)
**File**: `src/Lumeo/wwwroot/js/components.js`

iOS Safari and some Firefox configurations need `<html>` locked too — otherwise the scroll chain reaches it and the page still scrolls behind the modal/sheet/overlay. Both `lockScroll` and `unlockScroll` now lock / restore `document.documentElement` alongside `document.body`.

### 3. Confetti `Fire()` orphans rAF loops (CRIT, #69)
**File**: `src/Lumeo.Motion/wwwroot/js/motion.js` + `src/Lumeo.Motion/UI/Confetti/Confetti.razor`

`confettiFire` spawned a `requestAnimationFrame` loop per call without tracking the rafId. Multiple `Fire()` calls stacked parallel loops that each kept burning CPU until their particles' alpha fell to zero — and the loops kept running after the component disposed (`disposeConfetti` only cleared the observer record).

- Cancel any prior loop on `Fire()` via the existing `motionTickers` map under the `'<elementId>-confetti'` key.
- Store the rafId on every step so the cancel actually reaches the in-flight loop.
- `disposeConfetti` now `cancelAnimationFrame`s the tracked id before clearing the observer record.
- `Confetti.razor.DisposeAsync` gains the standard `try/catch (JSDisconnectedException)` wrap.

## Follow-ups (tracked in #63 / #69)
- `observeAutoScroll` scroll-listener leak
- `positionFixed` cleanup-throws-on-race
- `theme.js` multi-tab desync
- Motion `DisposeAsync` JSDisconnect-catch pattern on BlurFade / Dock / NumberTicker / TextReveal