### PR TITLE
feat: AutoFocus parameter on six form inputs

### DIFF
--- a/src/Lumeo/UI/Input/Input.razor
+++ b/src/Lumeo/UI/Input/Input.razor
@@ -18,7 +18,8 @@
         {
             <div class="flex items-center px-3 text-muted-foreground">@Prefix</div>
         }
-        <input name="@Name"
+        <input @ref="_inputRef"
+               name="@Name"
                aria-required="@Required.ToString().ToLowerInvariant()"
                aria-invalid="@EffectiveInvalid.ToString().ToLowerInvariant()"
                class="@WrappedInputClass" value="@Value" @oninput="HandleInput" disabled="@Disabled" />
@@ -36,7 +37,8 @@
 }
 else
 {
-    <input name="@Name"
+    <input @ref="_inputRef"
+           name="@Name"
            aria-required="@Required.ToString().ToLowerInvariant()"
            aria-invalid="@EffectiveInvalid.ToString().ToLowerInvariant()"
            class="@CssClass" value="@Value" @oninput="HandleInput" disabled="@Disabled" @attributes="AdditionalAttributes" />
@@ -74,8 +76,27 @@ else
     [Parameter] public string? HelperText { get; set; }
     [Parameter] public string? Label { get; set; }
     [Parameter] public string? Name { get; set; }
+    /// <summary>
+    /// Focuses the underlying &lt;input&gt; on first render. The HTML
+    /// <c>autofocus</c> attribute doesn't work in Blazor WASM because the
+    /// browser's autofocus algorithm runs during initial document parsing —
+    /// at parse time the WASM runtime hasn't booted yet and no &lt;input&gt;
+    /// exists for it to focus. This parameter uses ElementReference.FocusAsync
+    /// in OnAfterRenderAsync(firstRender) which is the canonical workaround.
+    /// </summary>
+    [Parameter] public bool AutoFocus { get; set; }
     [Parameter] public string? Class { get; set; }
     [Parameter(CaptureUnmatchedValues = true)] public Dictionary<string, object>? AdditionalAttributes { get; set; }
+
+    private ElementReference _inputRef;
+
+    /// <summary>The underlying &lt;input&gt; element. Exposed for advanced
+    /// scenarios that need direct access; prefer <see cref="FocusAsync"/>.</summary>
+    public ElementReference Element => _inputRef;
+
+    /// <summary>Programmatically move focus to the input. Safe to call after
+    /// the component has rendered at least once.</summary>
+    public ValueTask FocusAsync() => _inputRef.FocusAsync();
 
     private bool EffectiveInvalid => Invalid || FormField?.HasError == true;
     private bool InsideFormField => FormField is not null;
@@ -106,6 +127,15 @@ else
     private string WrapperClass => $"flex {WrapperSizeClasses} w-full rounded-md border {(EffectiveInvalid ? "border-destructive" : "border-input")} bg-transparent transition-colors {(EffectiveInvalid ? "focus-within:ring-[1.5px] focus-within:ring-destructive/20" : "focus-within:ring-[1.5px] focus-within:ring-ring")} disabled:cursor-not-allowed disabled:opacity-50 {Class}".Trim();
 
     private string WrappedInputClass => $"flex-1 bg-transparent {WrappedInputSizeClasses} py-1 placeholder:text-muted-foreground focus-visible:outline-none disabled:cursor-not-allowed".Trim();
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender && AutoFocus)
+        {
+            try { await _inputRef.FocusAsync(); }
+            catch (Microsoft.JSInterop.JSDisconnectedException) { }
+        }
+    }
 
     private async Task HandleInput(ChangeEventArgs e)
     {

--- a/src/Lumeo/UI/NumberInput/NumberInput.razor
+++ b/src/Lumeo/UI/NumberInput/NumberInput.razor
@@ -24,7 +24,8 @@
         {
             <span class="pl-2 text-sm text-muted-foreground select-none">@Prefix</span>
         }
-        <input type="number"
+        <input @ref="_inputRef"
+               type="number"
                name="@Name"
                aria-required="@Required.ToString().ToLowerInvariant()"
                aria-invalid="@EffectiveInvalid.ToString().ToLowerInvariant()"
@@ -98,8 +99,29 @@
     [Parameter] public string? Label { get; set; }
     [Parameter] public string? AriaLabel { get; set; }
     [Parameter] public string? Name { get; set; }
+    /// <summary>Focuses the underlying number &lt;input&gt; on first render.
+    /// See <c>Input.AutoFocus</c> for why the HTML <c>autofocus</c> attribute
+    /// doesn't work in Blazor WASM.</summary>
+    [Parameter] public bool AutoFocus { get; set; }
     [Parameter] public string? Class { get; set; }
     [Parameter(CaptureUnmatchedValues = true)] public Dictionary<string, object>? AdditionalAttributes { get; set; }
+
+    private ElementReference _inputRef;
+
+    /// <summary>The underlying number &lt;input&gt; element.</summary>
+    public ElementReference Element => _inputRef;
+
+    /// <summary>Programmatically move focus to the input.</summary>
+    public ValueTask FocusAsync() => _inputRef.FocusAsync();
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender && AutoFocus)
+        {
+            try { await _inputRef.FocusAsync(); }
+            catch (Microsoft.JSInterop.JSDisconnectedException) { }
+        }
+    }
 
     private bool EffectiveInvalid => Invalid || FormField?.HasError == true;
     private bool InsideFormField => FormField is not null;

