### PR TITLE
feat(overlay): MobileFullscreen option for Dialog / Sheet / Drawer

### DIFF
--- a/src/Lumeo/Services/OverlayService.cs
+++ b/src/Lumeo/Services/OverlayService.cs
@@ -198,6 +198,17 @@ public sealed record OverlayOptions
     /// off on desktop, on for mobile bottom-sheet pull-down.</summary>
     public bool? MobileSwipeToClose { get; init; }
 
+    /// <summary>When true and the viewport width is below
+    /// <see cref="MobileBreakpoint"/>, the overlay is forced full-screen
+    /// (full width + full height, no corner radius). Works across Dialog,
+    /// Sheet and Drawer overlays — replaces the consumer-side
+    /// <c>max-md:!h-full max-md:!w-full max-md:!max-w-full</c> Tailwind
+    /// override chain that was previously the only way to get a
+    /// full-screen Dialog on mobile. For Sheets, this is equivalent to
+    /// setting <see cref="MobileSheetSize"/> to <see cref="SheetSize.Full"/>
+    /// but composes more naturally for the Sheet+Dialog mixed case.</summary>
+    public bool MobileFullscreen { get; init; }
+
     /// <summary>
     /// Wrap the rendered component in a scrollable body region inside the
     /// overlay's chrome (Sheet only — Dialog and Drawer manage their own

