### PR TITLE
feat(a11y): disclosure aria-controls + NavMenu aria-current + ThemeToggle/QRCode/Avatar AriaLabel + Heading Level clamp

### DIFF
--- a/src/Lumeo/UI/Accordion/AccordionContent.razor
+++ b/src/Lumeo/UI/Accordion/AccordionContent.razor
@@ -1,6 +1,6 @@
 @namespace Lumeo
 
-<div role="region" class="grid transition-[grid-template-rows] duration-200 ease-out @(IsOpen ? "grid-rows-[1fr] opacity-100" : "grid-rows-[0fr] opacity-0") @CssClass" @attributes="AdditionalAttributes" aria-hidden="@(IsOpen ? "false" : "true")">
+<div id="@ItemContext.ContentId" role="region" aria-labelledby="@ItemContext.TriggerId" class="grid transition-[grid-template-rows] duration-200 ease-out @(IsOpen ? "grid-rows-[1fr] opacity-100" : "grid-rows-[0fr] opacity-0") @CssClass" @attributes="AdditionalAttributes" aria-hidden="@(IsOpen ? "false" : "true")">
     <div class="overflow-hidden min-h-0">
         <div class="pb-4 pt-0">
             @ChildContent

--- a/src/Lumeo/UI/Accordion/AccordionItem.razor
+++ b/src/Lumeo/UI/Accordion/AccordionItem.razor
@@ -1,7 +1,7 @@
 @namespace Lumeo
 
 @{
-    var itemContext = new AccordionItemContext(Value, Disabled);
+    var itemContext = new AccordionItemContext(Value, Disabled, _triggerId, _contentId);
 }
 
 <CascadingValue Value="itemContext" IsFixed="false">
@@ -17,10 +17,18 @@
     [Parameter] public string? Class { get; set; }
     [Parameter(CaptureUnmatchedValues = true)] public Dictionary<string, object>? AdditionalAttributes { get; set; }
 
+    // Stable IDs per item so AccordionTrigger can render aria-controls
+    // pointing at the AccordionContent it discloses, and the content can
+    // reflect aria-labelledby back at the trigger. Required by the
+    // disclosure pattern; without this pair the screen reader can't
+    // announce the relationship.
+    private readonly string _triggerId = LumeoIds.New("accordion-trigger");
+    private readonly string _contentId = LumeoIds.New("accordion-content");
+
     private string CssClass => Cx.Join(
         "border-b border-border/40",
         Cx.When(Disabled, "opacity-50"),
         Class);
 
-    public record AccordionItemContext(string Value, bool Disabled);
+    public record AccordionItemContext(string Value, bool Disabled, string TriggerId, string ContentId);
 }

--- a/src/Lumeo/UI/Accordion/AccordionTrigger.razor
+++ b/src/Lumeo/UI/Accordion/AccordionTrigger.razor
@@ -1,6 +1,6 @@
 @namespace Lumeo
 
-<button type="button" class="@CssClass" aria-expanded="@IsOpen" disabled="@IsDisabled" @onclick="Toggle" @attributes="AdditionalAttributes">
+<button type="button" id="@ItemContext.TriggerId" class="@CssClass" aria-expanded="@IsOpen" aria-controls="@ItemContext.ContentId" disabled="@IsDisabled" @onclick="Toggle" @attributes="AdditionalAttributes">
     @ChildContent
     <Blazicon Svg="Lucide.ChevronDown" class="@IconClasses" />
 </button>

--- a/src/Lumeo/UI/Avatar/Avatar.razor
+++ b/src/Lumeo/UI/Avatar/Avatar.razor
@@ -1,6 +1,6 @@
 @namespace Lumeo
 
-<div class="@CssClass" @attributes="AdditionalAttributes">
+<div class="@CssClass" role="@(AriaLabel is null ? null : "img")" aria-label="@AriaLabel" @attributes="AdditionalAttributes">
     <div class="@InnerClasses">
         @ChildContent
     </div>
@@ -18,6 +18,12 @@
     [Parameter] public Lumeo.Size Size { get; set; } = Lumeo.Size.Md;
     [Parameter] public AvatarShape Shape { get; set; } = AvatarShape.Circle;
     [Parameter] public AvatarStatus Status { get; set; } = AvatarStatus.None;