--- a/src/Lumeo/UI/OtpInput/OtpInput.razor
+++ b/src/Lumeo/UI/OtpInput/OtpInput.razor
@@ -77,8 +77,17 @@
     [Parameter] public string? HelperText { get; set; }
     [Parameter] public string? Label { get; set; }
     [Parameter] public string? Name { get; set; }
+    /// <summary>Focuses the first OTP digit input on first render. Useful
+    /// for the typical OTP flow where the field appears right after a
+    /// "code sent" screen and the user should be typing immediately.
+    /// See <c>Input.AutoFocus</c> for why the HTML <c>autofocus</c>
+    /// attribute doesn't work in Blazor WASM.</summary>
+    [Parameter] public bool AutoFocus { get; set; }
     [Parameter] public string? Class { get; set; }
     [Parameter(CaptureUnmatchedValues = true)] public Dictionary<string, object>? AdditionalAttributes { get; set; }
+
+    /// <summary>Programmatically move focus to the first digit input.</summary>
+    public ValueTask FocusAsync() => Interop.FocusElement($"{_baseId}-0");
 
     private bool EffectiveInvalid => Invalid || FormField?.HasError == true;
     private bool InsideFormField => FormField is not null;
@@ -134,6 +143,10 @@
         try
         {
             await Interop.RegisterOtpPaste(_baseId, Length, HandlePaste);
+            if (AutoFocus)
+            {
+                await Interop.FocusElement($"{_baseId}-0");
+            }
         }
         catch (JSDisconnectedException) { }
         catch (ObjectDisposedException) { }

--- a/src/Lumeo/UI/PasswordInput/PasswordInput.razor
+++ b/src/Lumeo/UI/PasswordInput/PasswordInput.razor
@@ -14,7 +14,8 @@
 
 <div class="@WrapperClass">
     <div class="@($"flex h-9 w-full rounded-md border {(EffectiveInvalid ? "border-destructive" : "border-input")} bg-transparent text-sm overflow-hidden transition-colors {(EffectiveInvalid ? "focus-within:ring-[1.5px] focus-within:ring-destructive/20" : "focus-within:ring-[1.5px] focus-within:ring-ring")}")">
-        <input type="@(_showPassword ? "text" : "password")"
+        <input @ref="_inputRef"
+               type="@(_showPassword ? "text" : "password")"
                name="@Name"
                aria-required="@Required.ToString().ToLowerInvariant()"
                aria-invalid="@EffectiveInvalid.ToString().ToLowerInvariant()"
