### PR TITLE
fix: address Codex review findings from prior 3.3.0-track PRs

### DIFF
--- a/docs/Lumeo.Docs/App.razor
+++ b/docs/Lumeo.Docs/App.razor
@@ -42,11 +42,25 @@
         }),
         ("/components/code-editor",      new[] { "Lumeo.CodeEditor.dll" }),
         ("/components/rich-text-editor", new[] { "Lumeo.Editor.dll" }),
-        ("/components/file-viewer",      new[] { "Lumeo.FileViewer.dll" }),
+        // FileViewer renders Code-kind files via CodeEditor and PDF-kind
+        // files via PdfViewer (see Lumeo.FileViewer/UI/FileViewer/
+        // FileViewer.razor switch on _resolvedKind). Without the two
+        // satellite DLLs in this route's lazy set, navigating directly to
+        // /components/file-viewer threw missing-assembly errors as soon as
+        // the demo file table tried to render one of those kinds. Pull
+        // them in alongside Lumeo.FileViewer.dll (Codex #50 review).
+        ("/components/file-viewer",      new[] { "Lumeo.FileViewer.dll", "Lumeo.CodeEditor.dll", "Lumeo.PdfViewer.dll" }),
         ("/components/gantt",            new[] { "Lumeo.Gantt.dll" }),
         ("/components/pdf-viewer",       new[] { "Lumeo.PdfViewer.dll" }),
         ("/components/scheduler",        new[] { "Lumeo.Scheduler.dll" }),
     };
+
+    // Note: the eight non-Lucide Blazicons packs are also preloaded by
+    // CustomizerSidebar on first render (Codex #50 review) so the
+    // customizer's icon-library picker works on every docs page, not
+    // just /components/icon. That loader lives next to the consumer in
+    // CustomizerSidebar.razor rather than here, so the App-level lazy
+    // map stays strictly route-prefix → DLL.
 
     private async Task OnNavigateAsync(NavigationContext context)
     {
@@ -75,10 +89,11 @@
         }
         catch
         {
-            // Best-effort: a failed fetch leaves the assemblies un-marked so
-            // the next navigation tries again. We intentionally swallow here
-            // rather than crash the router — the page itself will surface a
-            // meaningful error when its types can't resolve.
+            // Un-mark the names so the next navigation gets a fresh chance
+            // to fetch them, then rethrow so the router / error boundary
+            // surfaces the failure to the user instead of letting it sink
+            // into the unobserved-task pool (a previous comment here read
+            // as if the throw was a swallow — fixed per Codex review).
             foreach (var dll in needed) _loadedNames.Remove(dll);
             throw;
         }

--- a/docs/Lumeo.Docs/Lumeo.Docs.csproj
+++ b/docs/Lumeo.Docs/Lumeo.Docs.csproj
@@ -68,7 +68,7 @@
        route prefix handled in App.razor's NavigationContext switch — keep the two
        in sync when adding a new satellite package. -->
   <ItemGroup>
-    <!-- 7 icon packs (~few hundred KB each) — only the /components/icon route
+    <!-- 8 icon packs (~few hundred KB each) — only the /components/icon route
          shows examples from them. Blazicons.Lucide stays eager because it is
          used pervasively across the library. -->
     <BlazorWebAssemblyLazyLoad Include="Blazicons.Bootstrap.dll" />

--- a/docs/Lumeo.Docs/Shared/CustomizerSidebar.razor
+++ b/docs/Lumeo.Docs/Shared/CustomizerSidebar.razor
@@ -5,6 +5,7 @@
 @inject IconService _iconService
 @inject Lumeo.Services.ThemeService ThemeService
 @inject Lumeo.Services.KeyboardShortcutService Shortcuts
+@inject Microsoft.AspNetCore.Components.WebAssembly.Services.LazyAssemblyLoader LazyLoader
 @implements IAsyncDisposable
 
 
@@ -613,10 +614,39 @@
         await JS.InvokeVoidAsync("themeManager.setMenuAccent", accent);
     }
 