+    /// <summary>Accessible name announced for the avatar. When set, the
+    /// component renders <c>role="img"</c> + <c>aria-label</c> so a
+    /// screen-reader has something to read. Useful for image-only avatars
+    /// (no initials in <see cref="ChildContent"/>) where the user's name
+    /// is the meaningful AT context.</summary>
+    [Parameter] public string? AriaLabel { get; set; }
     [Parameter] public string? Class { get; set; }
     [Parameter(CaptureUnmatchedValues = true)] public Dictionary<string, object>? AdditionalAttributes { get; set; }
 

--- a/src/Lumeo/UI/Collapsible/Collapsible.razor
+++ b/src/Lumeo/UI/Collapsible/Collapsible.razor
@@ -1,7 +1,7 @@
 @namespace Lumeo
 
 @{
-    var context = new CollapsibleContext(Open, EventCallback.Factory.Create(this, Toggle));
+    var context = new CollapsibleContext(Open, EventCallback.Factory.Create(this, Toggle), _triggerId, _contentId);
 }
 
 <div class="@CssClass" @attributes="AdditionalAttributes">
@@ -24,6 +24,12 @@
     [Parameter] public string? Class { get; set; }
     [Parameter(CaptureUnmatchedValues = true)] public Dictionary<string, object>? AdditionalAttributes { get; set; }
 
+    // Stable per-instance IDs so the trigger can render
+    // aria-controls=ContentId and the content can render
+    // aria-labelledby=TriggerId. Same pattern as Accordion.
+    private readonly string _triggerId = LumeoIds.New("collapsible-trigger");
+    private readonly string _contentId = LumeoIds.New("collapsible-content");
+
     private string CssClass => $"{Class}".Trim();
 
     private async Task Toggle()
@@ -32,5 +38,5 @@
         await OpenChanged.InvokeAsync(Open);
     }
 
-    public record CollapsibleContext(bool IsOpen, EventCallback Toggle);
+    public record CollapsibleContext(bool IsOpen, EventCallback Toggle, string TriggerId, string ContentId);
 }

--- a/src/Lumeo/UI/Collapsible/CollapsibleContent.razor
+++ b/src/Lumeo/UI/Collapsible/CollapsibleContent.razor
@@ -1,6 +1,6 @@
 @namespace Lumeo
 
-<div role="region" class="grid transition-[grid-template-rows] duration-200 ease-out @(Context.IsOpen ? "grid-rows-[1fr] opacity-100" : "grid-rows-[0fr] opacity-0") @CssClass" @attributes="AdditionalAttributes" aria-hidden="@(Context.IsOpen ? "false" : "true")">
+<div id="@Context.ContentId" role="region" aria-labelledby="@Context.TriggerId" class="grid transition-[grid-template-rows] duration-200 ease-out @(Context.IsOpen ? "grid-rows-[1fr] opacity-100" : "grid-rows-[0fr] opacity-0") @CssClass" @attributes="AdditionalAttributes" aria-hidden="@(Context.IsOpen ? "false" : "true")">
     <div class="overflow-hidden min-h-0">
         @ChildContent
     </div>

--- a/src/Lumeo/UI/Collapsible/CollapsibleTrigger.razor
+++ b/src/Lumeo/UI/Collapsible/CollapsibleTrigger.razor
@@ -1,6 +1,6 @@
 @namespace Lumeo
 
-<div class="@CssClass" role="button" tabindex="0" aria-expanded="@Context.IsOpen" @onclick="Context.Toggle" @onkeydown="HandleKeyDown" @attributes="AdditionalAttributes">
+<div id="@Context.TriggerId" class="@CssClass" role="button" tabindex="0" aria-expanded="@Context.IsOpen" aria-controls="@Context.ContentId" @onclick="Context.Toggle" @onkeydown="HandleKeyDown" @attributes="AdditionalAttributes">
     @ChildContent
 </div>
 

--- a/src/Lumeo/UI/Heading/Heading.razor
+++ b/src/Lumeo/UI/Heading/Heading.razor
@@ -1,6 +1,11 @@
 @namespace Lumeo
 
