### PR TITLE
fix(overlay): AlertDialog Escape resolves ShowAlertDialogAsync (Codex #105)

### DIFF
--- a/src/Lumeo/UI/Overlay/OverlayProvider.razor
+++ b/src/Lumeo/UI/Overlay/OverlayProvider.razor
@@ -82,7 +82,11 @@
             break;
 
         case OverlayType.AlertDialog:
-            <AlertDialog @key="overlay.Id" Open="true">
+            @* OpenChanged wires Escape / overlay-click dismissals back to
+               OverlayService.Cancel so ShowAlertDialogAsync resolves. Without
+               it, the AlertDialog flips its local Open=false but the awaiting
+               caller (e.g. ConfirmButton) blocks forever. *@
+            <AlertDialog @key="overlay.Id" Open="true" OpenChanged="(bool val) => OnOverlayClosed(val, overlay.Id)">
                 <AlertDialogContent ZIndex="@overlay.ZIndex">
                     <AlertDialogHeader>
                         <AlertDialogTitle>@(overlay.AlertOptions?.Title ?? "Are you sure?")</AlertDialogTitle>


### PR DESCRIPTION
## Summary
Follow-up to PR #105. Codex flagged that `ShowAlertDialogAsync` (used by `ConfirmButton`) never resolves when the user dismisses the dialog with Escape — the AlertDialog flips its local `Open=false` but the awaiting Task is left hanging because the OverlayProvider's AlertDialog case did not wire `OpenChanged` back to `OverlayService.Cancel`.

- Wired `OpenChanged="(bool val) => OnOverlayClosed(val, overlay.Id)"` on the AlertDialog in `OverlayProvider.razor`, matching the existing pattern for Dialog/Sheet/Drawer.
- Cancel-button click still routes through `HandleCancel` directly (the `@onclick` on `<AlertDialogCancel>` overrides the inner Cancel via `AdditionalAttributes` splat), so there is no double-cancel.

## Test plan
- [ ] Open a `ConfirmButton` dialog → press Escape → `OnCancel` fires; the overlay slot is released.
- [ ] Same dialog → click Cancel button → `OnCancel` fires (regression check).
- [ ] CI green.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LJmBFYeCdQj2G2epoZaRzQ)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where dismissing dialogs via Escape key or clicking outside the dialog area did not properly notify the application, potentially leaving operations waiting for dialog completion blocked indefinitely.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Brain2k-0005/Lumeo/pull/108?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->