### PR TITLE
fix: DebouncedValue swallows callback exceptions + LumeoFormGenerator null-forgiving emit

### DIFF
--- a/src/Lumeo.SourceGenerators/LumeoFormGenerator.cs
+++ b/src/Lumeo.SourceGenerators/LumeoFormGenerator.cs
@@ -110,6 +110,12 @@ public sealed class LumeoFormGenerator : IIncrementalGenerator
     {
         public string PropertyName { get; set; } = "";
         public string PropertyTypeFq { get; set; } = ""; // fully-qualified C# type
+        /// <summary>True when the property type is nullable
+        /// (<c>string?</c>, <c>int?</c>, <c>MyClass?</c>). Drives whether the
+        /// generated <c>ValueChanged</c> writeback null-coalesces — without
+        /// this flag the previous emitter used <c>__v!</c> across the board,
+        /// silently assigning null into non-nullable string properties.</summary>
+        public bool IsNullable { get; set; }
         public string Label { get; set; } = "";
         public string? HelpText { get; set; }
         public bool Required { get; set; }
@@ -291,10 +297,19 @@ public sealed class LumeoFormGenerator : IIncrementalGenerator
         var type = prop.Type;
         var fqType = type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
 
+        // NullableAnnotation.Annotated catches both nullable reference types
+        // (string?, MyClass?) and nullable value types (int?, double?). For
+        // value types we additionally accept Nullable<T> in case the property
+        // is declared with the full generic name rather than the ? shorthand.
+        var isNullable = type.NullableAnnotation == NullableAnnotation.Annotated
+            || (type is INamedTypeSymbol nt && nt.IsGenericType
+                && nt.ConstructedFrom.SpecialType == SpecialType.System_Nullable_T);
+
         var f = new FieldModel
         {
             PropertyName = prop.Name,
             PropertyTypeFq = fqType,
+            IsNullable = isNullable,
             Label = SplitPascal(prop.Name),
         };
 
@@ -550,9 +565,16 @@ public sealed class LumeoFormGenerator : IIncrementalGenerator
             sb.Append("                    __field.AddAttribute(").Append(next()).AppendLine(", \"type\", \"email\");");
 
         sb.Append("                    __field.AddAttribute(").Append(next()).Append(", \"Value\", model.").Append(f.PropertyName).AppendLine(");");
+        // Writeback: nullable string? properties get the value as-is; the
+        // null-forgiving `__v!` the previous emitter used was a code smell —
+        // it suppressed the analyzer warning but silently assigned null into
+        // non-nullable string properties when the input was cleared.
+        // Non-nullable string properties now coalesce to string.Empty so a
+        // cleared input writes "" instead of null.
+        var writeback = f.IsNullable ? "__v" : "__v ?? string.Empty";
         sb.Append("                    __field.AddAttribute(").Append(next())
           .Append(", \"ValueChanged\", global::Microsoft.AspNetCore.Components.EventCallback.Factory.Create<string?>(model, __v => model.")
-          .Append(f.PropertyName).AppendLine(" = __v!));");
+          .Append(f.PropertyName).Append(" = ").Append(writeback).AppendLine("));");
         sb.AppendLine("                    __field.CloseComponent();");
     }
 

--- a/src/Lumeo/Internal/DebouncedValue.cs
+++ b/src/Lumeo/Internal/DebouncedValue.cs
@@ -56,13 +56,28 @@ internal sealed class DebouncedValue<T> : IDisposable
             cb = _callback;
             _hasPending = false;
         }
-        if (cb is not null && value is not null)
+        if (cb is null) return;
+        // Fire-and-forget but with the task observed: SafeInvokeAsync awaits
+        // the callback inside a try/catch so a throwing handler doesn't
+        // disappear into the unobserved-task pool with no signal. Before
+        // this, a network / validation / NRE in the consumer's debounced
+        // callback would silently corrupt component state.
+        _ = SafeInvokeAsync(cb, value);
+    }
+
+    private static async Task SafeInvokeAsync(Func<T, Task> cb, T? value)
+    {
+        try
         {
-            _ = cb(value);
+            await cb(value is null ? default! : value);
         }
-        else if (cb is not null)
+        catch (Exception ex)
         {
-            _ = cb(default!);
+            // Console.Error is the lowest-common-denominator sink that
+            // works in WASM, Server and MAUI Hybrid. Consumers wanting
+            // structured logging can catch inside their own callback —
+            // this is just the safety net so the exception doesn't vanish.
+            Console.Error.WriteLine($"[DebouncedValue<{typeof(T).Name}>] callback threw: {ex}");
         }
     }
 


### PR DESCRIPTION
## Summary
Two HIGH issues from #70. Both foundational — bugs here cascade to every consumer.

## 1. `DebouncedValue<T>` swallowed callback exceptions
`src/Lumeo/Internal/DebouncedValue.cs`

`Fire()` did `_ = cb(value)` — discarded the Task, exception vanished into the unobserved-task pool. A throwing handler (NRE, network failure, validation in the consumer) failed silently while component state drifted out of sync.

Fix routes the call through a new `SafeInvokeAsync` helper that awaits the callback inside `try/catch` and writes to `Console.Error` on exception. Lowest-common-denominator sink — works in WASM, Server and MAUI Hybrid. Consumers wanting structured logging can still catch inside their own callback.

## 2. `LumeoFormGenerator` emitted `__v!` for every TextInput writeback
`src/Lumeo.SourceGenerators/LumeoFormGenerator.cs`

`EmitTextInput` always wrote:
```csharp
__v => model.X = __v!
```
The null-forgiving suppressed the analyzer warning without fixing the assignment. For non-nullable `string` properties it silently assigned `null` on clear, producing a runtime `ArgumentNullException` downstream or a quiet data-loss state.

Now the generator tracks nullability on `FieldModel.IsNullable` and picks the writeback per property:
- `string?` → `model.X = __v;`
- `string` → `model.X = __v ?? string.Empty;`

Nullable detection covers both `NullableAnnotation.Annotated` (for `string?`, `MyClass?`) and `Nullable<T>` (for `int?`, `double?`).

## Out of scope (separate PR)
`EmitNumberInput` cast overflow on `uint` / `ulong` / `byte` / `short` targets — the current `(PropertyTypeFq)(__v ?? 0)` cast wraps on overflow. Needs per-type-aware coercion (`Math.Clamp` against `Min/Max` of the target type), bigger surface change.

## Test plan
- [ ] CI green. Existing FormTests don't assert on generated source text — they exercise behavior — so they continue to pass through the new emit shape.
- [ ] Manually verify generated code for a `[LumeoForm]` model with both `string?` and `string` properties looks right in `obj/GeneratedFiles/`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LJmBFYeCdQj2G2epoZaRzQ)_