### PR TITLE
release: 3.3.0 — final a11y batch + version bump

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
   <!-- Lockstep version shared by all Lumeo packages.
        Update this single property to version all packages in unison. -->
   <PropertyGroup>
-    <Version>3.2.8</Version>
+    <Version>3.3.0</Version>
   </PropertyGroup>
 
   <!-- Shared NuGet README packing lives in Directory.Build.targets, NOT here.

--- a/src/Lumeo/UI/Carousel/Carousel.razor
+++ b/src/Lumeo/UI/Carousel/Carousel.razor
@@ -91,13 +91,18 @@
     {
         var prevP = _canScrollPrev;
         var prevN = _canScrollNext;
+        var prevIndex = _currentIndex;
         _canScrollPrev = scrollPos > 0;
         _canScrollNext = scrollPos < maxScroll - 1;
         // Sync _currentIndex from the scroll position so button navigation
         // (ScrollNext/ScrollPrev) stays accurate after touch-swipe.
         if (nearestIndex >= 0)
             _currentIndex = nearestIndex;
-        if (prevP != _canScrollPrev || prevN != _canScrollNext)
+        // Also re-render when the index changes for a middle-to-middle swipe
+        // — without this the SlideAnnouncement live region stays stale and
+        // screen readers don't hear the slide change because prev/next
+        // flags remained true on both sides.
+        if (prevP != _canScrollPrev || prevN != _canScrollNext || prevIndex != _currentIndex)
             StateHasChanged();
         return Task.CompletedTask;
     }

--- a/src/Lumeo/UI/Carousel/Carousel.razor
+++ b/src/Lumeo/UI/Carousel/Carousel.razor
@@ -1,5 +1,6 @@
 @namespace Lumeo
 @implements IAsyncDisposable
+@inject Lumeo.Services.Localization.ILumeoLocalizer L
 
 @{
     var context = new CarouselContext(
@@ -8,7 +9,9 @@
         _canScrollPrev && !Disabled,
         _canScrollNext && !Disabled,
         EventCallback.Factory.Create(this, ScrollPrev),
-        EventCallback.Factory.Create(this, ScrollNext)
+        EventCallback.Factory.Create(this, ScrollNext),
+        RegisterItem,
+        UnregisterItem
     );
 }
 
@@ -16,6 +19,10 @@
     <CascadingValue Value="context" IsFixed="false">
         @ChildContent
     </CascadingValue>
+    @* Visually-hidden live region announces slide changes to assistive
+       tech. Auto-play decks or programmatic ScrollTo would otherwise be
+       silent. Polite (not assertive) so it doesn't interrupt other speech. *@
+    <span aria-live="polite" aria-atomic="true" class="sr-only">@SlideAnnouncement</span>
 </div>
 
 @inject IComponentInteropService Interop
@@ -34,8 +41,24 @@
     private bool _canScrollPrev;
     private bool _canScrollNext = true;
     private readonly string _contentId = LumeoIds.New("carousel");
+    // Item tokens registered by child CarouselItems so the live-region can
+    // emit "Slide N of M". The count is the only thing we read from this
+    // list — the token objects exist purely so Register/Unregister can be
+    // idempotent across re-renders without using indices.
+    private readonly List<object> _items = new();
 
     private string CssClass => $"relative {Class}".Trim();
+
+    private string SlideAnnouncement => _items.Count > 0
+        ? L["Carousel.SlideXofY", _currentIndex + 1, _items.Count]
+        : string.Empty;
+
+    private void RegisterItem(object token)
+    {
+        if (!_items.Contains(token)) _items.Add(token);
+    }
+
+    private void UnregisterItem(object token) => _items.Remove(token);
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
@@ -147,6 +170,8 @@
         bool CanScrollPrev,
         bool CanScrollNext,
         EventCallback ScrollPrev,
-        EventCallback ScrollNext
+        EventCallback ScrollNext,
+        Action<object> RegisterItem,
+        Action<object> UnregisterItem
     );
 }

--- a/src/Lumeo/UI/Carousel/CarouselItem.razor
+++ b/src/Lumeo/UI/Carousel/CarouselItem.razor
@@ -1,4 +1,5 @@
 @namespace Lumeo
