### PR TITLE
fix: Codex review leftovers on PRs #46 + #48 (DataGrid resize lifecycle + FLIP colspan + broader catch)

### DIFF
--- a/src/Lumeo.DataGrid/UI/DataGrid/DataGrid.razor
+++ b/src/Lumeo.DataGrid/UI/DataGrid/DataGrid.razor
@@ -1264,6 +1264,15 @@
             _pendingReorderAnimation = false;
             try { await Interop.AnimateColumnReorder(_gridId, ColumnReorderAnimationMs); }
             catch (JSDisconnectedException) { }
+            catch (Exception ex)
+            {
+                // Non-disconnect JS / runtime failures shouldn't throw out of
+                // OnAfterRenderAsync (Blazor would log unhandled-task) — route
+                // through OnError so consumers can react, but keep the flag
+                // cleared so a future render isn't blocked on a stale
+                // pending-animation state (Codex review on #48).
+                if (OnError.HasDelegate) await OnError.InvokeAsync(ex);
+            }
         }
     }
 
@@ -2451,6 +2460,14 @@
         // from its old visual position to its new one.
         try { await Interop.CaptureColumnRects(_gridId); }
         catch (JSDisconnectedException) { }
+        catch (Exception captureEx)
+        {
+            // Non-disconnect failures (DOM gone, malformed rects) shouldn't
+            // abort the column-order mutation that follows — the FLIP
+            // animation is a visual nice-to-have. Surface to OnError and
+            // continue so the data reorder still applies (Codex review #48).
+            if (OnError.HasDelegate) await OnError.InvokeAsync(captureEx);
+        }
 
         var col = _orderedColumns[args.OldIndex];
         _orderedColumns.RemoveAt(args.OldIndex);

--- a/src/Lumeo.DataGrid/UI/DataGrid/DataGridHeaderCell.razor
+++ b/src/Lumeo.DataGrid/UI/DataGrid/DataGridHeaderCell.razor
@@ -312,6 +312,20 @@
         {
             await EnsureResizeRegistered();
         }
+        else if (!Column.Resizable && _resizeRegistered)
+        {
+            // Column flipped Resizable true → false. The resize-handle div is
+            // gone from the DOM (the @if (Column.Resizable) gate above) but
+            // the JS pointer listener it was tied to stays attached to a
+            // detached element until we unregister it. More importantly,
+            // _resizeRegistered would otherwise stay true and a later
+            // false → true flip wouldn't re-call EnsureResizeRegistered —
+            // the newly-rendered handle would never receive a listener and
+            // resizing would silently stop working (Codex review on #46).
+            try { await Interop.UnregisterColumnResize(_resizeHandleId); }
+            catch (Microsoft.JSInterop.JSDisconnectedException) { }
+            _resizeRegistered = false;
+        }
 
         if (!Column.Filterable) return;
 

--- a/src/Lumeo/wwwroot/js/components.js
+++ b/src/Lumeo/wwwroot/js/components.js
@@ -1750,7 +1750,17 @@ export function captureColumnRects(gridId) {
         const cells = [th];
         if (tbody && colIdx >= 0) {
             for (const row of tbody.rows) {
-                if (row.children[colIdx]) cells.push(row.children[colIdx]);
+                const cell = row.children[colIdx];
+                if (!cell) continue;
+                // Skip non-data rows: grouped grids render DataGridGroupRow
+                // as a single <td colspan="N"> that spans every column.
+                // Capturing it under the reorder-column index would later
+                // FLIP-translate the entire group header sideways when only
+                // a single data column moved — visible jitter (Codex
+                // review on #48). colSpan > 1 is the cheapest way to
+                // identify span cells; data cells always have colSpan 1.
+                if (cell.colSpan && cell.colSpan > 1) continue;
+                cells.push(cell);
             }
         }
         snapshot[colId] = { left: th.getBoundingClientRect().left, cells };


### PR DESCRIPTION
## Summary
Sweep across the rest of the recently-merged PRs picked up three Codex / CodeRabbit findings that were never addressed. All real on re-verification.

## #46 — DataGridHeaderCell Column.Resizable lifecycle (P1)
`OnAfterRenderAsync` registered the JS resize listener when `Column.Resizable` flipped on, but never unregistered or reset `_resizeRegistered` when it flipped off. Because `DataGridHeaderCell` keys on `column.Id`, the same instance is reused across toggles — so a `true → false → true` sequence left `_resizeRegistered=true` through the off period and the newly-rendered handle never picked up the listener. Column resize silently stopped working.

Added the symmetric off branch: when `Column.Resizable` is false and `_resizeRegistered` is true, `UnregisterColumnResize` (wrapped in `JSDisconnect` catch) and reset the flag.

## #48 — FLIP snapshot captures group-row colspan cells (P2)
`columnReorderSnapshots` captured one body cell per column at index `colIdx` — but grouped grids render their per-group row as a single `<td colspan="N">` at index 0. Capturing that under col-0's snapshot meant a first-column reorder later translated the entire group header sideways.

Fix: skip cells with `colSpan > 1` during snapshot. Data cells always have `colSpan 1`; span cells are never per-column animation candidates.

## #48 — Broader catch + OnError on CaptureColumnRects / AnimateColumnReorder (Major)
Both interop calls caught only `JSDisconnectedException`. Any other runtime failure (malformed rects, JS module missing) propagated: `CaptureColumnRects` would abort `HandleColumnReorder` before the column-order mutation; `AnimateColumnReorder` would throw out of `OnAfterRenderAsync` after `_pendingReorderAnimation` was cleared. Added `catch (Exception ex)` that routes through `OnError` so the data reorder still applies and consumers see the failure.

## Test plan
- [ ] CI green.
- [ ] DataGrid: toggle a column's `Resizable` off → on → resize handle works.
- [ ] Grouped grid: drag the first column to a new position → group header stays put (no sideways translate).
- [ ] Simulate a JS exception in `CaptureColumnRects` → reorder still commits, `OnError` fires.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LJmBFYeCdQj2G2epoZaRzQ)_