### PR TITLE
fix(charts): Gauge div-by-zero on Min==Max + ResizeObserver leak on refresh

### DIFF
--- a/src/Lumeo.Charts/UI/Chart/Charts/GaugeChart.razor
+++ b/src/Lumeo.Charts/UI/Chart/Charts/GaugeChart.razor
@@ -68,11 +68,15 @@
 
         if (Ranges is { Count: > 0 })
         {
-            // Build axis line color stops from ranges
+            // Build axis line color stops from ranges. Guard the
+            // normalisation against Max == Min — division by zero produces
+            // NaN/Infinity in the color-stops payload and ECharts renders
+            // a broken gauge. Collapse to position 0 in that case.
+            var span = Max - Min;
             var colorStops = new List<object>();
             foreach (var range in Ranges.OrderBy(r => r.Threshold))
             {
-                var normalizedPos = (range.Threshold - Min) / (Max - Min);
+                var normalizedPos = span == 0 ? 0 : (range.Threshold - Min) / span;
                 colorStops.Add(new object[] { normalizedPos, range.Color });
             }
             // Ensure we reach 1.0

--- a/src/Lumeo.Charts/wwwroot/js/echarts-interop.js
+++ b/src/Lumeo.Charts/wwwroot/js/echarts-interop.js
@@ -426,9 +426,20 @@ export function refreshAllCharts() {
         const el = document.getElementById(id);
         if (!el) continue;
         const opts = chart.getOption();
+        // Tear down the old ResizeObserver before disposing the chart. The
+        // initChart path stores it on chart._lumeoObserver; without this
+        // disconnect it kept observing the (still-mounted) element and
+        // firing resize() calls into a disposed chart instance, leaving
+        // both the observer and the dead instance attached to the DOM.
+        if (chart._lumeoObserver) chart._lumeoObserver.disconnect();
         chart.dispose();
         const newChart = window.echarts.init(el, 'lumeo', { renderer: 'canvas' });
         newChart.setOption(opts);
+        // Re-attach a fresh observer so the new chart still auto-resizes;
+        // disposeChart and the original initChart use the same pattern.
+        const observer = new ResizeObserver(() => { newChart.resize(); });
+        observer.observe(el);
+        newChart._lumeoObserver = observer;
         charts.set(id, newChart);
     }
 }


### PR DESCRIPTION
## Summary
Closes the HIGH half of #68 — two verified Charts bugs.

## 1. GaugeChart div-by-zero on `Min == Max`
`src/Lumeo.Charts/UI/Chart/Charts/GaugeChart.razor:75`

When the consumer sets `Min == Max` (constant-value gauge, placeholder before data arrives, …), the range-normalisation
```csharp
(range.Threshold - Min) / (Max - Min)
```
evaluated to `NaN` / `Infinity` for every color stop. ECharts then rendered a broken gauge axis.

Fix: compute the span once, and when it's zero, collapse all stops to position `0` (a single solid color from the first range — sensible degenerate output).

## 2. `refreshAllCharts` orphans the old `ResizeObserver` AND skips re-attaching a new one
`src/Lumeo.Charts/wwwroot/js/echarts-interop.js:422`

On a theme switch, the refresh loop did `chart.getOption()` / `chart.dispose()` / new init, but skipped the `chart._lumeoObserver.disconnect()` that `disposeChart` already does. Two consequences:

- The old `ResizeObserver` kept firing into a disposed chart instance until the next page navigation (memory leak + log noise).
- The new chart had no observer attached at all → auto-resize quietly broken on every theme switch until reload.

Fix: disconnect before dispose, attach a fresh observer on the rebuilt chart so it stays in line with the `initChart` / `disposeChart` contract.

## Out of scope
- MED: WordCloud `Task.Delay(200)` extension-load race
- MED: Full `setOption(option, true)` per parameter change (incremental update API would need a separate, larger PR)
- LOW: Custom `Func<,>` formatter support for tooltips / labels

## Test plan
- [ ] CI green.
- [ ] Gauge with `Min == Max` (e.g. both 50, value 50) no longer throws and renders a single-color axis instead of a NaN axis.
- [ ] Toggle the docs theme on a page with charts → resize the window after → charts still resize automatically.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LJmBFYeCdQj2G2epoZaRzQ)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed gauge chart rendering failures when maximum and minimum values are equal to prevent rendering errors
  * Fixed chart refresh process to properly clean up and reinitialize resize observers, preserving auto-resize functionality

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Brain2k-0005/Lumeo/pull/77?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->