### PR TITLE
fix(editor): cut double round-trip per keystroke + clear debounce timer on destroy

### DIFF
--- a/src/Lumeo.CodeEditor/wwwroot/js/code-editor.js
+++ b/src/Lumeo.CodeEditor/wwwroot/js/code-editor.js
@@ -337,6 +337,15 @@ export async function setReadOnly(elementId, readOnly) {
 export async function destroy(elementId) {
     const inst = _instances.get(elementId);
     if (!inst) return;
+    // Cancel any pending debounced OnEditorChange round-trip before tearing
+    // down the editor. Without this, a setTimeout scheduled within the
+    // last 60 ms before destroy still fires, invokes the (about-to-be-)
+    // disposed dotNetRef and lands in the catch — harmless but wastes a
+    // round-trip and leaves a timer hanging until it resolves.
+    try {
+        const pending = inst.debounceTimer?.();
+        if (pending) clearTimeout(pending);
+    } catch {}
     try { inst.themeObserver?.disconnect(); } catch {}
     try { inst.view.destroy(); } catch {}
     _instances.delete(elementId);

--- a/src/Lumeo.Editor/wwwroot/js/rich-text-editor.js
+++ b/src/Lumeo.Editor/wwwroot/js/rich-text-editor.js
@@ -927,7 +927,11 @@ export const rte = {
                             // Soft cap — emit the overflow but consumers can trim.
                         }
                     }
-                    safeInvoke(dotNetRef, 'OnContentUpdate', html);
+                    // Single round-trip per keystroke. OnUpdate is the
+                    // canonical name; .NET-side OnContentUpdate is a legacy
+                    // alias that forwards to the same handler, so firing
+                    // both here would double the .NET round-trip cost on
+                    // every keystroke.
                     safeInvoke(dotNetRef, 'OnUpdate', html);
                 },
                 onSelectionUpdate: () => {


### PR DESCRIPTION
## Summary
Two small follow-ups verified in #65. Most of the agent's original HIGH claims didn't survive code verification (`_initialized` guards, `ObjectDisposedException` catches, `_lastSetValue` assigned before await — all already in place). These two are real.

## 1. `rich-text-editor.js` — double round-trip per keystroke
The TipTap `onUpdate` handler fired both `safeInvoke('OnContentUpdate', html)` AND `safeInvoke('OnUpdate', html)` per transaction. The .NET side maps `OnUpdate` to a 1-line forwarder that calls `OnContentUpdate` — so every keystroke triggered two .NET round-trips that did the exact same work.

Fix: keep only `'OnUpdate'` in the JS path (canonical name). The `OnContentUpdate` alias remains on .NET for any consumer that wired it directly. **Halves the keystroke-path interop cost** with zero consumer-facing behaviour change.

## 2. `code-editor.js` — debounce timer not cleared on `destroy()`
`destroy()` disconnected the `themeObserver` and tore down the `view`, but the 60 ms debounce `setTimeout` (closure-captured from `init()`) was left scheduled. If the user typed within 60 ms of closing the editor, the timer would fire after destroy, `invokeMethodAsync` on the just-disposed dotNetRef, and land in the catch — harmless but a wasted round-trip and a hanging timer.

The init path already stores `debounceTimer: () => debounceTimer` on the instance (closure-captured getter). `destroy()` now calls that getter and `clearTimeout()`s the pending handle before tearing down.

## Out of scope
Original #65 HIGHs verified as false positives:
- "ObjectDisposedException not caught alongside JSDisconnect" — both catches present (`CodeEditor.razor:138-139`)
- "RefreshActiveAsync no `_initialized` guard" — guard via `_instanceId is null` (`RichTextEditor.razor:464`)
- "OnParametersSetAsync no `_initialized` check" — guard at `RichTextEditor.razor:285`
- "SetHtmlAsync doesn't sync `_lastSetValue` before JS call" — assigned at line 474 before await on line 476

## Test plan
- [ ] CI green.
- [ ] Type into RichTextEditor → only one `OnUpdate` round-trip per keystroke (verify by logging on the .NET side or by network panel).
- [ ] Open CodeEditor, type rapidly, close it within 60 ms of last keystroke → no "object disposed" warnings in console.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LJmBFYeCdQj2G2epoZaRzQ)_