### PR TITLE
fix(image): empty wrapper when Class sized but Width/Height params unset

### DIFF
--- a/src/Lumeo/UI/Image/Image.razor
+++ b/src/Lumeo/UI/Image/Image.razor
@@ -91,7 +91,16 @@
         : null;
 
     private string ContainerClass => Cx.Join("relative inline-block overflow-hidden", Class);
-    private string ImageClass => Cx.Join("object-cover", Cx.When(Preview, "cursor-pointer"));
+    // When the consumer sized the wrapper via Class (e.g. "h-14 w-auto") but
+    // didn't pass explicit Width / Height params, the <img> had no size
+    // hints and collapsed to its natural dimensions inside an
+    // inline-block parent — net visual: empty container. Default the
+    // image to fill its parent in that case; explicit Width/Height still
+    // win because they become attributes on the <img> directly.
+    private string ImageClass => Cx.Join(
+        "object-cover",
+        Cx.When(Width is null && Height is null, "h-full w-full"),
+        Cx.When(Preview, "cursor-pointer"));
     private string FallbackClass => "flex items-center justify-center bg-muted rounded-md";
     private string FallbackStyle
     {


### PR DESCRIPTION
## Reproduction (from production feedback)
```razor
`&lt;Image Src="/logo.png" Class="h-14 w-auto" /&gt;`
```
Wrapper renders with the right height but the inner image is invisible — empty container.

## Cause
`src/Lumeo/UI/Image/Image.razor`:
- Wrapper: `relative inline-block overflow-hidden {Class}` → `inline-block` shrinks to content size.
- Image: `object-cover` only, no width / height when `Width` / `Height` params are null.

The `<img>` has no size hints, so the browser lays it out at its intrinsic natural size — sometimes `0×0` before load, never the parent's. The `inline-block` wrapper shrinks to that, net visual: empty.

## Fix
When neither `Width` nor `Height` is provided as a numeric param, add `h-full w-full` to `ImageClass` so the `<img>` fills whatever the parent (or the consumer's `Class` on the parent) sized to.

- Explicit `Width` / `Height` still win because they're emitted directly on the `<img>` as HTML attributes.
- `object-cover` continues to crop correctly within those bounds.

## Test plan
- [ ] CI green.
- [ ] ``&lt;Image Src="x.png" Class="h-14 w-auto" /&gt;`` renders the image filling the 56-px-tall wrapper.
- [ ] ``&lt;Image Src="x.png" Width="100" Height="100" /&gt;`` still renders at exactly 100×100 (explicit params unchanged).
- [ ] Existing tests stay green.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LJmBFYeCdQj2G2epoZaRzQ)_