### PR TITLE
perf, a11y: filter caches (#57) + Progress aria-busy on indeterminate (part of #55)

### DIFF
--- a/src/Lumeo/UI/PickList/PickList.razor
+++ b/src/Lumeo/UI/PickList/PickList.razor
@@ -149,15 +149,52 @@
         _targetSelected.RemoveWhere(i => !_targetItems.Contains(i));
     }
 
-    private List<TItem> FilteredSourceItems =>
-        string.IsNullOrWhiteSpace(_sourceSearch)
-            ? _sourceItems
-            : _sourceItems.Where(i => (i?.ToString() ?? "").Contains(_sourceSearch, StringComparison.OrdinalIgnoreCase)).ToList();
+    // Memoised filter lists. Re-run only when the source/target item list
+    // reference OR the corresponding search string changes — instead of
+    // every render. The dual-list layout reads both Filtered* properties
+    // per render, plus they're touched again inside CountClass / Move*
+    // handlers, so the previous getter-based filter was running 4-8×
+    // per parent re-render.
+    private List<TItem> _sourceFilterCache = [];
+    private List<TItem> _sourceFilterCacheBase = [];
+    private string _sourceFilterCacheTerm = "";
+    private List<TItem> _targetFilterCache = [];
+    private List<TItem> _targetFilterCacheBase = [];
+    private string _targetFilterCacheTerm = "";
 
-    private List<TItem> FilteredTargetItems =>
-        string.IsNullOrWhiteSpace(_targetSearch)
-            ? _targetItems
-            : _targetItems.Where(i => (i?.ToString() ?? "").Contains(_targetSearch, StringComparison.OrdinalIgnoreCase)).ToList();
+    private List<TItem> FilteredSourceItems
+    {
+        get
+        {
+            if (!ReferenceEquals(_sourceFilterCacheBase, _sourceItems)
+                || _sourceFilterCacheTerm != _sourceSearch)
+            {
+                _sourceFilterCacheBase = _sourceItems;
+                _sourceFilterCacheTerm = _sourceSearch;
+                _sourceFilterCache = string.IsNullOrWhiteSpace(_sourceSearch)
+                    ? _sourceItems
+                    : _sourceItems.Where(i => (i?.ToString() ?? "").Contains(_sourceSearch, StringComparison.OrdinalIgnoreCase)).ToList();
+            }
+            return _sourceFilterCache;
+        }
+    }
+
+    private List<TItem> FilteredTargetItems
+    {
+        get
+        {
+            if (!ReferenceEquals(_targetFilterCacheBase, _targetItems)
+                || _targetFilterCacheTerm != _targetSearch)
+            {
+                _targetFilterCacheBase = _targetItems;
+                _targetFilterCacheTerm = _targetSearch;
+                _targetFilterCache = string.IsNullOrWhiteSpace(_targetSearch)
+                    ? _targetItems
+                    : _targetItems.Where(i => (i?.ToString() ?? "").Contains(_targetSearch, StringComparison.OrdinalIgnoreCase)).ToList();
+            }
+            return _targetFilterCache;
+        }
+    }
 
     private void OnSourceSearch(ChangeEventArgs e) => _sourceSearch = e.Value?.ToString() ?? "";
     private void OnTargetSearch(ChangeEventArgs e) => _targetSearch = e.Value?.ToString() ?? "";

