### PR TITLE
feat(a11y): combobox listbox semantics — Mention + TagInput + Stepper tabpanel labelledby (#56)

### DIFF
--- a/src/Lumeo/UI/Mention/Mention.razor
+++ b/src/Lumeo/UI/Mention/Mention.razor
@@ -22,6 +22,10 @@
               name="@(Name ?? FormField?.Name)"
               aria-required="@(Required ? "true" : "false")"
               aria-invalid="@(EffectiveInvalid ? "true" : "false")"
+              aria-haspopup="listbox"
+              aria-expanded="@(_showDropdown ? "true" : "false")"
+              aria-controls="@_dropdownId"
+              aria-activedescendant="@(_showDropdown ? OptionElementId(_activeIndex) : null)"
               @ref="_textareaRef"
               @oninput="HandleInput"
               @onkeydown="HandleKeyDown"
@@ -30,12 +34,16 @@
 
     @if (_showDropdown && FilteredOptions.Any())
     {
-        <div id="@_dropdownId" class="@DropdownCssClass"
+        <div id="@_dropdownId" class="@DropdownCssClass" role="listbox"
              style="position: fixed; left: @(_caretLeft)px; top: @(_caretTop + 20)px;">
             @foreach (var (option, index) in FilteredOptions.Select((o, i) => (o, i)))
             {
                 var isActive = index == _activeIndex;
-                <button @key="option.Value" type="button"
+                <button @key="option.Value"
+                        id="@OptionElementId(index)"
+                        role="option"
+                        aria-selected="@(isActive ? "true" : "false")"
+                        type="button"
                         class="@OptionCssClass(isActive)"
                         @onpointerdown:preventDefault
                         @onclick="() => SelectOption(option)">
@@ -94,6 +102,12 @@
     private bool InsideFormField => FormField is not null;
 
     private readonly string _textareaId = LumeoIds.New("mention");
+
+    // ARIA option ID generator. The textarea's aria-activedescendant
+    // points at OptionElementId(_activeIndex); each option button renders
+    // the same id. Lets AT track the highlighted option while focus stays
+    // on the textarea — the combobox pattern.
+    private string OptionElementId(int index) => $"{_dropdownId}-opt-{index}";
     private readonly string _dropdownId = LumeoIds.New("mention-dd");
     private ElementReference _textareaRef;
     private bool _showDropdown;

--- a/src/Lumeo/UI/Stepper/Stepper.razor
+++ b/src/Lumeo/UI/Stepper/Stepper.razor
@@ -34,10 +34,12 @@
             var isCompleted = step.Completed || idx < ActiveStep;
             var isError = !step.IsStepValid() && idx < ActiveStep;
             <button type="button"
+                    id="@StepTabId(idx)"
                     role="tab"
                     aria-selected="@isActive.ToString().ToLower()"
                     aria-current="@(isActive ? "step" : null)"
                     aria-disabled="@(CanClickStep(idx) ? null : "true")"
+                    aria-controls="@_panelId"
                     tabindex="@(isActive ? 0 : -1)"
                     class="@GetStepIndicatorClass(idx, isActive, isCompleted, isError)"
                     @ref="_stepButtonRefs[idx]"
@@ -116,7 +118,11 @@
     }
 
     @* Step body panel *@
-    <div role="tabpanel" class="mt-4">
+    @* aria-labelledby points at the active step's tab id so AT announces
+       'panel — Step N: Title' when the panel receives focus. The
+       relationship is dynamic (active step changes), so we read the
+       currently-active step's id directly each render. *@
+    <div id="@_panelId" role="tabpanel" aria-labelledby="@(ActiveStep >= 0 && ActiveStep < _steps.Count ? StepTabId(ActiveStep) : null)" class="mt-4">
         @if (ActiveStep >= 0 && ActiveStep < _steps.Count)
         {
             var activeStep = _steps[ActiveStep];
@@ -178,6 +184,14 @@
     // ElementReferences for each step indicator button — sized in OnParametersSet
     // so @ref bindings in the render loop always find a valid slot.
     private ElementReference[] _stepButtonRefs = Array.Empty<ElementReference>();
+
+    // Stable IDs for the tabpanel and per-step tab buttons so the panel
+    // can reference the active step via aria-labelledby. Without these,
+    // AT announces the tabpanel without context (just "tab panel" instead
+    // of "Step 2: Billing details, tab panel").
+    private readonly string _panelId = LumeoIds.New("stepper-panel");
+    private readonly string _tabIdPrefix = LumeoIds.New("stepper-tab");
+    private string StepTabId(int idx) => $"{_tabIdPrefix}-{idx}";
 
     internal void RegisterStep(StepperStep.StepRegistration step)
     {

--- a/src/Lumeo/UI/TagInput/TagInput.razor
+++ b/src/Lumeo/UI/TagInput/TagInput.razor
@@ -54,6 +54,9 @@
                name="@(Name ?? FormField?.Name)"
                aria-required="@(Required ? "true" : "false")"
                aria-invalid="@(EffectiveInvalid ? "true" : "false")"
+               aria-haspopup="listbox"
+               aria-expanded="@(_showSuggestions && FilteredSuggestions.Count > 0 ? "true" : "false")"
+               aria-controls="@_suggestionsId"
                @oninput="OnInput"
                @onkeydown="OnKeyDown"
                @onfocus="() => _showSuggestions = FilteredSuggestions.Count > 0"
@@ -62,10 +65,12 @@
 
         @if (_showSuggestions && FilteredSuggestions.Count > 0)
         {
-            <div id="@_suggestionsId" class="fixed z-50 min-w-[150px] overflow-hidden rounded-md border border-border/40 bg-popover p-1 text-popover-foreground shadow-lg animate-fade-in">
-                @foreach (var suggestion in FilteredSuggestions)
+            <div id="@_suggestionsId" role="listbox" class="fixed z-50 min-w-[150px] overflow-hidden rounded-md border border-border/40 bg-popover p-1 text-popover-foreground shadow-lg animate-fade-in">
+                @foreach (var (suggestion, index) in FilteredSuggestions.Select((s, i) => (s, i)))
                 {
                     <button type="button"
+                            role="option"
+                            aria-selected="false"
                             class="flex w-full items-center rounded-sm px-2 py-1.5 text-sm hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground focus:outline-none cursor-pointer transition-colors"
                             @onclick="() => SelectSuggestion(suggestion)">
                         @if (SuggestionTemplate is not null)


### PR DESCRIPTION
## Summary
Closes the bulk of #56. WAI-ARIA combobox / tabpanel semantics.

## Mention
- Textarea: `aria-haspopup="listbox"`, `aria-expanded`, `aria-controls`, `aria-activedescendant` → so AT tracks the highlighted option while focus stays on the textarea.
- Dropdown: `role="listbox"`.
- Each option button: stable id, `role="option"`, `aria-selected` reflecting `isActive`.

## TagInput
- Input: `aria-haspopup` / `aria-expanded` / `aria-controls`.
- Suggestion popover: `role="listbox"`.
- Each suggestion button: `role="option"`, `aria-selected="false"` (static — TagInput doesn't track a keyboard-active suggestion index today; arrow-key suggestion nav is a separate enhancement).

## Stepper
- Each tab button: stable id + `aria-controls=PanelId`.
- Panel: `id` + `aria-labelledby` pointing at the active step's tab id. AT now announces "Step N: Title, tab panel".

## Out of scope
- FileManager `aria-level` on treeitems — needs threading depth through `RenderTreeNode` helper.
- Splitter `aria-valuenow` — needs pane-ratio cascade through `SplitterContext`.

Both filed for follow-up; bigger surface than fits cleanly here.

## Test plan
- [ ] CI green.
- [ ] Type `@` in Mention demo, arrow through options → AT announces each option as it becomes activedescendant.
- [ ] TagInput with suggestions: AT identifies the popover as a listbox.
- [ ] Stepper: tab to step indicator, Enter → AT reads tabpanel with step title in context.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LJmBFYeCdQj2G2epoZaRzQ)_