### PR TITLE
fix(js): observeAutoScroll listener + positionFixed cleanup + theme multi-tab sync (#63 leftovers)

### DIFF
--- a/src/Lumeo/wwwroot/js/components.js
+++ b/src/Lumeo/wwwroot/js/components.js
@@ -547,17 +547,26 @@ export function positionFixed(contentId, referenceId, align, matchWidth, side) {
 
     const cleanup = () => {
         cancelAnimationFrame(rafId);
-        window.removeEventListener('scroll', onScrollOrResize, { capture: true });
-        window.removeEventListener('resize', onScrollOrResize);
+        // Wrap removeEventListener in try/catch — the window object can
+        // throw in detached / cross-realm scenarios (worker hosts, MAUI
+        // Hybrid teardown), and we don't want a failure to remove one
+        // listener to skip the rest of the cleanup or the
+        // positionCleanups.delete below.
+        try { window.removeEventListener('scroll', onScrollOrResize, { capture: true }); } catch (_) {}
+        try { window.removeEventListener('resize', onScrollOrResize); } catch (_) {}
         positionCleanups.delete(contentId);
     };
     positionCleanups.set(contentId, cleanup);
 }
 
 export function unpositionFixed(contentId) {
-    if (positionCleanups.has(contentId)) {
-        positionCleanups.get(contentId)();
-    }
+    const fn = positionCleanups.get(contentId);
+    if (!fn) return;
+    // Even though cleanup() itself is now defensive, a stray exception
+    // mustn't leave the cleanup half-done — guard the call site too so
+    // a future change to the cleanup body can't take the registry into
+    // an inconsistent state.
+    try { fn(); } catch (_) { positionCleanups.delete(contentId); }
 }
 
 // --- Viewport Size ---
@@ -2297,14 +2306,24 @@ export const ai = {
         const el = document.getElementById(elementId);
         if (!el) return;
 
-        // Dispose any previous observer on the same id
+        // Tear down any previous registration on the same id — both the
+        // MutationObserver and the scroll listener.
         const prev = aiListObservers.get(elementId);
-        if (prev) prev.disconnect();
+        if (prev) {
+            prev.observer.disconnect();
+            if (prev.scrollTarget && prev.onScroll) {
+                prev.scrollTarget.removeEventListener('scroll', prev.onScroll);
+            }
+        }
 
         const isNearBottom = () => (el.scrollHeight - el.scrollTop - el.clientHeight) < 96;
         let stick = true;
 
-        el.addEventListener('scroll', () => { stick = isNearBottom(); }, { passive: true });
+        // Named handler so disposeAutoScroll can pass the same reference to
+        // removeEventListener — anonymous handlers can't be removed and
+        // would otherwise leak per element across component remounts.
+        const onScroll = () => { stick = isNearBottom(); };
+        el.addEventListener('scroll', onScroll, { passive: true });
 
         const scrollToBottom = () => {
             el.scrollTop = el.scrollHeight;
@@ -2317,15 +2336,17 @@ export const ai = {
             if (stick) scrollToBottom();
         });
         observer.observe(el, { childList: true, subtree: true, characterData: true });
-        aiListObservers.set(elementId, observer);
+        aiListObservers.set(elementId, { observer, scrollTarget: el, onScroll });
     },
 
     disposeAutoScroll(elementId) {
-        const obs = aiListObservers.get(elementId);
-        if (obs) {
-            obs.disconnect();
-            aiListObservers.delete(elementId);
+        const entry = aiListObservers.get(elementId);
+        if (!entry) return;
+        entry.observer.disconnect();
+        if (entry.scrollTarget && entry.onScroll) {
+            entry.scrollTarget.removeEventListener('scroll', entry.onScroll);
         }
+        aiListObservers.delete(elementId);
     },
 
     /* ---------- Scroll helper used by StreamingText / message list ---------- */

--- a/src/Lumeo/wwwroot/js/theme.js
+++ b/src/Lumeo/wwwroot/js/theme.js
@@ -106,31 +106,48 @@ window.themeManager = {
         } else {
             document.documentElement.classList.remove('dark');
         }
-        // Color scheme — localStorage wins; else JSON default.
+        // Color scheme — localStorage wins; else JSON default. Pattern
+        // throughout this block: explicitly REMOVE the attribute/style/class
+        // when the value is at its default before conditionally setting it.
+        // Without the remove step, init() being called a second time after
+        // a default-reset (typical: storage handler in another tab, or
+        // setScheme('zinc') in this tab) leaves the previous non-default
+        // DOM state stuck — the inverse change isn't applied because the
+        // setAttribute branch is skipped (Codex #101 review).
         const scheme = localStorage.getItem('theme-scheme') || lumeoDefault(defaults, 'theme');
         if (scheme && scheme !== 'zinc' && scheme !== '') {
             document.documentElement.setAttribute('data-theme', scheme);
+        } else {
+            document.documentElement.removeAttribute('data-theme');
         }
         // Radius
         var radius = localStorage.getItem('theme-radius');
         if (radius === null) radius = lumeoDefault(defaults, 'radius');
         if (radius !== null) {
             document.documentElement.style.setProperty('--radius', radius + 'rem');
+        } else {
+            document.documentElement.style.removeProperty('--radius');
         }
         // Style
         const style = localStorage.getItem('theme-style') || lumeoDefault(defaults, 'style');
         if (style === 'new-york') {
             document.documentElement.classList.add('style-new-york');
+        } else {
+            document.documentElement.classList.remove('style-new-york');
         }
         // Base color
         const baseColor = localStorage.getItem('theme-base-color') || lumeoDefault(defaults, 'baseColor');
         if (baseColor && baseColor !== 'slate') {
             document.documentElement.setAttribute('data-base-color', baseColor);
+        } else {
+            document.documentElement.removeAttribute('data-base-color');
         }
         // Menu accent
         const menuAccent = localStorage.getItem('theme-menu-accent') || lumeoDefault(defaults, 'menuAccent');
         if (menuAccent && menuAccent !== 'subtle') {
             document.documentElement.setAttribute('data-menu-accent', menuAccent);
+        } else {
+            document.documentElement.removeAttribute('data-menu-accent');
         }
         // Menu color
         const menuColor = localStorage.getItem('theme-menu-color') || lumeoDefault(defaults, 'menuColor');
@@ -140,6 +157,9 @@ window.themeManager = {
         } else if (menuColor === 'light') {
             document.documentElement.style.setProperty('--color-sidebar', 'hsl(0 0% 100%)');
             document.documentElement.style.setProperty('--color-sidebar-foreground', 'hsl(220 13% 10%)');
+        } else {
+            document.documentElement.style.removeProperty('--color-sidebar');
+            document.documentElement.style.removeProperty('--color-sidebar-foreground');
         }
         // Direction (RTL / LTR). Applied early so first paint is correct and
         // browser-native logical properties flip with no visible reflow.
@@ -163,22 +183,6 @@ window.themeManager = {
             el.textContent = fontCss;
         } else {
             applyLumeoFont(lumeoDefault(defaults, 'font'), lumeoDefault(defaults, 'fontLocalPath'));
-        }
-
-        // Multi-tab theme sync. Without this, toggling dark mode (or
-        // changing scheme / radius / direction) in one tab leaves other
-        // tabs of the same app on the stale theme — they only re-read
-        // localStorage on page load. The 'storage' event fires in every
-        // OTHER tab when a tab writes a key, so we just re-run the init
-        // pipeline to pick up the new value. Self-tab writes don't fire
-        // the event, so this can't loop. Idempotent — re-applying the
-        // same theme is a no-op.
-        if (!window.themeManager._storageHandlerInstalled) {
-            window.addEventListener('storage', function (e) {
-                if (!e.key || !e.key.startsWith('theme-') && e.key !== 'lumeo.direction') return;
-                try { window.themeManager.init(); } catch (_) {}
-            });
-            window.themeManager._storageHandlerInstalled = true;
         }
     },
     setMode: function (mode) {

--- a/src/Lumeo/wwwroot/js/theme.js
+++ b/src/Lumeo/wwwroot/js/theme.js
@@ -164,6 +164,22 @@ window.themeManager = {
         } else {
             applyLumeoFont(lumeoDefault(defaults, 'font'), lumeoDefault(defaults, 'fontLocalPath'));
         }
+
+        // Multi-tab theme sync. Without this, toggling dark mode (or
+        // changing scheme / radius / direction) in one tab leaves other
+        // tabs of the same app on the stale theme — they only re-read
+        // localStorage on page load. The 'storage' event fires in every
+        // OTHER tab when a tab writes a key, so we just re-run the init
+        // pipeline to pick up the new value. Self-tab writes don't fire
+        // the event, so this can't loop. Idempotent — re-applying the
+        // same theme is a no-op.
+        if (!window.themeManager._storageHandlerInstalled) {
+            window.addEventListener('storage', function (e) {
+                if (!e.key || !e.key.startsWith('theme-') && e.key !== 'lumeo.direction') return;
+                try { window.themeManager.init(); } catch (_) {}
+            });
+            window.themeManager._storageHandlerInstalled = true;
+        }
     },
     setMode: function (mode) {
         if (mode === 'system') {


### PR DESCRIPTION
## Summary
Closes #63 leftovers — the CRIT (`setupAutoResize` listener leak + `lockScroll` incomplete) shipped in #73. Three remaining items here.

## 1. `ai.observeAutoScroll` scroll-listener orphan
The anonymous `scroll` handler was added per registration but never captured. `disposeAutoScroll` only disconnected the `MutationObserver`, so the scroll listener leaked per element remount. Stored as `{ observer, scrollTarget, onScroll }` record on `aiListObservers`; dispose now removes the listener with the same reference. The re-register path tears down the prior one too.

## 2. `positionFixed` cleanup throws on detached window
`removeEventListener` calls could throw in detached / cross-realm scenarios (worker hosts, MAUI Hybrid teardown). The throw stopped the rest of the cleanup including `positionCleanups.delete` — leaving stale entries. Wrapped both removes in `try/catch` and added a defensive top-level catch in `unpositionFixed` so a future change to the cleanup body can't leave the registry inconsistent.

## 3. `theme.js` multi-tab desync
Toggling dark mode / scheme / radius / direction in one tab left other open tabs of the same app on the stale theme — they only re-read `localStorage` at page load. Added a one-time `storage` event listener that re-runs `themeManager.init()` when a `theme-*` / `lumeo.direction` key changes in another tab. Self-tab writes don't fire `storage` so this can't loop. Idempotent. `_storageHandlerInstalled` flag guards against double-install.

## Test plan
- [ ] CI green.
- [ ] AgentMessageList: mount/unmount rapidly in a parent — no growing scroll listener count in DevTools event-listener panel.
- [ ] Open Lumeo docs in two tabs, toggle dark mode in tab A → tab B updates to the same theme on the next render frame.
- [ ] Positioned popovers / tooltips dispose cleanly even when the host page is mid-navigation.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LJmBFYeCdQj2G2epoZaRzQ)_