@@ -82,10 +83,30 @@
     [Parameter] public string? HelperText { get; set; }
     [Parameter] public string? Label { get; set; }
     [Parameter] public string? Name { get; set; }
+    /// <summary>Focuses the underlying password &lt;input&gt; on first render.
+    /// See <c>Input.AutoFocus</c> for why the HTML <c>autofocus</c> attribute
+    /// doesn't work in Blazor WASM.</summary>
+    [Parameter] public bool AutoFocus { get; set; }
     [Parameter] public string? Class { get; set; }
     [Parameter(CaptureUnmatchedValues = true)] public Dictionary<string, object>? AdditionalAttributes { get; set; }
 
     private bool _showPassword;
+    private ElementReference _inputRef;
+
+    /// <summary>The underlying password &lt;input&gt; element.</summary>
+    public ElementReference Element => _inputRef;
+
+    /// <summary>Programmatically move focus to the input.</summary>
+    public ValueTask FocusAsync() => _inputRef.FocusAsync();
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender && AutoFocus)
+        {
+            try { await _inputRef.FocusAsync(); }
+            catch (Microsoft.JSInterop.JSDisconnectedException) { }
+        }
+    }
 
     private bool EffectiveInvalid => Invalid || FormField?.HasError == true;
     private bool InsideFormField => FormField is not null;

--- a/src/Lumeo/UI/TagInput/TagInput.razor
+++ b/src/Lumeo/UI/TagInput/TagInput.razor
@@ -123,6 +123,10 @@
     [Parameter] public string? Label { get; set; }
     [Parameter] public string? Name { get; set; }
     [Parameter] public string? Class { get; set; }
+    /// <summary>Focuses the inner text &lt;input&gt; on first render. See
+    /// <c>Input.AutoFocus</c> for why the HTML <c>autofocus</c> attribute
+    /// doesn't work in Blazor WASM.</summary>
+    [Parameter] public bool AutoFocus { get; set; }
     [Parameter] public string? MaxTagsHelperText { get; set; }
 
     [Parameter] public Func<TItem, string>? GetTagText { get; set; }
@@ -143,6 +147,9 @@
     private bool _showSuggestions;
     private string? _validationError;
     private readonly string _inputId = LumeoIds.New("taginput");
+
+    /// <summary>Programmatically move focus to the inner text input.</summary>
+    public ValueTask FocusAsync() => Interop.FocusElement(_inputId);
     private readonly string _suggestionsId = LumeoIds.New("taginput-suggestions");
     private bool _suggestionsRegistered;
 
@@ -314,6 +321,11 @@
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
+        if (firstRender && AutoFocus)
+        {
+            try { await Interop.FocusElement(_inputId); }
+            catch (JSDisconnectedException) { }
+        }
         if (_showSuggestions && !_suggestionsRegistered)
         {
             try

--- a/src/Lumeo/UI/Textarea/Textarea.razor
+++ b/src/Lumeo/UI/Textarea/Textarea.razor
@@ -13,7 +13,8 @@
 }
 
 <div>
-    <textarea id="@_elementId"
+    <textarea @ref="_textareaRef"
+              id="@_elementId"
               name="@Name"
               aria-required="@Required.ToString().ToLowerInvariant()"
               aria-invalid="@EffectiveInvalid.ToString().ToLowerInvariant()"
@@ -59,11 +60,23 @@
     [Parameter] public string? HelperText { get; set; }
     [Parameter] public string? Label { get; set; }
     [Parameter] public string? Name { get; set; }
+    /// <summary>Focuses the underlying &lt;textarea&gt; on first render. See
+    /// Input.AutoFocus — the HTML autofocus attribute doesn't work in Blazor
+    /// WASM because parse-time has already passed by the time the runtime
+    /// adds the element to the DOM.</summary>
+    [Parameter] public bool AutoFocus { get; set; }
     [Parameter] public string? Class { get; set; }
     [Parameter(CaptureUnmatchedValues = true)] public Dictionary<string, object>? AdditionalAttributes { get; set; }
 
     private readonly string _elementId = LumeoIds.New("textarea");
     private bool _autoResizeSetup;
