### PR TITLE
fix(maps,gantt): catch non-JSDisconnect init failures so component isn't silently inert

### DIFF
--- a/src/Lumeo.Gantt/UI/Gantt/Gantt.razor
+++ b/src/Lumeo.Gantt/UI/Gantt/Gantt.razor
@@ -166,6 +166,12 @@ else
             _instanceId = await Interop.GanttInitAsync(_hostRef, _selfRef, options);
             _initialized = true;
         }
+        catch (Microsoft.JSInterop.JSDisconnectedException)
+        {
+            // Circuit was torn down between firstRender starting and
+            // GanttInitAsync resolving. No init-error UI to show because the
+            // user is already gone — match the pattern other components use.
+        }
         catch (Microsoft.JSInterop.JSException ex)
         {
             _initError = $"Gantt initialization failed: {ex.Message}";

--- a/src/Lumeo.Maps/UI/Map/Map.razor
+++ b/src/Lumeo.Maps/UI/Map/Map.razor
@@ -201,6 +201,19 @@
                 await SyncStandalonePopupsAsync();
             }
             catch (JSDisconnectedException) { }
+            catch (Exception ex)
+            {
+                // Without this branch, a non-disconnect failure inside init
+                // (module load error, Leaflet runtime exception, misconfigured
+                // tile layer) propagated out of OnAfterRender and Blazor
+                // logged it once, but _initialized stayed false forever —
+                // every subsequent render skipped the init branch
+                // (firstRender is true exactly once), so the component
+                // became permanently inert with no visible error. Surface
+                // the failure on Console.Error so consumers can see what
+                // broke during dev instead of staring at a silent dead map.
+                Console.Error.WriteLine($"[Lumeo Map] init failed: {ex.Message}");
+            }
             return;
         }
 


### PR DESCRIPTION
## Summary
Two real findings from #66. Several other satellite-race claims in the original scan verified as false positives:

| Claim | Verification |
|---|---|
| Map `OnViewChanged` @bind ping-pong | FP — `_lastCenter` already set BEFORE `CenterChanged.InvokeAsync` |
| Gantt `ReplaceTask` race against value-type collections | FP — internal `_tasks` is always `Tasks?.ToList()` and emits via `ToList()` |
| Gantt missing `StateHasChanged` in init-error path | FP — line 175 has it |
| Scheduler `RefreshTitleAsync` null-deref | FP — `if (_instanceId is null) return;` guard at line 356 |

## 1. Map — silent permanent inertia on init failure
`src/Lumeo.Maps/UI/Map/Map.razor:195-204`

`OnAfterRenderAsync` only caught `JSDisconnectedException`. Anything else (module load error, Leaflet runtime exception, misconfigured tile layer) propagated, Blazor logged it once, but `_initialized` stayed false forever. Every subsequent render skipped the init branch (`firstRender` is true exactly once), so the component became **permanently inert** with no visible error.

Fix: also catch `Exception` and surface on `Console.Error` so consumers see what broke during dev instead of staring at a silent dead map. Kept the diff minimal — didn't add an `OnInitError` parameter yet; the same shape `Gantt` already uses can be added later if consumers ask.

## 2. Gantt — JSDisconnect during init not caught
`src/Lumeo.Gantt/UI/Gantt/Gantt.razor:169`

Init catch only handled `Microsoft.JSInterop.JSException`. A circuit drop between `firstRender` starting and `GanttInitAsync` resolving threw `JSDisconnectedException` as unhandled.

Fix: also catch `JSDisconnectedException`; no init-error UI on disconnect (user is gone) — matches the pattern other components use.

## Test plan
- [ ] CI green.
- [ ] Map with intentionally bad `TileLayer="invalid-name"` → `Console.Error` shows the failure with `[Lumeo Map] init failed: ...` instead of dying silently.
- [ ] Existing happy-path Map / Gantt tests stay green — the added catches are no-ops on the success path.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LJmBFYeCdQj2G2epoZaRzQ)_