### PR TITLE
fix(picklist): rebuild source/target lists on move so filter cache invalidates

### DIFF
--- a/src/Lumeo/UI/PickList/PickList.razor
+++ b/src/Lumeo/UI/PickList/PickList.razor
@@ -217,11 +217,16 @@
     private async Task MoveToTarget(List<TItem> toMove)
     {
         if (toMove.Count == 0) return;
-        foreach (var i in toMove)
-        {
-            _sourceItems.Remove(i);
-            if (!_targetItems.Contains(i)) _targetItems.Add(i);
-        }
+        // Build fresh lists rather than mutating in place. The filter caches
+        // (FilteredSourceItems / FilteredTargetItems) key on
+        // ReferenceEquals against the source / target lists; in-place
+        // Remove/Add would keep the same reference and let the cache hit
+        // stale after every move — items disappearing from the wrong pane
+        // or failing to appear in the other until the user retypes the
+        // search (Codex review on #100).
+        var moveSet = new HashSet<TItem>(toMove);
+        _sourceItems = _sourceItems.Where(i => !moveSet.Contains(i)).ToList();
+        _targetItems = _targetItems.Concat(toMove.Where(i => !_targetItems.Contains(i))).ToList();
         _sourceSelected.Clear();
         await SelectedItemsChanged.InvokeAsync(_targetItems.ToList());
     }
@@ -229,11 +234,9 @@
     private async Task MoveToSource(List<TItem> toMove)
     {
         if (toMove.Count == 0) return;
-        foreach (var i in toMove)
-        {
-            _targetItems.Remove(i);
-            if (!_sourceItems.Contains(i)) _sourceItems.Add(i);
-        }
+        var moveSet = new HashSet<TItem>(toMove);
+        _targetItems = _targetItems.Where(i => !moveSet.Contains(i)).ToList();
+        _sourceItems = _sourceItems.Concat(toMove.Where(i => !_sourceItems.Contains(i))).ToList();
         _targetSelected.Clear();
         await SelectedItemsChanged.InvokeAsync(_targetItems.ToList());
     }


### PR DESCRIPTION
## Summary
Codex review on #100 found that `PickList.MoveToTarget` / `MoveToSource` mutate `_sourceItems` / `_targetItems` **in place** — `Remove` on one list, `Add` on the other. The filter caches landed in #100 key on `ReferenceEquals` against those list fields, so the cache still hits after a move and a search-filtered view keeps showing the moved item in its old pane (or fails to surface it in the other) until the user retypes the search or the parent refreshes parameters.

## Fix
Replaced the mutate-in-place loops with fresh `List<T>` assignments:
```csharp
_sourceItems = _sourceItems.Where(i => !moveSet.Contains(i)).ToList();
_targetItems = _targetItems.Concat(toMove.Where(i => !_targetItems.Contains(i))).ToList();
```

New list references shift the cache key automatically; the next render recomputes the filtered view.

## Why Transfer isn't affected
`Transfer.MoveToTarget` / `MoveToSource` already replaced the list references via `SourceItems = remaining;` — the cache invalidates the same way.

## Test plan
- [ ] CI green.
- [ ] PickList demo with `ShowSearch="true"`: type a filter, select item, click Move → item moves and disappears from the source pane (no stale view).

---
_Generated by [Claude Code](https://claude.ai/code/session_01LJmBFYeCdQj2G2epoZaRzQ)_