-@switch (Level)
+@* Level is clamped to [1..6] so an accidental Level=0 / Level=42 still
+   renders a real <h*> instead of dropping into the default <h6> tag
+   silently. The clamp drives both the rendered tag AND the visual size
+   below, so the two stay consistent (a Level=0 input doesn't render as
+   an h6 with h1 sizing). *@
+@switch (ClampedLevel)
 {
     case 1:
         <h1 class="@CssClass" @attributes="AdditionalAttributes">@ChildContent</h1>
@@ -31,7 +36,9 @@
     [Parameter] public string? Class { get; set; }
     [Parameter(CaptureUnmatchedValues = true)] public Dictionary<string, object>? AdditionalAttributes { get; set; }
 
-    private string ResolvedSize => Size ?? Level switch
+    private int ClampedLevel => Math.Clamp(Level, 1, 6);
+
+    private string ResolvedSize => Size ?? ClampedLevel switch
     {
         1 => "4xl",
         2 => "3xl",
@@ -41,14 +48,14 @@
         _ => "base"
     };
 
-    private string ResolvedWeight => Weight ?? Level switch
+    private string ResolvedWeight => Weight ?? ClampedLevel switch
     {
         1 or 2 => "bold",
         3 or 4 => "semibold",
         _ => "medium"
     };
 
-    private string? ResolvedTracking => Tracking ?? Level switch
+    private string? ResolvedTracking => Tracking ?? ClampedLevel switch
     {
         1 or 2 => "tight",
         _ => null

--- a/src/Lumeo/UI/NavigationMenu/NavigationMenuLink.razor
+++ b/src/Lumeo/UI/NavigationMenu/NavigationMenuLink.razor
@@ -1,12 +1,16 @@
 @namespace Lumeo
 
-<a href="@Href" class="@CssClass" @onclick="HandleClick" @attributes="AdditionalAttributes">
+<a href="@Href" class="@CssClass" aria-current="@(IsActive ? "page" : null)" @onclick="HandleClick" @attributes="AdditionalAttributes">
     @ChildContent
 </a>
 
 @code {
     [CascadingParameter] public NavigationMenu.NavigationMenuContext Context { get; set; } = default!;
     [Parameter] public string? Href { get; set; }
+    /// <summary>When true, the link is the user's current location and is
+    /// rendered with <c>aria-current="page"</c>. Lets screen-reader users
+    /// identify the active item in a nav landmark.</summary>
+    [Parameter] public bool IsActive { get; set; }
     [Parameter] public RenderFragment? ChildContent { get; set; }
     [Parameter] public string? Class { get; set; }
     [Parameter(CaptureUnmatchedValues = true)] public Dictionary<string, object>? AdditionalAttributes { get; set; }

--- a/src/Lumeo/UI/QRCode/QRCode.razor
+++ b/src/Lumeo/UI/QRCode/QRCode.razor
@@ -1,7 +1,7 @@
 @namespace Lumeo
 
-<div class="@ContainerClass" style="@ContainerStyle" @attributes="AdditionalAttributes">
-    <svg viewBox="@ViewBox" xmlns="http://www.w3.org/2000/svg" style="display: block; width: 100%; height: 100%;">
+<div class="@ContainerClass" style="@ContainerStyle" role="img" aria-label="@(AriaLabel ?? $"QR code: {Value}")" @attributes="AdditionalAttributes">
+    <svg viewBox="@ViewBox" xmlns="http://www.w3.org/2000/svg" style="display: block; width: 100%; height: 100%;" aria-hidden="true">
         <rect x="0" y="0" width="@_totalSize" height="@_totalSize" fill="@BackgroundColor" />
         @if (_darkModules is not null)
         {
@@ -30,6 +30,11 @@
     [Parameter] public bool IncludeMargin { get; set; } = true;
     [Parameter] public string? ImageSrc { get; set; }
     [Parameter] public int ImageSize { get; set; } = 40;
+    /// <summary>Override the accessible label announced for the QR code.
+    /// Defaults to <c>"QR code: {Value}"</c>. Useful when the encoded
+    /// payload is a long URL or technical string the user doesn't need
+    /// read out — pass a human-friendly description instead.</summary>
+    [Parameter] public string? AriaLabel { get; set; }
     [Parameter] public string? Class { get; set; }
     [Parameter(CaptureUnmatchedValues = true)] public Dictionary<string, object>? AdditionalAttributes { get; set; }
 

--- a/src/Lumeo/UI/ThemeToggle/ThemeToggle.razor
+++ b/src/Lumeo/UI/ThemeToggle/ThemeToggle.razor
@@ -5,17 +5,20 @@
 @inject ThemeService Theme
 @inject Lumeo.Services.Localization.ILumeoLocalizer L
 
-<button class="inline-flex items-center justify-center h-9 w-9 cursor-pointer rounded-md border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+<button type="button"
+        class="inline-flex items-center justify-center h-9 w-9 cursor-pointer rounded-md border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
         @onclick="ToggleTheme"
         title="@L["Theme.Toggle"]"
+        aria-label="@L["Theme.Toggle"]"
+        aria-pressed="@_isDark.ToString().ToLowerInvariant()"
         @attributes="AdditionalAttributes">
     @if (_isDark)
     {
-        <Blazicon Svg="Lucide.Sun" class="h-4 w-4" />
+        <Blazicon Svg="Lucide.Sun" class="h-4 w-4" aria-hidden="true" />
     }
     else
     {
-        <Blazicon Svg="Lucide.Moon" class="h-4 w-4" />
+        <Blazicon Svg="Lucide.Moon" class="h-4 w-4" aria-hidden="true" />
     }
 </button>
 


### PR DESCRIPTION
## Summary
Batch from #51 / #52 / #53 / #54. Several items in those issues verified as false positives (`BreadcrumbPage` already sets `aria-current="page"`; `StepsItem` already renders `aria-current="step"` on the current step). Real fixes batched here.

## #51 — Accordion + Collapsible aria-controls + aria-labelledby
Both disclosure widgets plumb stable `TriggerId` + `ContentId` through the cascading context. `AccordionTrigger` / `CollapsibleTrigger` render `aria-controls=ContentId`, `AccordionContent` / `CollapsibleContent` render `id=ContentId` + `aria-labelledby=TriggerId`. Screen readers now announce the trigger↔region relationship.

## #52 — NavigationMenuLink IsActive
New `[Parameter] bool IsActive` renders `aria-current="page"` for the active link inside a nav landmark.

## #53 — ThemeToggle + QRCode
- **ThemeToggle**: `aria-label` + `aria-pressed` reflecting `_isDark`; inner icon `aria-hidden`.
- **QRCode**: `role="img"` + `aria-label` defaulting to `"QR code: {Value}"`. New `AriaLabel` parameter for cases where the payload shouldn't be read aloud. Inner SVG `aria-hidden`.

(ThemeSwitcher / SpeedDial / SplitButton / Toolbar overflow deferred — each needs a new L10n key per icon-only button.)

## #54 — AriaLabel param + Heading clamp
- **Avatar**: new `AriaLabel` parameter; renders `role="img"` + `aria-label` when set. Useful for image-only avatars where the user's name is the meaningful AT context but no initials live in `ChildContent`.
- **Heading**: `Math.Clamp(Level, 1, 6)` drives BOTH the rendered `<h*>` tag AND the resolved size/weight/tracking switches, so `Level=0` / `Level=42` still emit a valid heading with a consistent visual scale.

(Badge + Link AriaLabel + RingProgress/Gauge fallback labels deferred to a follow-up.)

## Test plan
- [ ] CI green.
- [ ] Accordion expand: AT announces "trigger expands {region}" with both ids resolving.
- [ ] `<NavigationMenuLink IsActive />` renders `aria-current="page"`.
- [ ] ThemeToggle in DevTools: `aria-pressed="true"` when dark, `"false"` when light.
- [ ] `<QRCode Value="...">` reads "QR code: ..." in AT; `AriaLabel="Wi-Fi join code"` overrides.
- [ ] `<Avatar AriaLabel="Jane Doe">` reads "Jane Doe" in AT.
- [ ] `<Heading Level="42" />` renders as `<h6>`; `<Heading Level="0" />` renders as `<h1>`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LJmBFYeCdQj2G2epoZaRzQ)_