### PR TITLE
feat(input): Search variant with auto search-icon prefix + min-width

### DIFF
--- a/src/Lumeo/UI/Input/Input.razor
+++ b/src/Lumeo/UI/Input/Input.razor
@@ -11,15 +11,22 @@
     </label>
 }
 
-@if (Prefix != null || Suffix != null || (Clearable && !string.IsNullOrEmpty(Value)))
+@if (Prefix != null || Suffix != null || Variant == InputVariant.Search || (Clearable && !string.IsNullOrEmpty(Value)))
 {
     <div class="@WrapperClass" @attributes="AdditionalAttributes">
-        @if (Prefix != null)
+        @if (Variant == InputVariant.Search && Prefix == null)
+        {
+            <div class="flex items-center ps-3 pe-1 text-muted-foreground">
+                <Blazicon Svg="Lucide.Search" class="h-4 w-4" />
+            </div>
+        }
+        else if (Prefix != null)
         {
             <div class="flex items-center px-3 text-muted-foreground">@Prefix</div>
         }
         <input @ref="_inputRef"
                name="@Name"
+               type="@(Variant == InputVariant.Search ? "search" : null)"
                aria-required="@Required.ToString().ToLowerInvariant()"
                aria-invalid="@EffectiveInvalid.ToString().ToLowerInvariant()"
                class="@WrappedInputClass" value="@Value" @oninput="HandleInput" disabled="@Disabled" />
@@ -85,8 +92,18 @@ else
     /// in OnAfterRenderAsync(firstRender) which is the canonical workaround.
     /// </summary>
     [Parameter] public bool AutoFocus { get; set; }
+    /// <summary>Visual / semantic input variant. <c>Default</c> is the
+    /// plain text input. <c>Search</c> auto-renders a search icon prefix,
+    /// sets <c>type="search"</c> (gives platforms a clear-button + IME
+    /// hints), and applies a search-friendly minimum width so the field
+    /// doesn't collapse in narrow flex containers — replaces the
+    /// <c>min-w-[180px] max-w-md</c> + manual icon prefix consumers
+    /// previously shipped at every search field call-site.</summary>
+    [Parameter] public InputVariant Variant { get; set; } = InputVariant.Default;
     [Parameter] public string? Class { get; set; }
     [Parameter(CaptureUnmatchedValues = true)] public Dictionary<string, object>? AdditionalAttributes { get; set; }
+
+    public enum InputVariant { Default, Search }
 
     private ElementReference _inputRef;
 
@@ -124,7 +141,14 @@ else
 
     private string CssClass => $"flex {SizeClasses} w-full rounded-md border {(EffectiveInvalid ? "border-destructive" : "border-input")} bg-transparent py-1 transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-[1.5px] {(EffectiveInvalid ? "focus-visible:ring-destructive/20" : "focus-visible:ring-ring")} disabled:cursor-not-allowed disabled:opacity-50 {Class}".Trim();
 
-    private string WrapperClass => $"flex {WrapperSizeClasses} w-full rounded-md border {(EffectiveInvalid ? "border-destructive" : "border-input")} bg-transparent transition-colors {(EffectiveInvalid ? "focus-within:ring-[1.5px] focus-within:ring-destructive/20" : "focus-within:ring-[1.5px] focus-within:ring-ring")} disabled:cursor-not-allowed disabled:opacity-50 {Class}".Trim();
+    // Search variant adds a min-width floor so the field doesn't collapse
+    // in narrow flex containers (the historical consumer fix was
+    // `min-w-[180px] max-w-md` per call-site). The min-w-0 default on
+    // flex children would otherwise let the wrapper shrink to ~40px when
+    // squeezed by siblings.
+    private string SearchSizeClass => Variant == InputVariant.Search ? "min-w-[180px] max-w-md" : "";
+
+    private string WrapperClass => $"flex {WrapperSizeClasses} {SearchSizeClass} w-full rounded-md border {(EffectiveInvalid ? "border-destructive" : "border-input")} bg-transparent transition-colors {(EffectiveInvalid ? "focus-within:ring-[1.5px] focus-within:ring-destructive/20" : "focus-within:ring-[1.5px] focus-within:ring-ring")} disabled:cursor-not-allowed disabled:opacity-50 {Class}".Trim();
 
     private string WrappedInputClass => $"flex-1 bg-transparent {WrappedInputSizeClasses} py-1 placeholder:text-muted-foreground focus-visible:outline-none disabled:cursor-not-allowed".Trim();
 


### PR DESCRIPTION
## Summary
Second small win from #90 roadmap. Consumers were repeating the same `min-w-[180px] max-w-md` width hack + manual `Lucide.Search` icon prefix at every search-field call-site (reported 5+ repeats per project). New `<Input Variant="Search" />` absorbs the pattern.

## What `Variant=Search` does
- **Auto-renders a `Lucide.Search` icon** as the prefix when no explicit `Prefix` slot is provided. Consumer-passed `Prefix` still wins, so the variant composes with custom decoration if needed.
- **Sets `type="search"`** on the underlying `<input>`:
  - native clear-X on Chromium / WebKit
  - hints IME / mobile keyboards to show a "Search" action
  - associates the field with form search semantics
- **Adds `min-w-[180px] max-w-md`** to the wrapper so the field doesn't collapse in narrow flex containers — the exact widths consumers were copy-pasting. Override-able via `Class`.

## Usage
```razor
<Input @bind-Value="_query" Placeholder="Search…" Variant="Lumeo.Input.InputVariant.Search" />
```

vs. before:
```razor
<div class="flex h-9 w-full min-w-[180px] max-w-md rounded-md border …">
  <div class="flex items-center px-3"><Blazicon Svg="Lucide.Search" class="h-4 w-4" /></div>
  <Input @bind-Value="_query" Placeholder="Search…" Class="border-0 …" />
</div>
```

## Default behavior
`Variant` defaults to `Default` — no change for existing consumers.

## Test plan
- [ ] CI green.
- [ ] `<Input Variant="Lumeo.Input.InputVariant.Search" />` renders the magnifying-glass icon and `type="search"`.
- [ ] In a narrow flex container, the search input stays at ≥180 px wide instead of collapsing.
- [ ] Existing `<Input>` (default variant) renders identically to before.
- [ ] `<Input Variant="Search" Prefix="...">` honors the consumer's Prefix instead of auto-injecting Lucide.Search.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LJmBFYeCdQj2G2epoZaRzQ)_