+    private static readonly string[] _iconPackDlls =
+    {
+        "Blazicons.Bootstrap.dll",
+        "Blazicons.Devicon.dll",
+        "Blazicons.FlagIcons.dll",
+        "Blazicons.FluentUI.dll",
+        "Blazicons.FontAwesome.dll",
+        "Blazicons.GoogleMaterialDesign.dll",
+        "Blazicons.Ionicons.dll",
+        "Blazicons.MaterialDesignIcons.dll",
+    };
+    private bool _iconPacksLoaded;
+
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
         if (firstRender)
         {
+            // Lazy-fetch the eight non-Lucide icon packs that the customizer's
+            // icon-library picker enumerates. App.razor only loads them on the
+            // /components/icon route, but the customizer is mounted by
+            // MainLayout on every docs page, and IconPreview references the
+            // pack types when the user opens the picker. Without this preload
+            // the picker hit unresolved-assembly errors on /components/button,
+            // /components/avatar, etc. (Codex #50 review). Fire-and-forget;
+            // failures are bounded by safeInvoke-style behaviour on the
+            // consumer side of the loader.
+            if (!_iconPacksLoaded)
+            {
+                _iconPacksLoaded = true;
+                try { await LazyLoader.LoadAssembliesAsync(_iconPackDlls); }
+                catch (Microsoft.JSInterop.JSDisconnectedException) { }
+            }
+
             await ThemeService.InitializeAsync();
             _darkMode = ThemeService.IsDark;
             ThemeService.OnThemeChanged += OnThemeServiceChanged;

--- a/src/Lumeo.Charts/UI/Chart/Charts/GaugeChart.razor
+++ b/src/Lumeo.Charts/UI/Chart/Charts/GaugeChart.razor
@@ -71,13 +71,29 @@
             // Build axis line color stops from ranges. Guard the
             // normalisation against Max == Min — division by zero produces
             // NaN/Infinity in the color-stops payload and ECharts renders
-            // a broken gauge. Collapse to position 0 in that case.
+            // a broken gauge.
+            //
+            // In ECharts, axisLine.lineStyle.color entries are END positions
+            // along the arc (each stop covers from the previous stop to
+            // its own position). Collapsing every stop to 0 means nothing
+            // covers the arc — the gauge renders empty. For the zero-span
+            // case we emit a single terminal stop at 1.0 using the first
+            // range's color so the whole arc renders as one solid band, the
+            // sensible degenerate output for a placeholder-style gauge.
             var span = Max - Min;
             var colorStops = new List<object>();
-            foreach (var range in Ranges.OrderBy(r => r.Threshold))
+            if (span == 0)
             {
-                var normalizedPos = span == 0 ? 0 : (range.Threshold - Min) / span;
-                colorStops.Add(new object[] { normalizedPos, range.Color });
+                var firstColor = Ranges.OrderBy(r => r.Threshold).First().Color;
+                colorStops.Add(new object[] { 1.0, firstColor });
+            }
+            else
+            {
+                foreach (var range in Ranges.OrderBy(r => r.Threshold))
+                {
+                    var normalizedPos = (range.Threshold - Min) / span;
+                    colorStops.Add(new object[] { normalizedPos, range.Color });
+                }
             }
             // Ensure we reach 1.0
             var maxThreshold = Ranges.Max(r => r.Threshold);

--- a/src/Lumeo.Editor/wwwroot/js/rich-text-editor.js
+++ b/src/Lumeo.Editor/wwwroot/js/rich-text-editor.js
@@ -927,12 +927,21 @@ export const rte = {
                             // Soft cap — emit the overflow but consumers can trim.
                         }
                     }
-                    // Single round-trip per keystroke. OnUpdate is the
-                    // canonical name; .NET-side OnContentUpdate is a legacy
-                    // alias that forwards to the same handler, so firing
-                    // both here would double the .NET round-trip cost on
-                    // every keystroke.
+                    // Fire BOTH OnUpdate (canonical) and OnContentUpdate
+                    // (legacy alias). The built-in RichTextEditor maps
+                    // OnUpdate → OnContentUpdate internally so the second
+                    // call is technically redundant for the bundled
+                    // component — BUT consumers using the public
+                    // RichTextInitAsync<T> surface with their own
+                    // DotNetObjectReference<T> may only implement
+                    // [JSInvokable] OnContentUpdate (the older name).
+                    // Firing only OnUpdate broke those external integrations
+                    // silently because safeInvoke catches the missing-method
+                    // error and swallows it (Codex #92 review). Keep both
+                    // until the alias can be officially deprecated with a
+                    // migration release note.
                     safeInvoke(dotNetRef, 'OnUpdate', html);
