### PR TITLE
feat: Lumeo.Size.Xxs token + Avatar/Chip support

### DIFF
--- a/src/Lumeo/Size.cs
+++ b/src/Lumeo/Size.cs
@@ -19,6 +19,12 @@ namespace Lumeo;
 /// </remarks>
 public enum Size
 {
+    /// <summary>Double extra small. For dense-mode <c>Avatar</c> / <c>Chip</c>
+    /// where a smaller indicator is needed (e.g. inline-with-text presence
+    /// dot, stacked-avatar list previews). Replaces consumer-side
+    /// <c>text-[10px]</c> / <c>h-5 w-5</c> arbitrary-value Tailwind escape
+    /// hatches with a first-class token.</summary>
+    Xxs,
     /// <summary>Extra small. Used by <c>Icon</c>.</summary>
     Xs,
     /// <summary>Small. Used by most sized components (Avatar, Chip, Input, etc.).</summary>

--- a/src/Lumeo/UI/Avatar/Avatar.razor
+++ b/src/Lumeo/UI/Avatar/Avatar.razor
@@ -38,6 +38,7 @@
 
     private string SizeClasses => Size switch
     {
+        Lumeo.Size.Xxs => "h-5 w-5 text-[10px]",
         Lumeo.Size.Sm => "h-8 w-8",
         Lumeo.Size.Lg => "h-12 w-12",
         Lumeo.Size.Xl => "h-16 w-16",

--- a/src/Lumeo/UI/Chip/Chip.razor
+++ b/src/Lumeo/UI/Chip/Chip.razor
@@ -70,6 +70,7 @@
 
     private string SizeClass => Size switch
     {
+        Lumeo.Size.Xxs => "text-[10px] px-1.5 py-0 rounded",
         Lumeo.Size.Sm => "text-xs px-2 py-0.5 rounded-md",
         Lumeo.Size.Lg => "text-sm px-3 py-1 rounded-lg",
         _ => "text-sm px-2.5 py-0.5 rounded-md"
@@ -93,6 +94,7 @@
 
     private string AvatarSizeClass => Size switch
     {
+        Lumeo.Size.Xxs => "h-3 w-3",
         Lumeo.Size.Sm => "h-4 w-4",
         Lumeo.Size.Lg => "h-6 w-6",
         _ => "h-5 w-5"
@@ -100,6 +102,7 @@
 
     private string CloseIconSize => Size switch
     {
+        Lumeo.Size.Xxs => "h-2.5 w-2.5",
         Lumeo.Size.Sm => "h-3 w-3",
         _ => "h-3.5 w-3.5"
     };


### PR DESCRIPTION
## Summary
First small win from #90 roadmap. Consumers reported writing `text-[10px]` arbitrary-value Tailwind on Avatar / Chip dense modes because the smallest supported size token (`Sm`) bottoms out at `text-xs` / `h-8`. A first-class `Xxs` token absorbs those one-off arbitrary values into the library.

## Changes
- `Lumeo.Size` enum gains `Xxs` as the new smallest member (above `Xs` in the enum so ordering reads "smaller → larger").
- `Avatar.SizeClasses` adds `Xxs → h-5 w-5 text-[10px]` — the arbitrary value now lives inside Lumeo instead of every consumer.
- `Chip.SizeClass` adds `Xxs → text-[10px] px-1.5 py-0 rounded`. Its inner `AvatarSizeClass` + `CloseIconSize` switches gain matching smaller variants (`h-3 w-3` / `h-2.5 w-2.5`) so the close X stays proportional.

## Out of scope
Other components that accept `Lumeo.Size` (Input, Spinner, Button, etc.) keep their existing scale. `Xxs` only makes sense where the component is already dense enough that going one notch smaller is meaningful — adding it to them is a separate, design-by-component decision. This PR makes the token exist and proves it out on the two cases the feedback called out.

## Test plan
- [ ] CI green.
- [ ] `<Avatar Size="Lumeo.Size.Xxs" />` renders at 20×20 with 10 px initials.
- [ ] `<Chip Size="Lumeo.Size.Xxs">tag</Chip>` renders compact with proportional close X.
- [ ] Existing Avatar / Chip rendering at `Sm` / `Md` / `Lg` / `Xl` unchanged.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LJmBFYeCdQj2G2epoZaRzQ)_