### PR TITLE
fix: Tour UpdateTargetRect race + ConsentBanner preferences-dialog focus

### DIFF
--- a/src/Lumeo/UI/ConsentBanner/ConsentBanner.razor
+++ b/src/Lumeo/UI/ConsentBanner/ConsentBanner.razor
@@ -99,7 +99,8 @@
                         @onclick="RejectAll">
                     @RejectLabel
                 </button>
-                <button type="button"
+                <button @ref="_prefSaveButtonRef"
+                        type="button"
                         class="inline-flex items-center justify-center rounded-md text-xs font-medium h-8 px-3 bg-primary text-primary-foreground hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-[1.5px] focus-visible:ring-ring focus-visible:ring-offset-2"
                         @onclick="SavePreferences">
                     @SaveLabel
@@ -146,6 +147,14 @@
 
     private bool _ready;
     private bool _preferencesOpen;
+    private ElementReference _prefSaveButtonRef;
+    // Set when OpenPreferences flips _preferencesOpen → true. OnAfterRender
+    // consumes it once the dialog is in the DOM and focuses the Save
+    // button. Without this, opening the preferences dialog left focus on
+    // the underlying page so keyboard-only users had to Tab through
+    // background content to reach the dialog — failing the modal-focus
+    // expectation set by aria-modal="true" on the wrapper.
+    private bool _shouldFocusPrefsOnRender;
     private Dictionary<string, bool> _draft = new(StringComparer.OrdinalIgnoreCase);
 
     protected override void OnInitialized()
@@ -162,15 +171,25 @@
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
-        if (!firstRender) return;
-        try
+        if (firstRender)
         {
-            await Consent.EnsureLoadedAsync();
-            _ready = true;
-            StateHasChanged();
+            try
+            {
+                await Consent.EnsureLoadedAsync();
+                _ready = true;
+                StateHasChanged();
+            }
+            catch (JSDisconnectedException) { }
+            catch (ObjectDisposedException) { }
         }
-        catch (JSDisconnectedException) { }
-        catch (ObjectDisposedException) { }
+
+        if (_shouldFocusPrefsOnRender)
+        {
+            _shouldFocusPrefsOnRender = false;
+            try { await _prefSaveButtonRef.FocusAsync(); }
+            catch (JSDisconnectedException) { }
+            catch (InvalidOperationException) { /* ref not yet bound — preferences dialog wasn't rendered this pass */ }
+        }
     }
 
     private void HandleConsentChange() => InvokeAsync(StateHasChanged);
@@ -192,6 +211,7 @@
         // Seed the draft from current consent so the toggles reflect reality.
         _draft = Categories.ToDictionary(c => c.Key, c => c.Required || Consent.HasConsent(c.Key), StringComparer.OrdinalIgnoreCase);
         _preferencesOpen = true;
+        _shouldFocusPrefsOnRender = true;
     }
 
     /// <summary>Public entry point so a "Manage cookie preferences" link anywhere in the layout can reopen the dialog.</summary>

--- a/src/Lumeo/UI/Tour/Tour.razor
+++ b/src/Lumeo/UI/Tour/Tour.razor
@@ -162,20 +162,29 @@
         }
     }
 
+    // Sequence stamp for UpdateTargetRect calls. Bumped on every entry;
+    // the awaited fetch checks the stamp on resolve to drop stale results.
+    private int _rectFetchSeq;
+
     private async Task UpdateTargetRect()
     {
         var selector = _currentStepConfig?.TargetSelector;
         if (selector == _currentTargetSelector) return; // Already positioned for this step
         _currentTargetSelector = selector;
-        if (selector is not null)
-        {
-            _targetRect = await Interop.GetElementRectBySelector(selector);
-        }
-        else
-        {
-            _targetRect = null;
-        }
-        StateHasChanged(); // Safe: only fires when selector changes, not on every render
+        // Race fix: if a second UpdateTargetRect fires while this call is
+        // awaiting GetElementRectBySelector (parent advances CurrentStep
+        // mid-flight, or HandleNext / HandlePrevious overlap), the later
+        // call bumps _rectFetchSeq and wins. Without this guard the
+        // earlier resolution overwrote _targetRect with the previous
+        // step's rect AFTER the later call had already committed the
+        // right rect — spotlight stuck on the wrong target for a render.
+        var stamp = ++_rectFetchSeq;
+        var newRect = selector is not null
+            ? await Interop.GetElementRectBySelector(selector)
+            : null;
+        if (stamp != _rectFetchSeq) return; // Newer call already committed.
+        _targetRect = newRect;
+        StateHasChanged();
     }
 
     private async Task HandleNext()


### PR DESCRIPTION
## Summary
Addresses #58. Three of the six items in that issue verified as false positives on re-check (`Window.DisposeAsync` — no persistent JS state; `PopConfirm.OnConfirm/OnCancel` — already awaited; `MegaMenuTrigger` — already has `aria-haspopup`; `Popover.PreventClose` — the parameter doesn't exist at all). Two are real.

## 1. Tour — `UpdateTargetRect` stale-resolve race
When the parent advanced `CurrentStep` mid-await of `GetElementRectBySelector`, or `HandleNext` / `HandlePrevious` overlapped (rapid keypress), the earlier resolution wrote `_targetRect` AFTER the later call had already committed the right rect — the highlight spotlight landed on the wrong target for one render.

Fix: `_rectFetchSeq` bump per call, captured stamp before the await, drop the assignment on stale resolution. Same pattern editor / map satellites use.

## 2. ConsentBanner — focus didn't move into preferences dialog
`OpenPreferences` flipped `_preferencesOpen → true` but didn't move focus into the rendered dialog. With `aria-modal="true"` on the wrapper, keyboard-only users were stuck Tabbing through the underlying page to reach the dialog — failing the modal-focus expectation the role sets up.

Fix: `@ref` on the Save button, `_shouldFocusPrefsOnRender` flag in `OpenPreferences` (single entry point also used by public `ShowPreferences`), consumed in `OnAfterRenderAsync` to `FocusAsync` the button. Catches `JSDisconnectedException` and `InvalidOperationException`.

## Test plan
- [ ] CI green.
- [ ] Tour: rapid Next/Previous spam keeps spotlight on the right element (no one-frame mis-target).
- [ ] ConsentBanner: click "Manage cookie preferences" → focus lands on the Save button; Escape returns focus correctly.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LJmBFYeCdQj2G2epoZaRzQ)_