### PR TITLE
fix: InplaceEditor focus management + Cascader drill-down preservation

### DIFF
--- a/src/Lumeo/UI/Cascader/Cascader.razor
+++ b/src/Lumeo/UI/Cascader/Cascader.razor
@@ -125,6 +125,10 @@
     private string _searchText = "";
     private readonly List<string> _selectedPath = [];
     private readonly List<CascaderOption> _activePanels = [];
+    // Tracks the last Value we synced into the active-panel trail so that
+    // OnParametersSet doesn't rebuild the trail on every parent re-render —
+    // it should only respond when Value actually changes from outside.
+    private List<string>? _lastSyncedValue;
     private readonly string _wrapperId = LumeoIds.New("cascader");
     private readonly string _triggerId = LumeoIds.New("cascader-trigger");
     private readonly string _contentId = LumeoIds.New("cascader-content");
@@ -154,6 +158,14 @@
 
     protected override void OnParametersSet()
     {
+        // Skip rebuilds when Value didn't change since last sync. Without
+        // this guard, any parent re-render (an unrelated sibling typing in
+        // a search box, a parent route change, etc.) would collapse the
+        // user's in-progress drill-down back to the Value-mandated path
+        // even though Value itself wasn't touched.
+        if (ValueEquals(_lastSyncedValue, Value)) return;
+        _lastSyncedValue = Value is null ? null : new List<string>(Value);
+
         if (Value is { Count: > 0 })
         {
             _selectedPath.Clear();
@@ -171,6 +183,16 @@
                 }
             }
         }
+    }
+
+    private static bool ValueEquals(List<string>? a, List<string>? b)
+    {
+        if (ReferenceEquals(a, b)) return true;
+        if (a is null || b is null) return false;
+        if (a.Count != b.Count) return false;
+        for (int i = 0; i < a.Count; i++)
+            if (!string.Equals(a[i], b[i], StringComparison.Ordinal)) return false;
+        return true;
     }
 
     private List<CascaderOption> GetOptionsForLevel(int level)

--- a/src/Lumeo/UI/InplaceEditor/InplaceEditor.razor
+++ b/src/Lumeo/UI/InplaceEditor/InplaceEditor.razor
@@ -18,7 +18,8 @@
             <div class="flex-1 min-w-0">
                 @if (EditMode == InplaceEditMode.Textarea)
                 {
-                    <textarea class="@EditInputClass"
+                    <textarea @ref="_editFieldRef"
+                              class="@EditInputClass"
                               rows="3"
                               value="@_editValue"
                               name="@(Name ?? FormField?.Name)"
@@ -30,7 +31,8 @@
                 }
                 else if (EditMode == InplaceEditMode.Select && SelectOptions is not null)
                 {
-                    <select class="w-full rounded border border-border/40 bg-background px-2 py-1 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
+                    <select @ref="_editFieldRef"
+                            class="w-full rounded border border-border/40 bg-background px-2 py-1 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
                             value="@_editValue"
                             name="@(Name ?? FormField?.Name)"
                             aria-required="@(Required ? "true" : "false")"
@@ -45,7 +47,8 @@
                 }
                 else
                 {
-                    <input type="text"
+                    <input @ref="_editFieldRef"
+                           type="text"
                            class="@EditInputClass"
                            value="@_editValue"
                            name="@(Name ?? FormField?.Name)"
@@ -76,7 +79,7 @@
     }
     else
     {
-        <div class="@DisplayClass" role="button" tabindex="@(Disabled ? "-1" : "0")" @onclick="StartEditing" @onkeydown="HandleDisplayKeyDown" aria-required="@(Required ? "true" : "false")" aria-invalid="@(EffectiveInvalid ? "true" : "false")" aria-disabled="@(Disabled ? "true" : null)">
+        <div @ref="_displayRef" class="@DisplayClass" role="button" tabindex="@(Disabled ? "-1" : "0")" @onclick="StartEditing" @onkeydown="HandleDisplayKeyDown" aria-required="@(Required ? "true" : "false")" aria-invalid="@(EffectiveInvalid ? "true" : "false")" aria-disabled="@(Disabled ? "true" : null)">
             <div class="flex-1 min-w-0">
                 @if (ChildContent is not null)
                 {
@@ -143,6 +146,35 @@
     private bool _editing;
     private string? _editValue;
 
+    private ElementReference _editFieldRef;
+    private ElementReference _displayRef;
+    // Set when the user enters edit mode so the next render moves focus to
+    // the input/textarea/select — without this, the user clicks to edit and
+    // still has to click again to actually type. Cleared after focus is
+    // moved so subsequent re-renders (e.g. typing into the field) don't
+    // steal focus back from where the caret has moved.
+    private bool _focusEditOnRender;
+    // Same idea for the reverse transition: Save/Cancel should return focus
+    // to the trigger so a keyboard-only user doesn't end up with focus on
+    // <body> after committing.
+    private bool _focusDisplayOnRender;
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (_focusEditOnRender)
+        {
+            _focusEditOnRender = false;
+            try { await _editFieldRef.FocusAsync(); }
+            catch (Microsoft.JSInterop.JSDisconnectedException) { }
+        }
+        else if (_focusDisplayOnRender)
+        {
+            _focusDisplayOnRender = false;
+            try { await _displayRef.FocusAsync(); }
+            catch (Microsoft.JSInterop.JSDisconnectedException) { }
+        }
+    }
+
     private string CssClass => $"group w-full {Class}".Trim();
     private string EditInputClass => $"w-full rounded border {(EffectiveInvalid ? "border-destructive focus:ring-destructive/20" : "border-border/40 focus:ring-ring")} bg-background px-2 py-1 text-sm focus:outline-none focus:ring-1";
 
@@ -157,6 +189,7 @@
         if (Disabled) return;
         _editValue = Value;
         _editing = true;
+        _focusEditOnRender = true;
     }
 
     private void HandleDisplayKeyDown(KeyboardEventArgs e)
