### PR TITLE
fix(motion): JSDisconnectedException catch in DisposeAsync on 4 components

### DIFF
--- a/src/Lumeo.Motion/UI/BlurFade/BlurFade.razor
+++ b/src/Lumeo.Motion/UI/BlurFade/BlurFade.razor
@@ -51,9 +51,8 @@
 
     public async ValueTask DisposeAsync()
     {
-        if (_registered)
-        {
-            await Interop.MotionDisposeObserver(_elementId);
-        }
+        if (!_registered) return;
+        try { await Interop.MotionDisposeObserver(_elementId); }
+        catch (JSDisconnectedException) { }
     }
 }

--- a/src/Lumeo.Motion/UI/Dock/Dock.razor
+++ b/src/Lumeo.Motion/UI/Dock/Dock.razor
@@ -43,9 +43,8 @@
 
     public async ValueTask DisposeAsync()
     {
-        if (_registered)
-        {
-            await Interop.MotionDisposeDock(_elementId);
-        }
+        if (!_registered) return;
+        try { await Interop.MotionDisposeDock(_elementId); }
+        catch (JSDisconnectedException) { }
     }
 }

--- a/src/Lumeo.Motion/UI/NumberTicker/NumberTicker.razor
+++ b/src/Lumeo.Motion/UI/NumberTicker/NumberTicker.razor
@@ -63,6 +63,8 @@
 
     public async ValueTask DisposeAsync()
     {
-        await Interop.MotionDisposeTicker(_elementId);
+        if (!_initialized) return;
+        try { await Interop.MotionDisposeTicker(_elementId); }
+        catch (JSDisconnectedException) { }
     }
 }

--- a/src/Lumeo.Motion/UI/TextReveal/TextReveal.razor
+++ b/src/Lumeo.Motion/UI/TextReveal/TextReveal.razor
@@ -48,9 +48,8 @@
 
     public async ValueTask DisposeAsync()
     {
-        if (_registered)
-        {
-            await Interop.MotionDisposeObserver(_elementId);
-        }
+        if (!_registered) return;
+        try { await Interop.MotionDisposeObserver(_elementId); }
+        catch (JSDisconnectedException) { }
     }
 }


### PR DESCRIPTION
## Summary
Closes the HIGH-severity half of #69 (the CRIT Confetti rAF leak shipped with #73). Same pattern as #49's `TabsList.DisposeAsync` fix: wrap the JS interop call in the dispose path with `try/catch (JSDisconnectedException)` so a circuit drop during teardown doesn't log an unhandled exception.

## Files changed
| File | Change |
|---|---|
| `src/Lumeo.Motion/UI/BlurFade/BlurFade.razor` | `try/catch (JSDisconnectedException)` around `MotionDisposeObserver` |
| `src/Lumeo.Motion/UI/Dock/Dock.razor` | same, around `MotionDisposeDock` |
| `src/Lumeo.Motion/UI/NumberTicker/NumberTicker.razor` | same, around `MotionDisposeTicker`; also gains an `if (!_initialized) return;` guard so dispose is a no-op if `OnAfterRenderAsync` never ran (parameter-only render path) |
| `src/Lumeo.Motion/UI/TextReveal/TextReveal.razor` | same, around `MotionDisposeObserver` |

`Microsoft.JSInterop` is already imported globally via `src/Lumeo.Motion/_Imports.razor` so no per-file `@using` needed.

## Test plan
- [ ] CI green.
- [ ] No-op visually: this only affects error handling during disposal — happy-path rendering is unchanged.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LJmBFYeCdQj2G2epoZaRzQ)_