+    private ElementReference _textareaRef;
+
+    /// <summary>The underlying &lt;textarea&gt; element.</summary>
+    public ElementReference Element => _textareaRef;
+
+    /// <summary>Programmatically move focus to the textarea.</summary>
+    public ValueTask FocusAsync() => _textareaRef.FocusAsync();
 
     private bool EffectiveInvalid => Invalid || FormField?.HasError == true;
     private bool InsideFormField => FormField is not null;
@@ -89,6 +102,11 @@
         {
             await Interop.SetupAutoResize(_elementId, MaxRows);
             _autoResizeSetup = true;
+        }
+        if (firstRender && AutoFocus)
+        {
+            try { await _textareaRef.FocusAsync(); }
+            catch (Microsoft.JSInterop.JSDisconnectedException) { }
         }
     }
 


### PR DESCRIPTION
## Summary
Adds `[Parameter] bool AutoFocus` + a public `FocusAsync()` method to **Input**, **Textarea**, **NumberInput**, **PasswordInput**, **OtpInput** and **TagInput**.

## Why
The HTML `autofocus` attribute is parse-time per spec — the browser runs it once during initial document parsing. In Blazor WASM the runtime hasn't booted when parsing finishes, so by the time the form input is added to the DOM the browser will never fire autofocus on it. Forwarding the attribute via `AdditionalAttributes` works (the HTML output is correct) but focus simply never happens. Every consumer hits this and works around it with `setTimeout` / `JSRuntime.eval` / direct `<InputText @ref>` escape hatches.

Matches the `AutoFocus` shape of MudBlazor, FluentUI Blazor, Radzen and Telerik so devs migrating between libraries don't have to relearn.

## API surface added per component
```csharp
[Parameter] public bool AutoFocus { get; set; }
public ElementReference Element { get; }
public ValueTask FocusAsync();
```

## Implementation
Textbook pattern, ~5 lines per component:

- New `[Parameter] bool AutoFocus`
- `ElementReference _inputRef` on the underlying `<input>` / `<textarea>`
- `OnAfterRenderAsync(firstRender)` → `_inputRef.FocusAsync()` wrapped in `try/catch (JSDisconnectedException)` to match library lifecycle hygiene
- `FocusAsync()` exposes the same call as an imperative method consumers can use to re-focus on demand
- `Element` getter for advanced scenarios

**OtpInput** and **TagInput** use the existing `IComponentInteropService.FocusElement(elementId)` helper because their focusable element (first OTP digit / inner tag input) is referenced by id and the direct `@ref` pattern doesn't apply as cleanly.

## Usage
```razor
<Input @bind-Value="_model.Email" type="email" AutoFocus />
<Textarea @bind-Value="_body" AutoFocus />
<OtpInput @bind-Value="_code" AutoFocus />
```

```csharp
// Imperatively re-focus after error
await _inputRef.FocusAsync();
```

## Out of scope (separate PR)
**Combobox**, **Select**, **DatePicker** — all delegate the focusable element to a child component (`ComboboxInput`, `SelectTrigger`, Popover-wrapped button). They need a small context-plumbing change to forward `AutoFocus` through to the right child without leaking the implementation detail. Filing as a follow-up.

## Test plan
- [ ] CI green.
- [ ] `<Input AutoFocus />` on a fresh page reload (cold WASM boot) focuses the input — was the original repro from the feature request.
- [ ] `<Textarea AutoFocus />` same.
- [ ] `<OtpInput AutoFocus />` focuses the first digit cell.
- [ ] Existing tests for these components stay green — no behavior change when `AutoFocus` is unset (default `false`).

---
_Generated by [Claude Code](https://claude.ai/code/session_01LJmBFYeCdQj2G2epoZaRzQ)_