@@ -198,6 +231,7 @@
     private async Task Save()
     {
         _editing = false;
+        _focusDisplayOnRender = true;
         var saved = _editValue ?? "";
         await ValueChanged.InvokeAsync(saved);
         await OnSave.InvokeAsync(saved);
@@ -206,6 +240,7 @@
     private async Task Cancel()
     {
         _editing = false;
+        _focusDisplayOnRender = true;
         _editValue = Value;
         await OnCancel.InvokeAsync();
     }


### PR DESCRIPTION
## Summary
Two HIGH-severity bugs from #64.

## 1. InplaceEditor focus management
`src/Lumeo/UI/InplaceEditor/InplaceEditor.razor`

Symptoms:
- Click / Enter on the display flips into edit mode but focus stays on the now-unmounted trigger. Keyboard-only users have to Tab to the input to type.
- Save / Cancel unmounts the edit field; focus falls through to the document body instead of returning to the display.

Fix:
- `ElementReference` on each possible edit field (textarea / select / input — only one is rendered per `EditMode`, so they share a single `_editFieldRef`).
- `ElementReference` on the display trigger (`_displayRef`).
- `StartEditing()` sets `_focusEditOnRender`; `Save` / `Cancel` set `_focusDisplayOnRender`.
- `OnAfterRenderAsync` consumes the flag, focuses the right element, then clears the flag so subsequent re-renders (typing into the field, parent rerender) don't steal focus back.
- `JSDisconnectedException` wrapped for circuit drops.

## 2. Cascader drill-down preservation
`src/Lumeo/UI/Cascader/Cascader.razor`

Symptoms:
- User opens the picker and drills into level 1 → level 2.
- Parent re-renders for any reason (sibling search-box typing, route change, fetch completion).
- `OnParametersSet` fires → unconditionally rebuilds `_selectedPath` / `_activePanels` from `Value` → user's in-progress navigation collapses back to the Value-mandated path.

Fix:
- Track `_lastSyncedValue`.
- `OnParametersSet` only rebuilds the panel trail when `Value` differs from the last sync (reference + ordinal sequence equality).
- Cleanly handles null↔null, same-instance and value-equality cases.

## Test plan
- [ ] CI green.
- [ ] InplaceEditor: click the display → edit field is focused immediately (no second click). Press Escape → focus returns to display. Press Tab from display to next focusable → no orphan focus state.
- [ ] Cascader: open the picker, drill into level 2, type into a sibling input on the same page → drill-down state preserved.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LJmBFYeCdQj2G2epoZaRzQ)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Cascader component now preserves state during parent re-renders when the value hasn't changed.
  * InplaceEditor component now properly manages focus when entering and exiting edit mode.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Brain2k-0005/Lumeo/pull/81?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->