+                    safeInvoke(dotNetRef, 'OnContentUpdate', html);
                 },
                 onSelectionUpdate: () => {
                     safeInvoke(dotNetRef, 'OnSelectionUpdate');

--- a/src/Lumeo.Editor/wwwroot/js/rich-text-editor.js
+++ b/src/Lumeo.Editor/wwwroot/js/rich-text-editor.js
@@ -112,6 +112,50 @@ function safeInvoke(dotNetRef, name, ...args) {
     }
 }
 
+// Tracks which dotNetRefs have a working canonical OnUpdate handler so the
+// rich-text content-update path doesn't probe twice per keystroke. Filled
+// the first time invokeContentUpdate sees a NotFound rejection for OnUpdate
+// on a given ref. Bounded — entries live for the lifetime of the dotNetRef,
+// which the .NET side disposes when the component disposes.
+const _noCanonicalOnUpdate = new WeakSet();
+
+// Calls the .NET-side content-update handler. The bundled RichTextEditor
+// implements both OnUpdate (canonical) and OnContentUpdate (legacy alias),
+// where the alias forwards to the canonical — so firing BOTH would run
+// every keystroke's ValueChanged twice (Codex review on #97). External
+// consumers that wired RichTextInitAsync<T> with their own
+// DotNetObjectReference may implement only the legacy OnContentUpdate.
+// Strategy: invoke OnUpdate first. If the .NET runtime rejects with
+// 'method not found', remember this ref and fall back to OnContentUpdate
+// for it (and every subsequent call) so we don't pay the failed-probe
+// cost per keystroke.
+function invokeContentUpdate(dotNetRef, html) {
+    if (_noCanonicalOnUpdate.has(dotNetRef)) {
+        safeInvoke(dotNetRef, 'OnContentUpdate', html);
+        return;
+    }
+    try {
+        const p = dotNetRef.invokeMethodAsync('OnUpdate', html);
+        if (p && typeof p.catch === 'function') {
+            p.catch((err) => {
+                const msg = err && err.message ? err.message : String(err || '');
+                // Blazor's missing-invokable message contains the method name
+                // plus "was not found". Other failures (network, throw in the
+                // consumer handler) should NOT trigger the fallback — those
+                // mean the canonical IS wired, it just failed once.
+                if (msg.indexOf("'OnUpdate'") !== -1 && msg.indexOf('not found') !== -1) {
+                    _noCanonicalOnUpdate.add(dotNetRef);
+                    safeInvoke(dotNetRef, 'OnContentUpdate', html);
+                }
+            });
+        }
+    } catch (_) {
+        // Synchronous throw on invokeMethodAsync (very rare; dotNetRef
+        // disposed mid-call). Best-effort fallback.
+        safeInvoke(dotNetRef, 'OnContentUpdate', html);
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Suggestion-list popup (used by mentions, slash commands, custom triggers).
 // Renders a styled floating list near the trigger caret. Keyboard nav is
@@ -927,21 +971,15 @@ export const rte = {
                             // Soft cap — emit the overflow but consumers can trim.
                         }
                     }
-                    // Fire BOTH OnUpdate (canonical) and OnContentUpdate
-                    // (legacy alias). The built-in RichTextEditor maps
-                    // OnUpdate → OnContentUpdate internally so the second
-                    // call is technically redundant for the bundled
-                    // component — BUT consumers using the public
-                    // RichTextInitAsync<T> surface with their own
-                    // DotNetObjectReference<T> may only implement
-                    // [JSInvokable] OnContentUpdate (the older name).
-                    // Firing only OnUpdate broke those external integrations
-                    // silently because safeInvoke catches the missing-method
-                    // error and swallows it (Codex #92 review). Keep both
-                    // until the alias can be officially deprecated with a
-                    // migration release note.
-                    safeInvoke(dotNetRef, 'OnUpdate', html);
-                    safeInvoke(dotNetRef, 'OnContentUpdate', html);
+                    // Single round-trip per keystroke via invokeContentUpdate:
+                    // tries OnUpdate (canonical) first, falls back to the
+                    // legacy OnContentUpdate only when the .NET ref doesn't
+                    // implement OnUpdate (external RichTextInitAsync<T>
+                    // consumers). Built-in RichTextEditor has OnUpdate so
+                    // OnContentUpdate (its alias) is NOT called a second
+                    // time — fixes the duplicate ValueChanged per keystroke
+                    // Codex review flagged on #97.
+                    invokeContentUpdate(dotNetRef, html);
                 },
                 onSelectionUpdate: () => {
                     safeInvoke(dotNetRef, 'OnSelectionUpdate');

--- a/src/Lumeo.SourceGenerators/LumeoFormGenerator.cs
+++ b/src/Lumeo.SourceGenerators/LumeoFormGenerator.cs
@@ -301,7 +301,15 @@ public sealed class LumeoFormGenerator : IIncrementalGenerator
         // (string?, MyClass?) and nullable value types (int?, double?). For
         // value types we additionally accept Nullable<T> in case the property
         // is declared with the full generic name rather than the ? shorthand.
-        var isNullable = type.NullableAnnotation == NullableAnnotation.Annotated
+        //
+        // NullableAnnotation.None — oblivious context (file/project compiled
+        // without <Nullable>enable</Nullable>) — must also be treated as
+        // nullable. In oblivious code, `string` is legally null and consumer
+        // models commonly use null as the "cleared" sentinel; coalescing to
+        // "" would change that on every input clear and break legacy data
+        // models (Codex #83 review). Only treat as non-nullable when the
+        // compiler explicitly says NotAnnotated.
+        var isNullable = type.NullableAnnotation != NullableAnnotation.NotAnnotated
             || (type is INamedTypeSymbol nt && nt.IsGenericType
                 && nt.ConstructedFrom.SpecialType == SpecialType.System_Nullable_T);
 

--- a/src/Lumeo/Size.cs
+++ b/src/Lumeo/Size.cs
@@ -19,22 +19,29 @@ namespace Lumeo;
 /// </remarks>
 public enum Size
 {
+    // Backing values pinned explicitly so future additions cannot silently
+    // re-number the existing members. Consumers that persist Lumeo.Size via
+    // ints (e.g. as ASP.NET TempData, EF column, Razor query string) get a
+    // stable mapping across upgrades. Append new values at the end with a
+    // fresh number; never insert in the middle.
+    /// <summary>Extra small. Used by <c>Icon</c>.</summary>
+    Xs = 0,
+    /// <summary>Small. Used by most sized components (Avatar, Chip, Input, etc.).</summary>
+    Sm = 1,
+    /// <summary>Medium / default. The neutral middle value for every sized component.</summary>
+    Md = 2,
+    /// <summary>Large. Used by most sized components.</summary>
+    Lg = 3,
+    /// <summary>Extra large. Used by <c>Avatar</c>, <c>Icon</c>.</summary>
+    Xl = 4,
+    /// <summary>2x extra large. Reserved for future use.</summary>
+    Xxl = 5,
     /// <summary>Double extra small. For dense-mode <c>Avatar</c> / <c>Chip</c>
     /// where a smaller indicator is needed (e.g. inline-with-text presence
     /// dot, stacked-avatar list previews). Replaces consumer-side
     /// <c>text-[10px]</c> / <c>h-5 w-5</c> arbitrary-value Tailwind escape
-    /// hatches with a first-class token.</summary>
-    Xxs,
-    /// <summary>Extra small. Used by <c>Icon</c>.</summary>
-    Xs,
-    /// <summary>Small. Used by most sized components (Avatar, Chip, Input, etc.).</summary>
-    Sm,
-    /// <summary>Medium / default. The neutral middle value for every sized component.</summary>
-    Md,
-    /// <summary>Large. Used by most sized components.</summary>
-    Lg,
-    /// <summary>Extra large. Used by <c>Avatar</c>, <c>Icon</c>.</summary>
-    Xl,
-    /// <summary>2x extra large. Reserved for future use.</summary>
-    Xxl,
+    /// hatches with a first-class token. Added in 3.3; appended at value 6
+    /// instead of inserted before <see cref="Xs"/> so existing serialised
+    /// ints (Sm=1, Md=2, …) still resolve to the same enum member.</summary>
+    Xxs = 6,
 }

--- a/src/Lumeo/UI/Cascader/Cascader.razor
+++ b/src/Lumeo/UI/Cascader/Cascader.razor
@@ -129,6 +129,15 @@
     // OnParametersSet doesn't rebuild the trail on every parent re-render —
     // it should only respond when Value actually changes from outside.
     private List<string>? _lastSyncedValue;
+    // Tracks the Options reference last synced. When async-loaded options
+    // arrive after the Value parameter was already set, the value-based
+    // guard alone would skip the rebuild and leave _selectedPath /
+    // _activePanels empty — the trigger label would update via
+    // SelectedLabels but opening the picker would land on the root with
+    // no drill-down trail. Tracking Options separately lets us re-resolve
+    // the trail once the options it refers to actually exist (Codex #81
+    // review).
+    private IReadOnlyList<CascaderOption>? _lastSyncedOptions;
     private readonly string _wrapperId = LumeoIds.New("cascader");
     private readonly string _triggerId = LumeoIds.New("cascader-trigger");
     private readonly string _contentId = LumeoIds.New("cascader-content");
@@ -158,13 +167,21 @@
 
     protected override void OnParametersSet()
     {
-        // Skip rebuilds when Value didn't change since last sync. Without
-        // this guard, any parent re-render (an unrelated sibling typing in
-        // a search box, a parent route change, etc.) would collapse the
-        // user's in-progress drill-down back to the Value-mandated path
-        // even though Value itself wasn't touched.
-        if (ValueEquals(_lastSyncedValue, Value)) return;
+        // Skip rebuilds when neither Value NOR Options changed since the
+        // last sync. Without this guard, any parent re-render (unrelated
+        // sibling typing in a search box, parent route change, etc.) would
+        // collapse the user's in-progress drill-down back to the
+        // Value-mandated path even though nothing relevant changed.
+        // Tracking Options separately matters because async-loaded
+        // option trees often arrive AFTER Value has already been set —
+        // without the Options check the rebuild gets skipped on that
+        // arrival, and opening the picker still uses the empty panel
+        // trail until Value changes again (Codex #81 review).
+        var valueChanged = !ValueEquals(_lastSyncedValue, Value);
+        var optionsChanged = !ReferenceEquals(_lastSyncedOptions, Options);
+        if (!valueChanged && !optionsChanged) return;
         _lastSyncedValue = Value is null ? null : new List<string>(Value);
+        _lastSyncedOptions = Options;
 
         if (Value is { Count: > 0 })
         {

--- a/src/Lumeo/UI/ColorPicker/ColorPicker.razor
+++ b/src/Lumeo/UI/ColorPicker/ColorPicker.razor
@@ -348,11 +348,66 @@
         if (_registered) await Cleanup();
     }
 
-    private void SyncStateFromHex(string hex)
+    // Parses both hex (#RGB / #RRGGBB / #RRGGBBAA) and rgba(r,g,b[,a]) into
+    // the component's r/g/b/h/s/v/alpha state. Without rgba() handling, a
+    // saved Value emitted by the alpha slider (which writes 'rgba(...)' when
+    // ShowAlpha + alpha<100) couldn't round-trip on remount — the trigger
+    // text showed the rgba string while the internal state fell back to
+    // black/100%, so the preview and the next slider edit corrupted the
+    // saved color (Codex #78 review).
+    private void SyncStateFromHex(string value)
     {
-        if (!TryParseHex(hex, out var r, out var g, out var b)) return;
-        _r = r; _g = g; _b = b;
-        (_h, _s, _v) = RgbToHsv(r, g, b);
+        if (TryParseHex(value, out var hr, out var hg, out var hb))
+        {
+            _r = hr; _g = hg; _b = hb;
+            (_h, _s, _v) = RgbToHsv(_r, _g, _b);
+            // Hex with alpha pair (#RRGGBBAA) updates alpha; plain hex
+            // leaves the existing _alpha untouched so a consumer toggling
+            // between hex strings doesn't reset the slider.
+            if (value.Length == 9 && int.TryParse(value.AsSpan(7, 2), System.Globalization.NumberStyles.HexNumber, null, out var ah))
+            {
+                _alpha = (int)Math.Round(ah / 255.0 * 100.0);
+            }
+            return;
+        }
+
+        if (TryParseRgba(value, out var rr, out var rg, out var rb, out var ra))
+        {
+            _r = rr; _g = rg; _b = rb;
+            (_h, _s, _v) = RgbToHsv(_r, _g, _b);
+            _alpha = ra;
+        }
+    }
+
+    // Accepts 'rgba(r,g,b[,a])' / 'rgb(r,g,b)' with whitespace tolerance.
+    // Alpha is the 0.0–1.0 CSS form; we convert to 0–100 to match the
+    // component's internal scale.
+    private static bool TryParseRgba(string value, out int r, out int g, out int b, out int alphaPct)
+    {
+        r = g = b = 0;
+        alphaPct = 100;
+        if (string.IsNullOrEmpty(value)) return false;
+        var open = value.IndexOf('(');
+        var close = value.IndexOf(')');
+        if (open <= 0 || close <= open) return false;
+        var prefix = value[..open].Trim().ToLowerInvariant();
+        if (prefix != "rgb" && prefix != "rgba") return false;
+
+        var parts = value[(open + 1)..close].Split(',');
+        if (parts.Length < 3 || parts.Length > 4) return false;
+
+        if (!int.TryParse(parts[0].Trim(), System.Globalization.NumberStyles.Integer, System.Globalization.CultureInfo.InvariantCulture, out r)) return false;
+        if (!int.TryParse(parts[1].Trim(), System.Globalization.NumberStyles.Integer, System.Globalization.CultureInfo.InvariantCulture, out g)) return false;
+        if (!int.TryParse(parts[2].Trim(), System.Globalization.NumberStyles.Integer, System.Globalization.CultureInfo.InvariantCulture, out b)) return false;
+        r = Math.Clamp(r, 0, 255);
+        g = Math.Clamp(g, 0, 255);
+        b = Math.Clamp(b, 0, 255);
+
+        if (parts.Length == 4 && double.TryParse(parts[3].Trim(), System.Globalization.NumberStyles.Float, System.Globalization.CultureInfo.InvariantCulture, out var a))
+        {
+            alphaPct = (int)Math.Round(Math.Clamp(a, 0.0, 1.0) * 100.0);
+        }
+        return true;
     }
 
     private static bool IsValidHex(string hex)

--- a/src/Lumeo/UI/Input/Input.razor
+++ b/src/Lumeo/UI/Input/Input.razor
@@ -13,7 +13,16 @@
 
 @if (Prefix != null || Suffix != null || Variant == InputVariant.Search || (Clearable && !string.IsNullOrEmpty(Value)))
 {
-    <div class="@WrapperClass" @attributes="AdditionalAttributes">
+    @* AdditionalAttributes splat goes on the <input>, not the wrapper div,
+       so consumer-passed placeholder / id / autocomplete / aria-label
+       reach the actual focusable element. The wrapper has no
+       @attributes binding — anything wrapper-targeted (z-index, data-*
+       for the visual container) belongs in Class instead. Without this
+       routing the Search variant — which forces this wrapper branch
+       even for plain `<Input Variant=Search Placeholder="…" />` —
+       silently dropped Placeholder onto the div where it has no
+       effect (Codex #95 review). *@
+    <div class="@WrapperClass">
         @if (Variant == InputVariant.Search && Prefix == null)
         {
             <div class="flex items-center ps-3 pe-1 text-muted-foreground">
@@ -29,7 +38,7 @@
                type="@(Variant == InputVariant.Search ? "search" : null)"
                aria-required="@Required.ToString().ToLowerInvariant()"
                aria-invalid="@EffectiveInvalid.ToString().ToLowerInvariant()"
-               class="@WrappedInputClass" value="@Value" @oninput="HandleInput" disabled="@Disabled" />
+               class="@WrappedInputClass" value="@Value" @oninput="HandleInput" disabled="@Disabled" @attributes="AdditionalAttributes" />
         @if (Clearable && !string.IsNullOrEmpty(Value))
         {
             <button type="button" class="flex items-center px-2 text-muted-foreground hover:text-foreground transition-colors" @onclick="HandleClear" tabindex="-1" aria-label="@L["Common.Clear"]">

--- a/src/Lumeo/UI/Overlay/OverlayProvider.razor
+++ b/src/Lumeo/UI/Overlay/OverlayProvider.razor
@@ -177,18 +177,32 @@
 
     // Composes the Class string passed to the inner Dialog/Sheet/Drawer
     // content. When MobileFullscreen + viewport is below MobileBreakpoint,
-    // appends the override classes that previously consumers had to ship
-    // themselves (max-md:!h-full max-md:!w-full max-md:!max-w-full
-    // max-md:!rounded-none). We don't need the max-md: prefix because the
-    // provider already knows it's mobile via IsMobile() — the classes
-    // apply unconditionally at the moment of render. Order matters: the
-    // consumer's own Class wins for unrelated tokens, the fullscreen
-    // tokens are appended after so they override the component's defaults.
+    // appends the override classes that consumers previously shipped
+    // themselves (max-md:!h-full max-md:!w-full …).
+    //
+    // We don't need the max-md: prefix because the provider already gates
+    // by viewport via IsMobile(); the classes apply unconditionally at
+    // render time and flip out when the breakpoint crosses. BUT we DO
+    // need Tailwind's `!important` variant on every token: Tailwind
+    // utility precedence comes from the generated stylesheet order, not
+    // the class-attribute order. In the shipped lumeo-utilities.css,
+    // SheetContent's `sm:max-w-sm` / `max-w-lg` and side-specific
+    // rounded utilities are emitted *after* `.max-w-full` and
+    // `.rounded-none`, so the non-important fullscreen tokens lose
+    // against the defaults in the 640–767px range — dialogs stayed
+    // capped at max-w-lg, sheets at sm:max-w-sm, corners stayed
+    // rounded. The `!` prefix makes Tailwind emit the rule as
+    // !important, restoring the override-chain behaviour consumers got
+    // from their hand-rolled `max-md:!…` classes (Codex #91 review).
+    //
+    // Trim()s the final string so an opts.Class with trailing/leading
+    // whitespace doesn't end up with double spaces in the rendered
+    // class attribute.
     private string? EffectiveClass(OverlayOptions opts)
     {
         if (!IsMobile(opts) || !opts.MobileFullscreen) return opts.Class;
-        const string fs = "h-full w-full max-w-full max-h-full rounded-none";
-        return string.IsNullOrEmpty(opts.Class) ? fs : $"{opts.Class} {fs}";
+        const string fs = "!h-full !w-full !max-w-full !max-h-full !rounded-none";
+        return (string.IsNullOrEmpty(opts.Class) ? fs : $"{opts.Class} {fs}").Trim();
     }
 
     private void HandleShow(OverlayInstance instance)

--- a/src/Lumeo/UI/Splitter/SplitterDivider.razor
+++ b/src/Lumeo/UI/Splitter/SplitterDivider.razor
@@ -3,7 +3,7 @@
 
 <div id="@_dividerId"
      role="separator"
-     aria-orientation="@(IsHorizontal ? "horizontal" : "vertical")"
+     aria-orientation="@(IsHorizontal ? "vertical" : "horizontal")"
      tabindex="0"
      class="@CssClass"
      @onpointerdown="OnPointerDown"


### PR DESCRIPTION
## Summary
Sweep of unresolved Codex / CodeRabbit review comments across the 3.3.0-track PRs. Most were valid, batched here so they ship together. After merge → 3.3.0 release.

## Per-PR findings addressed

### #49 — SplitterDivider `aria-orientation` inverted (P2)
`IsHorizontal` means panes are in a **row** which renders a **vertical** divider. `aria-orientation` describes the line's axis, so the mapping was reversed. Inverted to `IsHorizontal ? "vertical" : "horizontal"`.

### #50 — Lazy-load coverage gaps (P1 + P2 + 2 doc fixes)
- **P1**: `/components/file-viewer` loaded only `Lumeo.FileViewer.dll`. FileViewer dispatches to `CodeEditor` and `PdfViewer` based on kind — both lazy in #50 — so direct nav hit missing-assembly errors. Added them to the route entry.
- **P2**: The eight non-Lucide icon packs were only mapped to `/components/icon`, but CustomizerSidebar (mounted on every docs page) opens an IconPreview picker that references them. Preload via `LazyAssemblyLoader` in CustomizerSidebar's `OnAfterRenderAsync(firstRender)`.
- Misleading "we swallow here" comment that preceded a `throw;` — clarified.
- "7 icon packs" comment in csproj → "8".

### #77 — GaugeChart `Min==Max` empty arc (P2)
ECharts color stops are END positions; collapsing to 0 covered nothing. Now emits a single terminal stop at 1.0 using the first range's color → solid-color arc.

### #78 — ColorPicker rgba round-trip (P2)
`SyncStateFromHex` only parsed hex; emitted `rgba(...)` values couldn't round-trip on remount. Extended parser to accept `rgba(r,g,b[,a])` and `#RRGGBBAA`.

### #81 — Cascader didn't rebuild when Options arrived late (P2)
The drill-down preservation guard compared only Value. Late-arriving async Options left the panel trail empty. Now also tracks `_lastSyncedOptions`.

### #83 — SourceGen oblivious-string nullability (P2)
Treating `NullableAnnotation.None` (oblivious context) as not-nullable forced cleared inputs to "" instead of null — breaking legacy models. Now: nullable unless explicitly `NotAnnotated`.

### #91 — OverlayProvider MobileFullscreen utilities lose Tailwind precedence (P2 + Trim)
SheetContent's default `sm:max-w-sm` / `max-w-lg` / `rounded-*` are emitted after the override classes, so non-important `h-full max-w-full rounded-none` lost the cascade at 640–767px. Prefixed every override with `!`. Also added `.Trim()` to the concat result.

### #92 — RichTextEditor lost `OnContentUpdate` for external callers (P2)
Reverted the keystroke-path optimisation. Consumers using `RichTextInitAsync<T>` with their own `DotNetObjectReference` implementing only the legacy `OnContentUpdate` stopped receiving edits silently. JS now fires both names until the alias is officially deprecated.

### #94 — Size enum backing values shifted (P2)
Inserting `Xxs` at position 0 silently renumbered every member — bin-compat break for persisted ints. Pinned `Xs..Xxl = 0..5` explicit, moved `Xxs` to position 6 (appended).

### #95 — Input.Variant=Search dropped `AdditionalAttributes` (P2)
The wrapper-branch `<div>` received `@attributes` splat. Search variant forced every plain search field through that branch, so consumer-passed `placeholder` / `id` / `aria-label` landed on the wrapper. Moved `@attributes` to the `<input>` in the wrapper branch.

### #96 — out of scope
`ButtonSize.Icon` fallthrough was already fixed on the in-flight #96 branch; not re-applied here.

## Test plan
- [ ] CI green.
- [ ] Manual sanity:
  - Splitter resize handle on a horizontal-orientation Splitter reports `aria-orientation="vertical"` in DevTools.
  - Navigate directly to `/components/file-viewer` → demo files render without missing-assembly errors.
  - Open customizer sidebar's icon-library picker on `/components/button` → no errors.
  - GaugeChart with `Min == Max == 50` and a single Range renders a solid-color arc.
  - ColorPicker with `Value="rgba(255,0,0,0.5)"` initial state shows the right color + 50% alpha slider.
  - Cascader with `Value="..."` set before async Options arrive: opening the picker drills down correctly.
  - Mobile-viewport (`<768px`) overlay with `MobileFullscreen=true` actually fills the viewport.
  - RichTextEditor consumers that wired only `[JSInvokable] OnContentUpdate` still receive edits.
  - `<Input Variant="Search" Placeholder="…" />` shows the placeholder on the actual input.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LJmBFYeCdQj2G2epoZaRzQ)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Color picker now supports CSS `rgb()` and `rgba()` color formats alongside hex.
  * Icon picker includes lazy-loading optimization for faster performance.

* **Bug Fixes**
  * Fixed gauge chart rendering for edge cases.
  * Cascader selection no longer collapses when parent options update.
  * Input component attributes now correctly target input elements.
  * Fixed overlay fullscreen behavior on mobile devices.
  * Corrected splitter divider accessibility labeling.

* **Improvements**
  * Enhanced form generation nullability detection.
  * Rich text editor maintains backward compatibility with older integrations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Brain2k-0005/Lumeo/pull/97?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->