### PR TITLE
feat: ConfirmButton + Spacer.Orientation + EmptyState.Image (#86 small features)

### DIFF
--- a/src/Lumeo/UI/ConfirmButton/ConfirmButton.razor
+++ b/src/Lumeo/UI/ConfirmButton/ConfirmButton.razor
@@ -1,0 +1,91 @@
+@namespace Lumeo
+@inject Lumeo.Services.IOverlayService Overlay
+
+@*
+    ConfirmButton — a Button that opens an AlertDialog before firing OnConfirm.
+
+    Replaces the ~15-line boilerplate of wiring a Button + AlertDialog manually
+    for the destructive-action / commit-changes flow. Internally delegates to
+    OverlayService.ShowAlertDialogAsync, so the dialog renders through the
+    existing OverlayProvider — no extra DOM in the consumer's tree.
+
+    The button itself accepts the same Variant / Size / Disabled / IsLoading
+    parameters as <Button>, so it composes pixel-for-pixel with surrounding
+    buttons.
+*@
+
+<Button Variant="@Variant"
+        Size="@Size"
+        Disabled="@Disabled"
+        IsLoading="@IsLoading"
+        Class="@Class"
+        OnClick="HandleClick"
+        @attributes="AdditionalAttributes">
+    @ChildContent
+</Button>
+
+@code {
+    /// <summary>Button content (the visible label or icon).</summary>
+    [Parameter] public RenderFragment? ChildContent { get; set; }
+
+    /// <summary>Title shown at the top of the confirm dialog.
+    /// Defaults to the AlertDialog default ("Are you sure?").</summary>
+    [Parameter] public string? Title { get; set; }
+
+    /// <summary>Optional descriptive body text under the title.</summary>
+    [Parameter] public string? Description { get; set; }
+
+    /// <summary>Label for the confirm action button. Defaults to "Continue".</summary>
+    [Parameter] public string? ConfirmText { get; set; }
+
+    /// <summary>Label for the cancel action button. Defaults to "Cancel".</summary>
+    [Parameter] public string? CancelText { get; set; }
+
+    /// <summary>When true, the confirm button is styled as destructive
+    /// (red) — for delete / remove / discard actions.</summary>
+    [Parameter] public bool IsDestructive { get; set; }
+
+    /// <summary>Fires after the user confirms. Does NOT fire on cancel —
+    /// listen to <see cref="OnCancel"/> for that path if needed.</summary>
+    [Parameter] public EventCallback OnConfirm { get; set; }
+
+    /// <summary>Fires when the user cancels (or closes the dialog without
+    /// confirming). Optional — most consumers only care about OnConfirm.</summary>
+    [Parameter] public EventCallback OnCancel { get; set; }
+
+    /// <summary>Visual variant of the trigger button. Defaults to
+    /// <see cref="Button.ButtonVariant.Default"/>; commonly set to
+    /// <see cref="Button.ButtonVariant.Destructive"/> for delete actions
+    /// so the button itself is red even before the dialog opens.</summary>
+    [Parameter] public Button.ButtonVariant Variant { get; set; } = Button.ButtonVariant.Default;
+
+    /// <summary>Size of the trigger button.</summary>
+    [Parameter] public Button.ButtonSize Size { get; set; } = Button.ButtonSize.Default;
+
+    [Parameter] public bool Disabled { get; set; }
+    [Parameter] public bool IsLoading { get; set; }
+    [Parameter] public string? Class { get; set; }
+    [Parameter(CaptureUnmatchedValues = true)] public Dictionary<string, object>? AdditionalAttributes { get; set; }
+
+    private async Task HandleClick()
+    {
+        var opts = new Lumeo.Services.AlertDialogOptions
+        {
+            Title = Title ?? "Are you sure?",
+            Description = Description,
+            ConfirmText = ConfirmText ?? "Continue",
+            CancelText = CancelText ?? "Cancel",
+            IsDestructive = IsDestructive,
+        };
+
+        var result = await Overlay.ShowAlertDialogAsync(opts);
+        if (result.Cancelled)
+        {
+            if (OnCancel.HasDelegate) await OnCancel.InvokeAsync();
+        }
+        else
+        {
+            if (OnConfirm.HasDelegate) await OnConfirm.InvokeAsync();
+        }
+    }
+}

--- a/src/Lumeo/UI/EmptyState/EmptyState.razor
+++ b/src/Lumeo/UI/EmptyState/EmptyState.razor
@@ -1,7 +1,16 @@
 @namespace Lumeo
 
 <div role="status" class="@CssClass" @attributes="AdditionalAttributes">
-    @if (IconContent is not null)
+    @if (Image is not null)
+    {
+        @* Custom illustration takes precedence over IconContent when both
+           are provided — Image is the "branded empty state" slot, IconContent
+           is the default Lucide-style affordance. *@
+        <div class="mb-4">
+            @Image
+        </div>
+    }
+    else if (IconContent is not null)
     {
         <div class="mb-4 text-muted-foreground">
             @IconContent
@@ -26,6 +35,12 @@
 @code {
     /// <summary>Icon slot. Named <c>IconContent</c> to avoid shadowing the <c>&lt;Icon&gt;</c> component.</summary>
     [Parameter] public RenderFragment? IconContent { get; set; }
+
+    /// <summary>Custom illustration slot for branded empty states. Wins over
+    /// <see cref="IconContent"/> when both are provided. Use for SVGs / images
+    /// where the icon doesn't carry enough brand weight (404, broken state,
+    /// onboarding hero).</summary>
+    [Parameter] public RenderFragment? Image { get; set; }
 
     [Parameter] public string? Title { get; set; }
     [Parameter] public string? Description { get; set; }

--- a/src/Lumeo/UI/Spacer/Spacer.razor
+++ b/src/Lumeo/UI/Spacer/Spacer.razor
@@ -2,7 +2,7 @@
 
 @if (string.IsNullOrEmpty(Size))
 {
-    <div class="@($"flex-1 {Class}".Trim())" @attributes="AdditionalAttributes"></div>
+    <div class="@($"{GrowClass} {Class}".Trim())" @attributes="AdditionalAttributes"></div>
 }
 else
 {
@@ -10,7 +10,22 @@ else
 }
 
 @code {
+    /// <summary>Tailwind size token (e.g. <c>"4"</c>, <c>"px"</c>). When set,
+    /// renders a fixed-size square spacer. When unset, renders a flex-grow
+    /// spacer that fills available space along the parent flex axis.</summary>
     [Parameter] public string? Size { get; set; }
+
+    /// <summary>Hints which axis the parent flex container uses so the
+    /// grow-spacer collapses to zero on the cross-axis instead of
+    /// expanding it. Default <see cref="Orientation.Horizontal"/> keeps
+    /// the historical behaviour (flex-1 inside a row). Switch to
+    /// <see cref="Orientation.Vertical"/> when the parent is a column
+    /// stack — without it, the spacer's <c>flex-1</c> took width from
+    /// the column instead of pushing siblings to opposite ends.</summary>
+    [Parameter] public Lumeo.Orientation Orientation { get; set; } = Lumeo.Orientation.Horizontal;
+
     [Parameter] public string? Class { get; set; }
     [Parameter(CaptureUnmatchedValues = true)] public Dictionary<string, object>? AdditionalAttributes { get; set; }
+
+    private string GrowClass => Orientation == Lumeo.Orientation.Vertical ? "flex-1 w-0" : "flex-1 h-0";
 }


### PR DESCRIPTION
## Summary
Three small features from #86. Plus `IResponsiveService.IsMobile`, also requested, turned out to already exist in the codebase (FP from feedback).

## ConfirmButton (new component)
Wraps Button + AlertDialog. Triggers `OverlayService.ShowAlertDialogAsync` internally, so the dialog flows through `OverlayProvider` — no extra DOM in the consumer tree, no `@bind-Open` state to manage.

```razor
<ConfirmButton OnConfirm="Delete"
               Title="Wirklich löschen?"
               IsDestructive="true"
               Variant="Button.ButtonVariant.Destructive">
    Delete
</ConfirmButton>
```

Replaces ~15 lines of boilerplate per destructive-action call site. Surface mirrors `Button` (`Variant` / `Size` / `Disabled` / `IsLoading`) + dialog-specific `Title` / `Description` / `ConfirmText` / `CancelText` / `IsDestructive`. Two callbacks: `OnConfirm` fires only on confirm, `OnCancel` only on cancel.

## Spacer.Orientation
The grow-spacer (no `Size`) rendered `flex-1` unconditionally. In a flex-col parent, `flex-1` took width from the column instead of pushing siblings to opposite ends. New `Orientation` parameter (default `Horizontal` preserves the historical behaviour); `Vertical` switches to `flex-1 w-0` so the cross-axis collapses cleanly.

## EmptyState.Image
New `RenderFragment Image` slot for branded empty states (illustrations, brand SVGs). Takes precedence over `IconContent` when both provided, so consumers can keep the icon as a fallback while opting into a custom illustration for the marquee 404 / onboarding case.

## Out of scope
- SheetBody (#86 high-priority) — needs cascade design + tests for sticky-footer + focus-ring-padding. Separate focused PR.
- FileUpload Variant=Trigger — large surface (touches the whole pending-list path). Separate PR.
- PdfViewer fit-modes — needs pdf.js FIT constants mapping + per-page recompute. Separate PR.

## Test plan
- [ ] CI green.
- [ ] `<ConfirmButton OnConfirm="...">` opens AlertDialog, returns to confirm/cancel paths correctly.
- [ ] `<Spacer Orientation="Lumeo.Orientation.Vertical">` inside a column pushes siblings apart.
- [ ] `<EmptyState Image="<svg…>">` renders the SVG instead of `IconContent`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LJmBFYeCdQj2G2epoZaRzQ)_