+@implements IDisposable
 @inject Lumeo.Services.Localization.ILumeoLocalizer L
 
 @{
@@ -19,6 +20,11 @@
     [Parameter] public int? Total { get; set; }
     [Parameter] public string? Class { get; set; }
     [Parameter(CaptureUnmatchedValues = true)] public Dictionary<string, object>? AdditionalAttributes { get; set; }
+
+    private readonly object _token = new();
+
+    protected override void OnInitialized() => Context?.RegisterItem(_token);
+    public void Dispose() => Context?.UnregisterItem(_token);
 
     private string? SlideLabel => Index.HasValue && Total.HasValue
         ? L["Carousel.SlideXofY", Index.Value, Total.Value]

--- a/src/Lumeo/UI/ReasoningDisplay/ReasoningDisplay.razor
+++ b/src/Lumeo/UI/ReasoningDisplay/ReasoningDisplay.razor
@@ -5,10 +5,14 @@
         <span class="inline-flex h-3.5 w-3.5 shrink-0 items-center justify-center text-muted-foreground transition-transform duration-150 [details[open]_&]:rotate-90">
             <Icon Name="ChevronRight" Size="Lumeo.Size.Sm" />
         </span>
-        <span class="italic text-muted-foreground">@ResolvedSummary</span>
+        @* aria-live="polite" on the summary text wrapper so when IsStreaming
+           flips and ResolvedSummary changes ("Thinking…" → "Reasoned for 1.2s"),
+           assistive tech announces the transition. aria-atomic re-reads the
+           whole label rather than the diff. *@
+        <span class="italic text-muted-foreground" aria-live="polite" aria-atomic="true">@ResolvedSummary</span>
         @if (IsStreaming)
         {
-            <span class="inline-flex items-center">
+            <span class="inline-flex items-center" aria-hidden="true">
                 <span class="h-1 w-1 rounded-full bg-muted-foreground animate-pulse"></span>
             </span>
         }


### PR DESCRIPTION
## Summary

- Bumps `Directory.Build.props` Version 3.2.8 → **3.3.0**.
- Last two a11y items from #55: Carousel slide-change live region (announces "Slide N of M") + ReasoningDisplay summary aria-live (announces "Thinking…" → "Reasoned for X.Xs" transitions).

## Draft release notes for `v3.3.0`

Copy into the GitHub release UI when you're ready to tag.

### Added
- **New components**: `ConfirmButton`, `UploadTrigger`.
- **New parameters**: `AutoFocus` (Input / Textarea / NumberInput / Combobox / Select / DatePicker / TagInput), `MobileFullscreen` (Dialog / Sheet / Drawer overlays), `Input.Variant=Search`, `PdfViewer.FitMode` (Custom / FitWidth / FitPage), `Spacer.Orientation`, `EmptyState.Image`, `AriaLabel` on Avatar / QRCode / ThemeToggle, `NavigationMenuLink.IsActive`.
- **Tokens**: `Lumeo.Size.Xxs` (Avatar + Chip).

### Improved (a11y)
- Disclosure widgets (`Accordion`, `Collapsible`) wire `aria-controls` / `aria-labelledby`.
- `Stepper` tab→panel `aria-controls` / `aria-labelledby` round-trip.
- `Mention` + `TagInput`: combobox / listbox semantics with `aria-activedescendant`.
- `Progress`: `aria-busy` on indeterminate; no more `aria-valuenow="null"`.
- `Splitter`: divider `aria-valuenow` / `aria-valuemin` / `aria-valuemax` bounded by both adjacent panes.
- `FileManager`: tree items emit `aria-level`.
- `TreeSelect`: tristate `aria-checked` in Multiple mode + `aria-level`.
- `NavigationMenu`: `aria-current="page"` when `IsActive`.
- `ConsentBanner`: focus the preferences save button after dialog opens.
- `Carousel`: visually-hidden polite live region announces slide changes ("Slide N of M").
- `ReasoningDisplay`: `aria-live` on summary so streaming → reasoned state transitions are announced.
- L10n: 69 missing Editor / Gantt / Scheduler strings backfilled in En + De.

### Fixed
- **Critical**: JS-interop listener leaks across components, Confetti `requestAnimationFrame` leak on dispose, `lockScroll` now mutates `body` AND `html`, `positionFixed` cleanup wrapped in try/catch, theme multi-tab sync via `storage` event.
- `RichTextEditor`: cut double-roundtrip per keystroke; clear debounce timer on destroy.
- `PdfViewer`: left half un-scrollable when canvas zoomed past viewport width (`mx-auto` instead of `justify-center`); track `FitMode` explicitly so refit fires on parent rerender (no NaN sentinel).
- `Charts.GaugeChart`: div-by-zero on `Min==Max`.
- `Charts.echarts-interop`: `ResizeObserver` re-attached on `refreshAllCharts`.
- `ColorPicker`: alpha slider propagates to `Value`; alpha preserved across other slider moves.
- `Cascader`: drill-down preserved across re-renders.
- `InplaceEditor`: focus management on edit-cancel.
- `DebouncedValue`: callback exceptions surface via `Console.Error` instead of being swallowed.
- `LumeoFormGenerator`: nullability detection + null-forgiving emit on writeback.
- `Tour`: `UpdateTargetRect` race via sequence guard.
- `DataGrid`: column-resize lifecycle (unregister on Resizable flip-off); FLIP snapshot skips `colSpan > 1` cells; broader catch with `OnError` plumbing on capture/animate.
- `PickList`: source/target lists rebuilt on move so the filter cache invalidates.
- `Image`: empty wrapper when only `Class` is sized.
- `Maps` + `Gantt` + `Scheduler`: non-`JSDisconnected` init failures caught so the component isn't silently inert.
- `Heading.Level` clamped 1–6 (no `<h7>`).
- `Splitter` divider: `aria-orientation` mapping fixed (was inverted).
- `OverlayProvider`: AlertDialog `OpenChanged` wired so `ShowAlertDialogAsync` resolves on Escape (otherwise `ConfirmButton` await blocked forever).
- 18 closed issues across the a11y / DX / satellite-widget tracks (#51-#56, #58-#59, #64-#68, #70, #80, #86).

### Docs site
- Lazy-load icon packs + 6 satellite component packages (`Lumeo.Docs.csproj` `<BlazorWebAssemblyLazyLoad>` entries + `OnNavigateAsync` route→DLL map).

## Test plan
- [ ] CI green
- [ ] Smoke-check Carousel auto-advance with screen reader: each slide announced
- [ ] Smoke-check ReasoningDisplay streaming → done transition is announced
- [ ] After merge: bump confirmation from owner, then tag `v3.3.0` + GitHub release + NuGet publish

---
_Generated by [Claude Code](https://claude.ai/code/session_01LJmBFYeCdQj2G2epoZaRzQ)_