--- a/src/Lumeo/UI/Overlay/OverlayProvider.razor
+++ b/src/Lumeo/UI/Overlay/OverlayProvider.razor
@@ -8,7 +8,7 @@
     {
         case OverlayType.Dialog:
             <Dialog @key="overlay.Id" Open="true" OpenChanged="(bool val) => OnOverlayClosed(val, overlay.Id)">
-                <DialogContent ZIndex="@overlay.ZIndex" PreventClose="@overlay.Options.PreventClose" Class="@overlay.Options.Class">
+                <DialogContent ZIndex="@overlay.ZIndex" PreventClose="@overlay.Options.PreventClose" Class="@EffectiveClass(overlay.Options)">
                     @if (overlay.Title is not null)
                     {
                         <DialogHeader>
@@ -26,7 +26,7 @@
 
         case OverlayType.Sheet:
             <Sheet @key="overlay.Id" Open="true" OpenChanged="(bool val) => OnOverlayClosed(val, overlay.Id)">
-                <SheetContent ZIndex="@overlay.ZIndex" Side="@EffectiveSheetSide(overlay.Options)" Size="@EffectiveSheetSize(overlay.Options)" PreventClose="@overlay.Options.PreventClose" SwipeToClose="@EffectiveSwipeToClose(overlay.Options)" Class="@overlay.Options.Class">
+                <SheetContent ZIndex="@overlay.ZIndex" Side="@EffectiveSheetSide(overlay.Options)" Size="@EffectiveSheetSize(overlay.Options)" PreventClose="@overlay.Options.PreventClose" SwipeToClose="@EffectiveSwipeToClose(overlay.Options)" Class="@EffectiveClass(overlay.Options)">
                     @if (overlay.Title is not null)
                     {
                         <SheetHeader>
@@ -65,7 +65,7 @@
 
         case OverlayType.Drawer:
             <Drawer @key="overlay.Id" Open="true" OpenChanged="(bool val) => OnOverlayClosed(val, overlay.Id)">
-                <DrawerContent ZIndex="@overlay.ZIndex" PreventClose="@overlay.Options.PreventClose" Class="@overlay.Options.Class">
+                <DrawerContent ZIndex="@overlay.ZIndex" PreventClose="@overlay.Options.PreventClose" Class="@EffectiveClass(overlay.Options)">
                     @if (overlay.Title is not null)
                     {
                         <DrawerHeader>
@@ -152,7 +152,8 @@
         opts.MobileBreakpoint is not null
         && (opts.MobileSheetSide is not null
             || opts.MobileSheetSize is not null
-            || opts.MobileSwipeToClose is not null);
+            || opts.MobileSwipeToClose is not null
+            || opts.MobileFullscreen);
 
     // Effective Side/Size/SwipeToClose helpers — picked at each render so a
     // viewport crossing flips them automatically via HandleViewportChanged.
@@ -173,6 +174,22 @@
 
     private bool EffectiveSwipeToClose(OverlayOptions opts) =>
         IsMobile(opts) && opts.MobileSwipeToClose is bool m ? m : opts.SwipeToClose;
+
+    // Composes the Class string passed to the inner Dialog/Sheet/Drawer
+    // content. When MobileFullscreen + viewport is below MobileBreakpoint,
+    // appends the override classes that previously consumers had to ship
+    // themselves (max-md:!h-full max-md:!w-full max-md:!max-w-full
+    // max-md:!rounded-none). We don't need the max-md: prefix because the
+    // provider already knows it's mobile via IsMobile() — the classes
+    // apply unconditionally at the moment of render. Order matters: the
+    // consumer's own Class wins for unrelated tokens, the fullscreen
+    // tokens are appended after so they override the component's defaults.
+    private string? EffectiveClass(OverlayOptions opts)
+    {
+        if (!IsMobile(opts) || !opts.MobileFullscreen) return opts.Class;
+        const string fs = "h-full w-full max-w-full max-h-full rounded-none";
+        return string.IsNullOrEmpty(opts.Class) ? fs : $"{opts.Class} {fs}";
+    }
 
     private void HandleShow(OverlayInstance instance)
     {


### PR DESCRIPTION
## Summary
Closes one item from the roadmap (#90). Adds `OverlayOptions.MobileFullscreen` — a single bool that forces an overlay full-screen on viewports below `MobileBreakpoint`.

## Why
Today consumers ship a hand-rolled `OverlayClasses.cs` helper that injects this Tailwind override chain into the `Class` of every overlay that should become full-screen on mobile:

```
max-md:!h-full max-md:!w-full max-md:!max-w-full max-md:!rounded-none
```

`Sheet` had a partial built-in (`MobileSheetSize = SheetSize.Full`), but `Dialog` had no equivalent — the consumer had to maintain the override chain. This PR closes that gap across **Dialog / Sheet / Drawer** via one bool flag.

## Implementation
- `OverlayOptions.MobileFullscreen` (bool, default `false`).
- `OverlayProvider.EffectiveClass(opts)` appends `h-full w-full max-w-full max-h-full rounded-none` to the `Class` passed to the inner `*Content` when both `IsMobile(opts)` (viewport `<` `MobileBreakpoint`) and `MobileFullscreen` are true.
- No `max-md:` prefix needed — `IsMobile()` already gates by viewport. Classes apply unconditionally at render time and flip back when the viewport crosses the breakpoint, via the existing `HandleViewportChanged` re-render path.
- `HasMobileOverrides` extended to include `MobileFullscreen` so the responsive re-render triggers for sheets that only opt into this (without other `Mobile*` overrides).

## Usage
```csharp
await OverlayService.ShowDialogAsync<MyForm>(new OverlayOptions
{
    MobileFullscreen = true   // <-- replaces the whole override chain
});
```

## Test plan
- [ ] CI green.
- [ ] Dialog with `MobileFullscreen = true` opened on `<768px` viewport renders edge-to-edge with no border-radius.
- [ ] Same dialog on `≥768px` viewport renders centered with the usual size.
- [ ] Rotating a tablet across the breakpoint live-flips the layout (re-render via `HandleViewportChanged`).
- [ ] `MobileFullscreen=true` composes correctly with consumer-provided `Class` (their tokens come first, fullscreen tokens after).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `MobileFullscreen` option for overlay components (Dialog, Sheet, Drawer). When enabled, overlays automatically expand to full-screen mode on mobile devices, using full width/height and removing corner radius.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Brain2k-0005/Lumeo/pull/91?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->