### PR TITLE
fix(pdfviewer): left half un-scrollable when canvas zoomed past viewport width

### DIFF
--- a/src/Lumeo.PdfViewer/UI/PdfViewer/PdfViewer.razor
+++ b/src/Lumeo.PdfViewer/UI/PdfViewer/PdfViewer.razor
@@ -127,8 +127,17 @@
         }
         else
         {
-            <div class="flex min-h-full items-start justify-center p-4">
-                <div class="relative inline-block">
+            @* Centering via `mx-auto` on the inner block, not `justify-center`
+               on the parent. When the zoomed canvas overflows the scroll
+               container, `justify-content: center` would keep centering it,
+               which clips the left half against the parent's content-start
+               edge and makes that half un-scrollable (the scroll origin is
+               the content box, not the centered child). Auto-margins
+               absorb free space when there's room (canvas centered) and
+               collapse to zero when there isn't (canvas pinned to start,
+               full overflow scrolls into view both directions). *@
+            <div class="flex min-h-full items-start p-4">
+                <div class="relative inline-block mx-auto">
                     <canvas id="@_canvasId" class="@CanvasVisibilityClass shadow-md"></canvas>
                     @if (_highlights.Count > 0 && !string.IsNullOrWhiteSpace(_searchQuery))
                     {


### PR DESCRIPTION
## Reproduction
Open the PdfViewer demo (or any consumer), zoom in until the canvas is wider than the viewport. Right-arrow / trackpad scroll right works — you can see the right side of the page. Scroll left does nothing — the left side of the page stays clipped and unreachable.

## Cause
`src/Lumeo.PdfViewer/UI/PdfViewer/PdfViewer.razor:130` wrapped the canvas in `<div class="flex min-h-full items-start justify-center p-4">`. With `justify-content: center` on the flex parent and a child that's wider than the parent, the child stays centered — so its left edge sits **before** the parent's content-start position. Scroll origin in a flex/block container is the content box, so anything to the left of that origin is unreachable by scrolling. Right overflow stays reachable because that side is past the content box's right edge, on the correct side of the scroll origin.

## Fix
Drop `justify-center` from the flex parent and use `mx-auto` on the inline-block child instead. Auto-margins on a flex item:

- absorb free space when there's room → canvas centered, same look as before
- collapse to zero when the child outgrows the container → canvas pinned to start, full overflow scrolls into view in either direction

Standard pattern for "centered figure inside a horizontally-scrollable region".

## Test plan
- [ ] Open a PDF, zoom in past viewport width. Scroll-wheel + trackpad: both left and right edges of the page reachable.
- [ ] Zoom back out so the page fits: canvas remains centered horizontally in the scroll area.
- [ ] No visible regression on the unzoomed default state across narrow / wide containers.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LJmBFYeCdQj2G2epoZaRzQ)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved PDF viewer canvas positioning and scrolling behavior when zoomed in or when content exceeds the visible container.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Brain2k-0005/Lumeo/pull/76?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->