--- a/src/Lumeo/UI/Progress/Progress.razor
+++ b/src/Lumeo/UI/Progress/Progress.razor
@@ -63,7 +63,7 @@
     @if (ShowLabel)
     {
         <div class="flex items-center gap-2">
-            <div class="@CircularWrapperClass" role="progressbar" aria-valuenow="@(IsIndeterminate ? null : Value)" aria-valuemin="0" aria-valuemax="@Max" @attributes="AdditionalAttributes">
+            <div class="@CircularWrapperClass" role="progressbar" aria-valuenow="@(IsIndeterminate ? null : Value)" aria-valuemin="0" aria-valuemax="@Max" aria-busy="@IsIndeterminate.ToString().ToLowerInvariant()" @attributes="AdditionalAttributes">
                 <svg viewBox="0 0 36 36" class="@CircularSvgClass" style="@CircularSizeStyle">
                     <circle cx="18" cy="18" r="@CircularRadius" fill="none" stroke="currentColor" class="text-primary/20" stroke-width="@StrokeWidth" />
                     <circle cx="18" cy="18" r="@CircularRadius" fill="none" stroke="currentColor" class="@CircularStrokeColor"
@@ -87,7 +87,7 @@
     }
     else
     {
-        <div class="@CircularWrapperClass" role="progressbar" aria-valuenow="@(IsIndeterminate ? null : Value)" aria-valuemin="0" aria-valuemax="@Max" @attributes="AdditionalAttributes">
+        <div class="@CircularWrapperClass" role="progressbar" aria-valuenow="@(IsIndeterminate ? null : Value)" aria-valuemin="0" aria-valuemax="@Max" aria-busy="@IsIndeterminate.ToString().ToLowerInvariant()" @attributes="AdditionalAttributes">
             <svg viewBox="0 0 36 36" class="@CircularSvgClass" style="@CircularSizeStyle">
                 <circle cx="18" cy="18" r="@CircularRadius" fill="none" stroke="currentColor" class="text-primary/20" stroke-width="@StrokeWidth" />
                 <circle cx="18" cy="18" r="@CircularRadius" fill="none" stroke="currentColor" class="@CircularStrokeColor"
@@ -110,7 +110,7 @@ else
     @if (ShowLabel)
     {
         <div class="flex items-center gap-2">
-            <div class="@CssClass" role="progressbar" aria-valuenow="@(IsIndeterminate ? null : Value)" aria-valuemin="0" aria-valuemax="@Max" @attributes="AdditionalAttributes">
+            <div class="@CssClass" role="progressbar" aria-valuenow="@(IsIndeterminate ? null : Value)" aria-valuemin="0" aria-valuemax="@Max" aria-busy="@IsIndeterminate.ToString().ToLowerInvariant()" @attributes="AdditionalAttributes">
                 @if (IsIndeterminate)
                 {
                     <div class="@($"animate-progress-indeterminate rounded-[var(--radius)] {VariantClasses}")"></div>
@@ -125,7 +125,7 @@ else
     }
     else
     {
-        <div class="@CssClass" role="progressbar" aria-valuenow="@(IsIndeterminate ? null : Value)" aria-valuemin="0" aria-valuemax="@Max" @attributes="AdditionalAttributes">
+        <div class="@CssClass" role="progressbar" aria-valuenow="@(IsIndeterminate ? null : Value)" aria-valuemin="0" aria-valuemax="@Max" aria-busy="@IsIndeterminate.ToString().ToLowerInvariant()" @attributes="AdditionalAttributes">
             @if (IsIndeterminate)
             {
                 <div class="@($"animate-progress-indeterminate rounded-[var(--radius)] {VariantClasses}")"></div>

--- a/src/Lumeo/UI/TagInput/TagInput.razor
+++ b/src/Lumeo/UI/TagInput/TagInput.razor
@@ -165,17 +165,48 @@
             : GetTagText is not null ? GetTagText(item)
             : (item?.ToString() ?? "");
 
+    // Memoised filter list. Recomputed when any of (Suggestions ref,
+    // Tags ref, _inputValue, AllowDuplicates) changes. Property getter
+    // previously recomputed on every access — focus / blur / render
+    // each touched FilteredSuggestions multiple times so the LINQ ran
+    // ~3-5× per keystroke against the full Suggestions list. Cache
+    // collapses that to one recompute per actual input change.
+    private List<TItem> _filteredSuggestionsCache = [];
+    private object? _filterCacheSuggestionsRef;
+    private object? _filterCacheTagsRef;
+    private string? _filterCacheInputValue;
+    private bool _filterCacheAllowDup;
+
     private List<TItem> FilteredSuggestions
     {
         get
         {
-            if (Suggestions is null || string.IsNullOrWhiteSpace(_inputValue)) return [];
+            if (ReferenceEquals(_filterCacheSuggestionsRef, Suggestions)
+                && ReferenceEquals(_filterCacheTagsRef, Tags)
+                && string.Equals(_filterCacheInputValue, _inputValue, StringComparison.Ordinal)
+                && _filterCacheAllowDup == AllowDuplicates)
+            {
+                return _filteredSuggestionsCache;
+            }
+
+            _filterCacheSuggestionsRef = Suggestions;
+            _filterCacheTagsRef = Tags;
+            _filterCacheInputValue = _inputValue;
+            _filterCacheAllowDup = AllowDuplicates;
+
+            if (Suggestions is null || string.IsNullOrWhiteSpace(_inputValue))
+            {
+                _filteredSuggestionsCache = [];
+                return _filteredSuggestionsCache;
+            }
+
             var tags = Tags ?? [];
-            return Suggestions
+            _filteredSuggestionsCache = Suggestions
                 .Where(s => GetSuggestionTextSafe(s).Contains(_inputValue, StringComparison.OrdinalIgnoreCase)
                             && (AllowDuplicates || !tags.Any(t => EqualityComparer<TItem>.Default.Equals(t, s))))
                 .Take(8)
                 .ToList();
+            return _filteredSuggestionsCache;
         }
     }
 

--- a/src/Lumeo/UI/Transfer/Transfer.razor
+++ b/src/Lumeo/UI/Transfer/Transfer.razor
@@ -104,15 +104,56 @@
 
     private const string ButtonClass = "inline-flex items-center justify-center h-8 w-8 rounded-md border border-input bg-background hover:bg-accent hover:text-accent-foreground transition-colors focus-visible:outline-none focus-visible:ring-[1.5px] focus-visible:ring-ring focus-visible:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed";
 
-    private List<TransferItem> FilteredSourceItems =>
-        string.IsNullOrWhiteSpace(_sourceSearch)
-            ? SourceItems ?? []
-            : (SourceItems ?? []).Where(i => i.Label.Contains(_sourceSearch, StringComparison.OrdinalIgnoreCase)).ToList();
+    // Memoised filter lists. Same shape as PickList — re-run only when
+    // the input list reference OR the search term changes. The dual-list
+    // layout reads both Filtered* properties per render plus they're
+    // touched from selection-state computations, so the previous getter
+    // ran 4-8× per parent re-render. Cache collapses that to once per
+    // actual input change.
+    private List<TransferItem> _sourceFilterCache = [];
+    private List<TransferItem>? _sourceFilterCacheBase;
+    private string _sourceFilterCacheTerm = "";
+    private List<TransferItem> _targetFilterCache = [];
+    private List<TransferItem>? _targetFilterCacheBase;
+    private string _targetFilterCacheTerm = "";
 
-    private List<TransferItem> FilteredTargetItems =>
-        string.IsNullOrWhiteSpace(_targetSearch)
-            ? TargetItems ?? []
-            : (TargetItems ?? []).Where(i => i.Label.Contains(_targetSearch, StringComparison.OrdinalIgnoreCase)).ToList();
+    private List<TransferItem> FilteredSourceItems
+    {
+        get
+        {
+            if (!ReferenceEquals(_sourceFilterCacheBase, SourceItems)
+                || _sourceFilterCacheTerm != _sourceSearch)
+            {
+                _sourceFilterCacheBase = SourceItems;
+                _sourceFilterCacheTerm = _sourceSearch;
+                _sourceFilterCache = string.IsNullOrWhiteSpace(_sourceSearch)
+                    ? SourceItems ?? new List<TransferItem>()
+                    : (SourceItems ?? new List<TransferItem>())
+                        .Where(i => i.Label.Contains(_sourceSearch, StringComparison.OrdinalIgnoreCase))
+                        .ToList();
+            }
+            return _sourceFilterCache;
+        }
+    }
+
+    private List<TransferItem> FilteredTargetItems
+    {
+        get
+        {
+            if (!ReferenceEquals(_targetFilterCacheBase, TargetItems)
+                || _targetFilterCacheTerm != _targetSearch)
+            {
+                _targetFilterCacheBase = TargetItems;
+                _targetFilterCacheTerm = _targetSearch;
+                _targetFilterCache = string.IsNullOrWhiteSpace(_targetSearch)
+                    ? TargetItems ?? new List<TransferItem>()
+                    : (TargetItems ?? new List<TransferItem>())
+                        .Where(i => i.Label.Contains(_targetSearch, StringComparison.OrdinalIgnoreCase))
+                        .ToList();
+            }
+            return _targetFilterCache;
+        }
+    }
 
     private void OnSourceSearch(ChangeEventArgs e) => _sourceSearch = e.Value?.ToString() ?? "";
     private void OnTargetSearch(ChangeEventArgs e) => _targetSearch = e.Value?.ToString() ?? "";


### PR DESCRIPTION
## Summary
Closes #57. Progress aria-busy half of #55 — the Carousel slide-change live region from #55 is deferred (needs total-slide plumbing from `CarouselContent` children, larger surface change).

## #57 — Filter LINQ caches
Three components used property-getter LINQ that ran on every access. PickList / Transfer's dual-list layout reads `Filtered*` twice in markup plus again from selection / count logic — 4-8× per parent re-render. TagInput's `FilteredSuggestions` ran from focus / blur / dropdown render paths against the full Suggestions list per keystroke.

Each now memoises:
- **cache key**: input list reference + search term (+ `AllowDuplicates` for TagInput)
- returns the cached `List<T>` when the key matches
- rebuilds only on key shift

Per-keystroke / per-render cost collapses from N filter passes to one (when the input actually changed) or zero (when nothing relevant changed).

## #55 — Progress aria-busy on indeterminate
All four render branches emitted `role="progressbar" aria-valuenow="null"` when `IsIndeterminate=true`. ARIA-conformant progressbars in indeterminate state should drop `aria-valuenow` (already done — `null`) AND report `aria-busy="true"` so AT can announce "busy / loading". Added across all four branches.

## Out of scope
Carousel slide-change live region — needs `CarouselContent` to track total slide count via context. Separate focused PR.

## Test plan
- [ ] CI green.
- [ ] Type into TagInput rapidly — dropdown options recompute once per typed char, not per render.
- [ ] PickList / Transfer scroll: no jank from filter re-runs during unrelated parent re-renders.
- [ ] `<Progress IsIndeterminate="true" />` shows `aria-busy="true"` in DevTools.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LJmBFYeCdQj2G2epoZaRzQ)_