### PR TITLE
fix(colorpicker): alpha slider now propagates to Value + preserves alpha across other slider moves

### DIFF
--- a/src/Lumeo/UI/ColorPicker/ColorPicker.razor
+++ b/src/Lumeo/UI/ColorPicker/ColorPicker.razor
@@ -252,27 +252,45 @@
         }
     }
 
-    private void OnAlphaChanged(ChangeEventArgs e)
+    private async Task OnAlphaChanged(ChangeEventArgs e)
     {
-        if (int.TryParse(e.Value?.ToString(), out var a)) _alpha = Math.Clamp(a, 0, 100);
+        if (!int.TryParse(e.Value?.ToString(), out var a)) return;
+        _alpha = Math.Clamp(a, 0, 100);
+        await ApplyAlpha();
     }
 
     private async Task OnRChanged(ChangeEventArgs e) { if (int.TryParse(e.Value?.ToString(), out var n)) { _r = Math.Clamp(n, 0, 255); await ApplyRgb(); } }
     private async Task OnGChanged(ChangeEventArgs e) { if (int.TryParse(e.Value?.ToString(), out var n)) { _g = Math.Clamp(n, 0, 255); await ApplyRgb(); } }
     private async Task OnBChanged(ChangeEventArgs e) { if (int.TryParse(e.Value?.ToString(), out var n)) { _b = Math.Clamp(n, 0, 255); await ApplyRgb(); } }
 
+    // Single point of truth for the bound Value string. When alpha is at
+    // 100 % (or alpha is disabled), emit the compact hex form so existing
+    // consumers that only handle hex keep working. Below 100 %, emit
+    // rgba() so the alpha is actually round-trippable to CSS.
+    private string ComposeCurrentValue() =>
+        ShowAlpha && _alpha < 100
+            ? $"rgba({_r}, {_g}, {_b}, {(_alpha / 100.0).ToString("0.##", System.Globalization.CultureInfo.InvariantCulture)})"
+            : $"#{_r:X2}{_g:X2}{_b:X2}";
+
     private async Task ApplyHsv()
     {
         (_r, _g, _b) = HsvToRgb(_h, _s, _v);
-        Value = $"#{_r:X2}{_g:X2}{_b:X2}";
+        Value = ComposeCurrentValue();
         _lastSyncedValue = Value;
         await ValueChanged.InvokeAsync(Value);
     }
 
     private async Task ApplyRgb()
     {
-        Value = $"#{_r:X2}{_g:X2}{_b:X2}";
+        Value = ComposeCurrentValue();
         (_h, _s, _v) = RgbToHsv(_r, _g, _b);
+        _lastSyncedValue = Value;
+        await ValueChanged.InvokeAsync(Value);
+    }
+
+    private async Task ApplyAlpha()
+    {
+        Value = ComposeCurrentValue();
         _lastSyncedValue = Value;
         await ValueChanged.InvokeAsync(Value);
     }


### PR DESCRIPTION
## Summary
Closes the ColorPicker part of #64. Verified bug at `src/Lumeo/UI/ColorPicker/ColorPicker.razor:255`.

## What was broken
`OnAlphaChanged` only clamped `_alpha` into local state — no call to `ValueChanged`, no `Value` update. Moving the opacity slider had no visible effect on the bound `Value` at all.

Worse, after lowering alpha and then moving any R/G/B/H/S/V slider, `ApplyHsv` and `ApplyRgb` both wrote `Value` back as 6-digit hex unconditionally, dropping the user's chosen alpha. Net effect: the alpha channel was effectively non-functional through the bound parameter, only correct in the in-component preview.

## Fix
- `OnAlphaChanged` is now async and applies the new alpha via a new `ApplyAlpha()`.
- Single `ComposeCurrentValue()` helper picks the output format based on whether alpha is below 100% and `ShowAlpha` is on: returns `rgba()` in that case, hex otherwise. Matches what `DisplayColor` was already producing for the in-component preview, so the bound `Value` finally stays in sync with what the user sees.
- `ApplyHsv` / `ApplyRgb` / new `ApplyAlpha` all write `Value` via the same helper → alpha is preserved across any subsequent slider move.

## Known out-of-scope
`SyncStateFromHex` / `TryParseHex` only handle hex input. A consumer setting `Value = "rgba(...)"` or `Value = "#RRGGBBAA"` still doesn't fully round-trip alpha into the internal `_alpha` field. Worth a follow-up but separate from this fix; the reported defect was about user interaction on the alpha slider, which this PR addresses.

## Test plan
- [ ] CI green.
- [ ] Move the opacity slider on the ColorPicker demo → bound `Value` shows `rgba(...)` and visibly reflects the new alpha.
- [ ] Lower opacity to 50%, then move the Hue slider → `Value` stays in `rgba(…, 0.5)` form, alpha preserved.
- [ ] Default behavior (alpha at 100%) still emits compact `#RRGGBB` hex so existing hex-only consumers are unaffected.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LJmBFYeCdQj2G2epoZaRzQ)_