### PR TITLE
fix(treeselect): aria-checked tristate in Multiple mode + aria-level

### DIFF
--- a/src/Lumeo/UI/TreeSelect/TreeSelect.razor
+++ b/src/Lumeo/UI/TreeSelect/TreeSelect.razor
@@ -254,6 +254,42 @@
         }
     }
 
+    // ARIA: trees that allow multiple selection should expose aria-checked
+    // (with a "mixed" tristate when some descendants are selected) rather
+    // than aria-selected, per WAI-ARIA tree pattern §3.40. Single-select
+    // trees continue to use aria-selected.
+    //
+    // The tristate is descendant-aware: a parent with hasChildren reports
+    // "true" when every leaf under it is selected, "false" when none, and
+    // "mixed" when some are. Without this, screen-reader users only hear
+    // the parent's own selection state — which the component never sets,
+    // because in Multiple mode only leaves are selectable.
+    private string? GetAriaCheckedString(TreeSelectItem item, bool hasChildren)
+    {
+        if (!Multiple) return null;
+        if (!hasChildren) return IsSelected(item.Value) ? "true" : "false";
+
+        int selected = 0, total = 0;
+        CountLeafSelection(item, ref selected, ref total);
+        if (total == 0) return "false";
+        if (selected == 0) return "false";
+        if (selected == total) return "true";
+        return "mixed";
+    }
+
+    private void CountLeafSelection(TreeSelectItem item, ref int selected, ref int total)
+    {
+        if (item.Children is { Count: > 0 })
+        {
+            foreach (var child in item.Children) CountLeafSelection(child, ref selected, ref total);
+        }
+        else
+        {
+            total++;
+            if (IsSelected(item.Value)) selected++;
+        }
+    }
+
     private RenderFragment RenderTreeItem(TreeSelectItem item, int depth) => __builder =>
     {
         if (!IsVisible(item)) return;
@@ -264,7 +300,11 @@
         var isLeaf = !hasChildren;
         var paddingLeft = depth * 16 + 8;
 
-        <div role="treeitem" aria-selected="@isSelected" aria-expanded="@(hasChildren ? isExpanded : null)">
+        <div role="treeitem"
+             aria-selected="@(Multiple ? null : isSelected.ToString().ToLowerInvariant())"
+             aria-checked="@GetAriaCheckedString(item, hasChildren)"
+             aria-expanded="@(hasChildren ? isExpanded : null)"
+             aria-level="@(depth + 1)">
             <div class="@GetItemClass(isSelected, item.Disabled, isLeaf)"
                  style="padding-left: @(paddingLeft)px"
                  @onclick="() => HandleItemClick(item, hasChildren)"


### PR DESCRIPTION
## Summary
Closes the remaining HIGH from #64. Two ARIA gaps in TreeSelect's tree pattern.

## 1. `aria-selected` → `aria-checked` (tristate) in Multiple mode
`src/Lumeo/UI/TreeSelect/TreeSelect.razor`

WAI-ARIA tree pattern §3.40: trees that allow multiple selection of leaves should report `aria-checked` (with a `"mixed"` tristate when some descendants are selected) rather than `aria-selected`. Screen-reader users in Multiple mode were hearing the wrong state, and the parent of a partially-selected subtree had no announcement at all.

- Single mode keeps `aria-selected` — unchanged.
- Multiple mode now emits `aria-checked` on every treeitem.
  - **Leaf** nodes: `"true"` / `"false"` from their own selection.
  - **Parent** nodes: `"true"` when every leaf under them is selected, `"false"` when none, `"mixed"` otherwise. Computed by a small descendant walker.
- `aria-selected` is `null` in Multiple mode so it isn't double-reported.

## 2. `aria-level` added
The tree had no `aria-level` on treeitems, so AT couldn't announce "level 3 of N" on focus traversal. Now set to `depth + 1` per spec (1-based).

## Out of scope
Cascade-select-children + auto-mixed parent on **actual** partial-child selection is a behavioral change that deserves its own issue/PR — it's a UX shift beyond ARIA wiring. This PR fixes how the *current* selection model is exposed to AT; click semantics stay the same.

## Test plan
- [ ] CI green.
- [ ] In Multiple mode, partially-select some leaves under a parent → inspect the parent treeitem element → `aria-checked="mixed"`.
- [ ] Select all leaves under a parent → parent reports `aria-checked="true"`.
- [ ] Single mode → `aria-selected` still present, `aria-checked` is null.
- [ ] Every treeitem element has `aria-level` reflecting its depth.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LJmBFYeCdQj2G2epoZaRzQ)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accessibility in multi-select tree components with enhanced WAI-ARIA compliance for state indication to better support assistive technologies.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Brain2k-0005/Lumeo/pull/82?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->