### PR TITLE
release: 3.5.0 — Density + OverlayOptions split + SheetContent SizePreset + DataGrid sequencing (closes #67, #87, #90 deferred)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -123,6 +123,42 @@ Overlay components (modals, drawers, popovers, etc.) must:
 - Implement `IAsyncDisposable` for cleanup.
 - Handle `JSDisconnectedException` in cleanup methods.
 
+### `@bind-Value` convention (#87.3)
+
+Every two-way-bindable input MUST expose the `Value` + `ValueChanged`
+pair so consumers can write `<MyInput @bind-Value="_model.Field" />`
+without learning per-input variations. Concretely:
+
+- Parameter name: `Value` (not `Text`, `Selection`, `Number`).
+- Event callback: `EventCallback<T> ValueChanged` typed to the same `T`.
+- Fire `ValueChanged` on the SAME edit boundary the user expects:
+  - **Text-like inputs** (Input, Textarea, NumberInput): on every keystroke
+    so live validation works. If debouncing is desirable, expose a
+    `DebounceMs` parameter rather than swallowing keystrokes.
+  - **Picker inputs** (Select, Combobox, DatePicker, ColorPicker): on
+    selection commit (item click, date pick, color confirm) — NOT on
+    intermediate hover/keyboard navigation.
+  - **Toggle inputs** (Checkbox, Switch, RadioGroup): on the change event.
+- If a non-string value needs a converter, expose the convention via an
+  analyzer-friendly parameter (e.g. `Format` / `Culture`); never silently
+  parse with the invariant culture.
+- Internal field that holds the in-flight buffer (before commit) is
+  named `_pending` or `_buffer`, never `Value` itself — `Value` is the
+  consumer's source of truth.
+
+### Per-component "gotchas" metadata (#87.5)
+
+When a component has non-obvious default behaviour, surface it in the
+MCP / skill registry so AI-assisted consumers don't trip over it:
+
+- Add a `gotchas` array on the component's registry entry
+  (`tools/Lumeo.RegistryGen/`) listing one-line callouts (e.g.
+  `"SheetContent has no inner scroll container by default — wrap a
+  long form's body in flex-1 overflow-y-auto"`).
+- `Lumeo.RegistryGen` picks these up automatically from
+  `<gotcha>...</gotcha>` XML doc comments on the component class, so
+  the source of truth stays in the `.razor` file.
+
 ## Pull Request Guidelines
 
 - Keep PRs focused — one feature or fix per PR.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -146,24 +146,24 @@ without learning per-input variations. Concretely:
   named `_pending` or `_buffer`, never `Value` itself — `Value` is the
   consumer's source of truth.
 
-### Per-component "gotchas" metadata (#87.5, proposed)
+### Per-component "gotchas" metadata (#87.5)
 
-> **Status: proposed convention — extraction not yet wired into
-> `Lumeo.RegistryGen`.** Don't rely on `<gotcha>` comments surfacing in
-> MCP / skill metadata until the generator support lands.
+When a component has non-obvious default behaviour, surface it in the MCP /
+skill registry so AI-assisted consumers don't trip over it. This is a live,
+supported convention — `Lumeo.RegistryGen` extracts it automatically.
 
-When a component has non-obvious default behaviour, the goal is to surface
-it in the MCP / skill registry so AI-assisted consumers don't trip over it.
-The intended convention:
-
-- Author one-line callouts as `<gotcha>…</gotcha>` XML doc comments on the
-  component class (e.g. `<gotcha>SheetContent has no inner scroll container
-  by default — wrap a long form's body in flex-1 overflow-y-auto</gotcha>`),
+- Author one-line callouts as `<gotcha>…</gotcha>` anywhere in the `.razor`
+  file — typically inside the leading `@* … *@` comment block (e.g.
+  `<gotcha>SheetContent has no inner scroll container by default — wrap a
+  long body in flex-1 overflow-y-auto, or use OverlayForm.</gotcha>`),
   keeping the source of truth in the `.razor` file.
-- A future `Lumeo.RegistryGen` pass will lift them into a `gotchas` array on
-  each component's registry entry.
-
-Until then, document non-obvious defaults in the component's docs page.
+- Match the line `<gotcha>...</gotcha>` exactly; the inner text is extracted
+  and trimmed. Content may span multiple lines (the matcher is singleline).
+- `Lumeo.RegistryGen` lifts every gotcha into a `gotchas[]` array on the
+  component's `registry.json` entry and its `components-api.json` entry
+  (empty array when a component declares none). The
+  `sync-mcp-registry.yml` workflow regenerates both on push to `master`, so
+  don't hand-edit the JSON — just author the `<gotcha>` comment.
 
 ## Pull Request Guidelines
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -146,18 +146,24 @@ without learning per-input variations. Concretely:
   named `_pending` or `_buffer`, never `Value` itself — `Value` is the
   consumer's source of truth.
 
-### Per-component "gotchas" metadata (#87.5)
+### Per-component "gotchas" metadata (#87.5, proposed)
 
-When a component has non-obvious default behaviour, surface it in the
-MCP / skill registry so AI-assisted consumers don't trip over it:
+> **Status: proposed convention — extraction not yet wired into
+> `Lumeo.RegistryGen`.** Don't rely on `<gotcha>` comments surfacing in
+> MCP / skill metadata until the generator support lands.
 
-- Add a `gotchas` array on the component's registry entry
-  (`tools/Lumeo.RegistryGen/`) listing one-line callouts (e.g.
-  `"SheetContent has no inner scroll container by default — wrap a
-  long form's body in flex-1 overflow-y-auto"`).
-- `Lumeo.RegistryGen` picks these up automatically from
-  `<gotcha>...</gotcha>` XML doc comments on the component class, so
-  the source of truth stays in the `.razor` file.
+When a component has non-obvious default behaviour, the goal is to surface
+it in the MCP / skill registry so AI-assisted consumers don't trip over it.
+The intended convention:
+
+- Author one-line callouts as `<gotcha>…</gotcha>` XML doc comments on the
+  component class (e.g. `<gotcha>SheetContent has no inner scroll container
+  by default — wrap a long form's body in flex-1 overflow-y-auto</gotcha>`),
+  keeping the source of truth in the `.razor` file.
+- A future `Lumeo.RegistryGen` pass will lift them into a `gotchas` array on
+  each component's registry entry.
+
+Until then, document non-obvious defaults in the component's docs page.
 
 ## Pull Request Guidelines
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
   <!-- Lockstep version shared by all Lumeo packages.
        Update this single property to version all packages in unison. -->
   <PropertyGroup>
-    <Version>3.4.0</Version>
+    <Version>3.5.0</Version>
   </PropertyGroup>
 
   <!-- Shared NuGet README packing lives in Directory.Build.targets, NOT here.

--- a/src/Lumeo.DataGrid/UI/DataGrid/DataGridServerService.cs
+++ b/src/Lumeo.DataGrid/UI/DataGrid/DataGridServerService.cs
@@ -44,6 +44,13 @@ internal sealed class DataGridServerService : IDisposable
             try
             {
                 await onServerRequest.InvokeAsync(request);
+                // Generation guard: if a newer request was issued while the
+                // consumer's callback was running, the older response would
+                // race the newer one to update Items. Cancel the old token
+                // so the consumer's "honour CancellationToken" path drops
+                // the stale response.
+                if (generation != _requestGeneration)
+                    return;
             }
             catch (OperationCanceledException)
             {

--- a/src/Lumeo.DataGrid/UI/DataGrid/DataGridServerService.cs
+++ b/src/Lumeo.DataGrid/UI/DataGrid/DataGridServerService.cs
@@ -44,13 +44,6 @@ internal sealed class DataGridServerService : IDisposable
             try
             {
                 await onServerRequest.InvokeAsync(request);
-                // Generation guard: if a newer request was issued while the
-                // consumer's callback was running, the older response would
-                // race the newer one to update Items. Cancel the old token
-                // so the consumer's "honour CancellationToken" path drops
-                // the stale response.
-                if (generation != _requestGeneration)
-                    return;
             }
             catch (OperationCanceledException)
             {
@@ -59,6 +52,10 @@ internal sealed class DataGridServerService : IDisposable
             }
             catch (Exception ex)
             {
+                // Suppress errors from already-superseded requests so a
+                // race-cancelled HTTP call doesn't surface as an error in
+                // the grid (the consumer will issue a fresh request anyway).
+                if (generation != _requestGeneration) return;
                 Error = ex.Message;
                 if (onError?.HasDelegate == true)
                     await onError.Value.InvokeAsync(ex);

--- a/src/Lumeo.DataGrid/UI/DataGrid/DataGridServerService.cs
+++ b/src/Lumeo.DataGrid/UI/DataGrid/DataGridServerService.cs
@@ -44,6 +44,15 @@ internal sealed class DataGridServerService : IDisposable
             try
             {
                 await onServerRequest.InvokeAsync(request);
+                // Success-path stale guard: a newer request may have been
+                // issued while this callback awaited. The service can't undo
+                // a stale Items assignment the consumer already made — that's
+                // why DataGridServerRequest.CancellationToken exists and the
+                // consumer MUST check request.IsCurrent (or the token) before
+                // assigning. What we CAN do here is stop a stale request from
+                // clearing Error / resetting IsLoading for the newer one.
+                if (generation != _requestGeneration)
+                    return;
             }
             catch (OperationCanceledException)
             {

--- a/src/Lumeo.DataGrid/UI/DataGrid/DataGridState.cs
+++ b/src/Lumeo.DataGrid/UI/DataGrid/DataGridState.cs
@@ -68,7 +68,20 @@ public record DataGridServerRequest(
     string? GlobalSearch,
     string? GroupBy = null,
     CancellationToken CancellationToken = default
-);
+)
+{
+    /// <summary>True while this is still the grid's most recent request.
+    /// Becomes false once a newer request supersedes it. Check this (or
+    /// <see cref="CancellationToken"/>) immediately before assigning the
+    /// fetched rows to your bound <c>Items</c> so an out-of-order completion
+    /// can't overwrite a newer page:
+    /// <code>
+    /// var data = await Api.QueryAsync(req.Page, req.CancellationToken);
+    /// if (req.IsCurrent) Items = data.Rows;
+    /// </code>
+    /// </summary>
+    public bool IsCurrent => !CancellationToken.IsCancellationRequested;
+}
 
 public record DataGridServerResponse<TItem>(
     IEnumerable<TItem> Items,

--- a/src/Lumeo/Density.cs
+++ b/src/Lumeo/Density.cs
@@ -1,0 +1,29 @@
+namespace Lumeo;
+
+/// <summary>
+/// Orthogonal "tightness" axis applied across sized components. Sits next to
+/// the size scale (<see cref="Size"/>) rather than replacing it: a
+/// <c>Size.Md</c> button can render at <c>Density.Compact</c> for a dense
+/// admin grid or <c>Density.Spacious</c> for a marketing hero, without
+/// scaling the type ramp itself.
+/// </summary>
+/// <remarks>
+/// Components opt in per-component by reading <see cref="DensityScope.Current"/>
+/// from a cascading <see cref="DensityScope"/> wrapper, or by accepting an
+/// explicit <c>Density</c> parameter that overrides the inherited value. Only
+/// padding / gap / row-height tokens shift between values — text size, icon
+/// size, and border radius are unaffected (use <see cref="Size"/> for those).
+/// </remarks>
+public enum Density
+{
+    /// <summary>Minimum padding. For data grids, dense admin tables, sidebar
+    /// pickers. Visual hit area is ~24-28px.</summary>
+    Compact = 0,
+
+    /// <summary>Default. Standard app density. Hit area ~36-40px.</summary>
+    Comfortable = 1,
+
+    /// <summary>Generous padding. Marketing pages, onboarding wizards,
+    /// thumb-first mobile UIs. Hit area ~44-48px (Apple HIG minimum).</summary>
+    Spacious = 2,
+}

--- a/src/Lumeo/Services/OverlayService.cs
+++ b/src/Lumeo/Services/OverlayService.cs
@@ -152,7 +152,7 @@ public sealed class OverlayParameters
     public Dictionary<string, object> ToDictionary() => new(_parameters);
 }
 
-public sealed record OverlayOptions
+public record OverlayOptions
 {
     public string? Class { get; init; }
     public bool PreventClose { get; init; }
@@ -226,6 +226,27 @@ public sealed record OverlayOptions
     /// </summary>
     public bool ScrollableBody { get; init; } = true;
 }
+
+/// <summary>
+/// Sheet-specific overlay options. Type-distinguishes the sheet-only properties
+/// (<see cref="OverlayOptions.SheetSide"/>, <see cref="OverlayOptions.SheetSize"/>,
+/// <see cref="OverlayOptions.SwipeToClose"/>, <see cref="OverlayOptions.MobileSheetSide"/>,
+/// <see cref="OverlayOptions.MobileSheetSize"/>, <see cref="OverlayOptions.MobileSwipeToClose"/>)
+/// from the shared base — passing this to <see cref="OverlayService.ShowDialogAsync{T}"/>
+/// would not compile, eliminating the silent-no-op class of bug (#87.1).
+/// Use <c>OverlayOptions</c> when you don't need the typed contract.
+/// </summary>
+public sealed record SheetOverlayOptions : OverlayOptions { }
+
+/// <summary>Dialog-specific overlay options. Currently identical surface to the
+/// shared base but typed separately so the sheet-only properties carry a
+/// "no effect here" signal at the type level.</summary>
+public sealed record DialogOverlayOptions : OverlayOptions { }
+
+/// <summary>Drawer-specific overlay options. Drawer enables swipe-to-close by
+/// default; the inherited <see cref="OverlayOptions.SwipeToClose"/> is ignored
+/// for drawers.</summary>
+public sealed record DrawerOverlayOptions : OverlayOptions { }
 
 public sealed record AlertDialogOptions
 {

--- a/src/Lumeo/Services/OverlayService.cs
+++ b/src/Lumeo/Services/OverlayService.cs
@@ -228,24 +228,27 @@ public record OverlayOptions
 }
 
 /// <summary>
-/// Sheet-specific overlay options. Type-distinguishes the sheet-only properties
-/// (<see cref="OverlayOptions.SheetSide"/>, <see cref="OverlayOptions.SheetSize"/>,
-/// <see cref="OverlayOptions.SwipeToClose"/>, <see cref="OverlayOptions.MobileSheetSide"/>,
-/// <see cref="OverlayOptions.MobileSheetSize"/>, <see cref="OverlayOptions.MobileSwipeToClose"/>)
-/// from the shared base — passing this to <see cref="OverlayService.ShowDialogAsync{T}"/>
-/// would not compile, eliminating the silent-no-op class of bug (#87.1).
-/// Use <c>OverlayOptions</c> when you don't need the typed contract.
+/// Sheet-shaped overlay options. <b>Semantic</b> marker — at the call site
+/// you get clearer intent ("this configures a Sheet") and IDE navigation,
+/// but the existing <see cref="OverlayService.ShowDialogAsync{T}"/> /
+/// <see cref="OverlayService.ShowDrawerAsync{T}"/> still accept any
+/// <see cref="OverlayOptions"/> via standard subtype polymorphism, so
+/// nothing prevents passing this record to the wrong service overload —
+/// the unused sheet-only properties stay silent no-ops there.
+/// Compile-time enforcement requires narrowing the service-method
+/// signatures to the typed record (planned for 4.0 as a breaking change).
 /// </summary>
 public sealed record SheetOverlayOptions : OverlayOptions { }
 
-/// <summary>Dialog-specific overlay options. Currently identical surface to the
-/// shared base but typed separately so the sheet-only properties carry a
-/// "no effect here" signal at the type level.</summary>
+/// <summary>Dialog-shaped overlay options. Semantic marker (same caveat as
+/// <see cref="SheetOverlayOptions"/>) — typed for documentation and IDE
+/// auto-complete, not enforced at the service overload boundary.</summary>
 public sealed record DialogOverlayOptions : OverlayOptions { }
 
-/// <summary>Drawer-specific overlay options. Drawer enables swipe-to-close by
-/// default; the inherited <see cref="OverlayOptions.SwipeToClose"/> is ignored
-/// for drawers.</summary>
+/// <summary>Drawer-shaped overlay options. Drawer enables swipe-to-close by
+/// default; the inherited <see cref="OverlayOptions.SwipeToClose"/> is
+/// ignored for drawers. Semantic marker (see <see cref="SheetOverlayOptions"/>
+/// for the enforcement caveat).</summary>
 public sealed record DrawerOverlayOptions : OverlayOptions { }
 
 public sealed record AlertDialogOptions

--- a/src/Lumeo/UI/Alert/Alert.razor
+++ b/src/Lumeo/UI/Alert/Alert.razor
@@ -62,6 +62,12 @@
     [Parameter] public RenderFragment? ChildContent { get; set; }
     [Parameter] public AlertVariant Variant { get; set; } = AlertVariant.Default;
     [Parameter] public Lumeo.Size Size { get; set; } = Lumeo.Size.Md;
+    /// <summary>Per-alert density override. When null, inherits from any
+    /// ancestor <see cref="DensityScope"/>; if neither is set, matches the
+    /// historical <c>Comfortable</c> default. Only the box padding shifts —
+    /// text/icon size stay governed by <see cref="Size"/>.</summary>
+    [Parameter] public Density? Density { get; set; }
+    [CascadingParameter] private Density? InheritedDensity { get; set; }
     [Parameter] public bool IsDismissible { get; set; }
     [Parameter] public EventCallback OnDismiss { get; set; }
     [Parameter] public string? Title { get; set; }
@@ -115,11 +121,21 @@
     // colored variants knock it softer since their tinted background already carries the visual weight.
     private string CssClass => $"relative w-full rounded-lg border border-border/60 {SizePaddingClass} text-sm {VariantClasses} {Class}".Trim();
 
-    private string SizePaddingClass => Size switch
+    private Lumeo.Density EffectiveDensity => Density ?? InheritedDensity ?? Lumeo.Density.Comfortable;
+
+    // Box padding tracks Size x Density; Comfortable reproduces the historical
+    // per-Size values verbatim.
+    private string SizePaddingClass => (Size, EffectiveDensity) switch
     {
-        Lumeo.Size.Sm => "px-3 py-2",
-        Lumeo.Size.Lg => "px-5 py-4",
-        _ => "px-4 py-3"
+        (Lumeo.Size.Sm, Lumeo.Density.Compact)  => "px-2.5 py-1.5",
+        (Lumeo.Size.Sm, Lumeo.Density.Spacious) => "px-4 py-3",
+        (Lumeo.Size.Sm, _)                      => "px-3 py-2",
+        (Lumeo.Size.Lg, Lumeo.Density.Compact)  => "px-4 py-3",
+        (Lumeo.Size.Lg, Lumeo.Density.Spacious) => "px-6 py-5",
+        (Lumeo.Size.Lg, _)                      => "px-5 py-4",
+        (_, Lumeo.Density.Compact)              => "px-3 py-2",
+        (_, Lumeo.Density.Spacious)             => "px-5 py-4",
+        _                                       => "px-4 py-3"
     };
 
     private string IconSizeClass => Size switch

--- a/src/Lumeo/UI/Badge/Badge.razor
+++ b/src/Lumeo/UI/Badge/Badge.razor
@@ -52,8 +52,9 @@
 
     /// <summary>Per-badge density override. When null, inherits from any
     /// ancestor <see cref="DensityScope"/>; if neither is set, matches the
-    /// historical <c>Comfortable</c> default. Only the horizontal padding
-    /// shifts; text size + radius are unchanged. Has no effect on dot badges.</summary>
+    /// historical <c>Comfortable</c> default. Adjusts padding (Spacious also
+    /// adds a touch of vertical padding); text size + radius are unchanged.
+    /// Has no effect on dot badges.</summary>
     [Parameter] public Density? Density { get; set; }
     [CascadingParameter] private Density? InheritedDensity { get; set; }
     [Parameter] public string? Class { get; set; }
@@ -74,7 +75,7 @@
         }
     }
 
-    // Horizontal padding tracks density; Comfortable reproduces the historical px-2.5.
+    // Padding tracks density; Comfortable reproduces the historical px-2.5 py-0.5.
     private string PadClass => EffectiveDensity switch
     {
         Lumeo.Density.Compact => "px-2 py-0.5",

--- a/src/Lumeo/UI/Badge/Badge.razor
+++ b/src/Lumeo/UI/Badge/Badge.razor
@@ -50,10 +50,18 @@
     /// </summary>
     [Parameter] public bool Animated { get; set; }
 
+    /// <summary>Per-badge density override. When null, inherits from any
+    /// ancestor <see cref="DensityScope"/>; if neither is set, matches the
+    /// historical <c>Comfortable</c> default. Only the horizontal padding
+    /// shifts; text size + radius are unchanged. Has no effect on dot badges.</summary>
+    [Parameter] public Density? Density { get; set; }
+    [CascadingParameter] private Density? InheritedDensity { get; set; }
     [Parameter] public string? Class { get; set; }
     [Parameter(CaptureUnmatchedValues = true)] public Dictionary<string, object>? AdditionalAttributes { get; set; }
 
     private bool _isRemoved;
+
+    private Lumeo.Density EffectiveDensity => Density ?? InheritedDensity ?? Lumeo.Density.Comfortable;
 
     private string CssClass
     {
@@ -62,11 +70,19 @@
             var animatedClass = Animated ? "lumeo-badge-animated" : null;
             return IsDot
                 ? Cx.Join("inline-flex h-2 w-2 rounded-full p-0", VariantClasses, animatedClass, Class)
-                : Cx.Join(BaseClasses, VariantClasses, animatedClass, Class);
+                : Cx.Join(BaseClasses, PadClass, VariantClasses, animatedClass, Class);
         }
     }
 
-    private const string BaseClasses = "inline-flex items-center rounded-md border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none";
+    // Horizontal padding tracks density; Comfortable reproduces the historical px-2.5.
+    private string PadClass => EffectiveDensity switch
+    {
+        Lumeo.Density.Compact => "px-2 py-0.5",
+        Lumeo.Density.Spacious => "px-3 py-1",
+        _ => "px-2.5 py-0.5"
+    };
+
+    private const string BaseClasses = "inline-flex items-center rounded-md border text-xs font-semibold transition-colors focus:outline-none";
 
     private string DotClasses => VariantClasses;
 

--- a/src/Lumeo/UI/Button/Button.razor
+++ b/src/Lumeo/UI/Button/Button.razor
@@ -133,7 +133,9 @@
                 (ButtonSize.Default, Lumeo.Density.Compact)  => ("h-8",  "px-3",  "h-8 w-8"),
                 (ButtonSize.Default, Lumeo.Density.Spacious) => ("h-11", "px-6 py-2.5", "h-11 w-11"),
                 (ButtonSize.Default, _)                      => ("h-9",  "px-4 py-2",   "h-9 w-9"),
-                (ButtonSize.Icon, _)                         => ("h-9",  "",       "h-9 w-9"),
+                (ButtonSize.Icon, Lumeo.Density.Compact)  => ("h-8",  "",       "h-8 w-8"),
+                (ButtonSize.Icon, Lumeo.Density.Spacious) => ("h-11", "",       "h-11 w-11"),
+                (ButtonSize.Icon, _)                      => ("h-9",  "",       "h-9 w-9"),
                 _ => ("", "", "")
             };
             var textClass = Size == ButtonSize.Sm ? " text-xs" : "";

--- a/src/Lumeo/UI/Button/Button.razor
+++ b/src/Lumeo/UI/Button/Button.razor
@@ -38,6 +38,13 @@
     [Parameter] public RenderFragment? RightIcon { get; set; }
     [Parameter] public ButtonVariant Variant { get; set; } = ButtonVariant.Default;
     [Parameter] public ButtonSize Size { get; set; } = ButtonSize.Default;
+    /// <summary>Per-button density override. When null, the button inherits
+    /// from any ancestor <see cref="DensityScope"/>; if neither is set,
+    /// behaviour matches the historical <c>Comfortable</c> default. Only
+    /// padding / row-height shifts between values — text size + radius
+    /// are governed by <see cref="Size"/>.</summary>
+    [Parameter] public Density? Density { get; set; }
+    [CascadingParameter] private Density? InheritedDensity { get; set; }
     [Parameter] public bool FullWidth { get; set; }
     [Parameter] public string? Class { get; set; }
     [Parameter] public EventCallback<Microsoft.AspNetCore.Components.Web.MouseEventArgs> OnClick { get; set; }
@@ -109,14 +116,33 @@
         _ => ""
     };
 
-    private string SizeClasses => Size switch
+    private Lumeo.Density EffectiveDensity => Density ?? InheritedDensity ?? Lumeo.Density.Comfortable;
+
+    private string SizeClasses
     {
-        ButtonSize.Default => "h-9 px-4 py-2",
-        ButtonSize.Sm => "h-8 rounded-md px-3 text-xs",
-        ButtonSize.Lg => "h-10 rounded-md px-8",
-        ButtonSize.Icon => "h-9 w-9",
-        _ => ""
-    };
+        get
+        {
+            var (height, pad, padIcon) = (Size, EffectiveDensity) switch
+            {
+                (ButtonSize.Sm, Lumeo.Density.Compact)    => ("h-7",  "px-2.5",  "h-7 w-7"),
+                (ButtonSize.Sm, Lumeo.Density.Spacious)   => ("h-9",  "px-4",    "h-9 w-9"),
+                (ButtonSize.Sm, _)                        => ("h-8",  "px-3",    "h-8 w-8"),
+                (ButtonSize.Lg, Lumeo.Density.Compact)    => ("h-9",  "px-6",    "h-9 w-9"),
+                (ButtonSize.Lg, Lumeo.Density.Spacious)   => ("h-12", "px-10",   "h-12 w-12"),
+                (ButtonSize.Lg, _)                        => ("h-10", "px-8",    "h-10 w-10"),
+                (ButtonSize.Default, Lumeo.Density.Compact)  => ("h-8",  "px-3",  "h-8 w-8"),
+                (ButtonSize.Default, Lumeo.Density.Spacious) => ("h-11", "px-6 py-2.5", "h-11 w-11"),
+                (ButtonSize.Default, _)                      => ("h-9",  "px-4 py-2",   "h-9 w-9"),
+                (ButtonSize.Icon, _)                         => ("h-9",  "",       "h-9 w-9"),
+                _ => ("", "", "")
+            };
+            var textClass = Size == ButtonSize.Sm ? " text-xs" : "";
+            var radiusClass = Size is ButtonSize.Sm or ButtonSize.Lg ? " rounded-md" : "";
+            return Size == ButtonSize.Icon
+                ? padIcon + radiusClass
+                : $"{height} {pad}{textClass}{radiusClass}";
+        }
+    }
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {

--- a/src/Lumeo/UI/Card/Card.razor
+++ b/src/Lumeo/UI/Card/Card.razor
@@ -3,21 +3,25 @@
 
 @if (OnClick.HasDelegate)
 {
-    <div @ref="_el"
-         class="@CssClass"
-         role="button"
-         tabindex="0"
-         @onclick="OnClick"
-         @onkeydown="HandleKeyDown"
-         @attributes="AdditionalAttributes">
-        @ChildContent
-    </div>
+    <CascadingValue TValue="Lumeo.Density?" Value="EffectiveDensity" IsFixed="false">
+        <div @ref="_el"
+             class="@CssClass"
+             role="button"
+             tabindex="0"
+             @onclick="OnClick"
+             @onkeydown="HandleKeyDown"
+             @attributes="AdditionalAttributes">
+            @ChildContent
+        </div>
+    </CascadingValue>
 }
 else
 {
-    <div class="@CssClass" @attributes="AdditionalAttributes">
-        @ChildContent
-    </div>
+    <CascadingValue TValue="Lumeo.Density?" Value="EffectiveDensity" IsFixed="false">
+        <div class="@CssClass" @attributes="AdditionalAttributes">
+            @ChildContent
+        </div>
+    </CascadingValue>
 }
 
 @code {
@@ -59,22 +63,10 @@ else
         _ => null
     };
 
-    private Lumeo.Density EffectiveDensity => Density ?? InheritedDensity ?? Lumeo.Density.Comfortable;
-
-    // Density controls the implicit gap rhythm inside the card via a
-    // descendant-only space-y selector — leaf CardHeader / CardContent /
-    // CardFooter components keep their own padding, so this gives a
-    // visible tightness shift without coupling Card to its children.
-    private string GapClass => EffectiveDensity switch
-    {
-        Lumeo.Density.Compact => "[&>*+*]:mt-2",
-        Lumeo.Density.Spacious => "[&>*+*]:mt-6",
-        _ => ""
-    };
+    private Lumeo.Density? EffectiveDensity => Density ?? InheritedDensity;
 
     private string CssClass => Cx.Join(
         "rounded-lg border border-border/40 bg-card text-card-foreground",
-        GapClass,
         Cx.When(IsInteractive, "cursor-pointer transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 hover:bg-accent/30"),
         IsInteractive ? PressEffectClass : null,
         Class);

--- a/src/Lumeo/UI/Card/Card.razor
+++ b/src/Lumeo/UI/Card/Card.razor
@@ -38,6 +38,13 @@ else
     /// </summary>
     [Parameter] public Button.ButtonPressEffect PressEffect { get; set; } = Button.ButtonPressEffect.None;
 
+    /// <summary>Per-card density override. Tightens internal padding when
+    /// rendered inside dense layouts (DataGrid row, dashboard tile grid).
+    /// Falls back to ancestor <see cref="DensityScope"/> or
+    /// <c>Comfortable</c>.</summary>
+    [Parameter] public Density? Density { get; set; }
+    [CascadingParameter] private Density? InheritedDensity { get; set; }
+
     [Parameter(CaptureUnmatchedValues = true)] public Dictionary<string, object>? AdditionalAttributes { get; set; }
 
     private Microsoft.AspNetCore.Components.ElementReference _el;
@@ -52,8 +59,22 @@ else
         _ => null
     };
 
+    private Lumeo.Density EffectiveDensity => Density ?? InheritedDensity ?? Lumeo.Density.Comfortable;
+
+    // Density controls the implicit gap rhythm inside the card via a
+    // descendant-only space-y selector — leaf CardHeader / CardContent /
+    // CardFooter components keep their own padding, so this gives a
+    // visible tightness shift without coupling Card to its children.
+    private string GapClass => EffectiveDensity switch
+    {
+        Lumeo.Density.Compact => "[&>*+*]:mt-2",
+        Lumeo.Density.Spacious => "[&>*+*]:mt-6",
+        _ => ""
+    };
+
     private string CssClass => Cx.Join(
         "rounded-lg border border-border/40 bg-card text-card-foreground",
+        GapClass,
         Cx.When(IsInteractive, "cursor-pointer transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 hover:bg-accent/30"),
         IsInteractive ? PressEffectClass : null,
         Class);

--- a/src/Lumeo/UI/Card/CardContent.razor
+++ b/src/Lumeo/UI/Card/CardContent.razor
@@ -1,11 +1,19 @@
 @namespace Lumeo
 
-<div class="@($"p-6 pt-0 {Class}".Trim())" @attributes="AdditionalAttributes">
+<div class="@($"{PadClass} {Class}".Trim())" @attributes="AdditionalAttributes">
     @ChildContent
 </div>
 
 @code {
     [Parameter] public RenderFragment? ChildContent { get; set; }
     [Parameter] public string? Class { get; set; }
+    [CascadingParameter] private Lumeo.Density? Density { get; set; }
     [Parameter(CaptureUnmatchedValues = true)] public Dictionary<string, object>? AdditionalAttributes { get; set; }
+
+    private string PadClass => Density switch
+    {
+        Lumeo.Density.Compact => "p-4 pt-0",
+        Lumeo.Density.Spacious => "p-8 pt-0",
+        _ => "p-6 pt-0"
+    };
 }

--- a/src/Lumeo/UI/Card/CardFooter.razor
+++ b/src/Lumeo/UI/Card/CardFooter.razor
@@ -1,11 +1,19 @@
 @namespace Lumeo
 
-<div class="@($"flex items-center p-6 pt-0 {Class}".Trim())" @attributes="AdditionalAttributes">
+<div class="@($"flex items-center {PadClass} {Class}".Trim())" @attributes="AdditionalAttributes">
     @ChildContent
 </div>
 
 @code {
     [Parameter] public RenderFragment? ChildContent { get; set; }
     [Parameter] public string? Class { get; set; }
+    [CascadingParameter] private Lumeo.Density? Density { get; set; }
     [Parameter(CaptureUnmatchedValues = true)] public Dictionary<string, object>? AdditionalAttributes { get; set; }
+
+    private string PadClass => Density switch
+    {
+        Lumeo.Density.Compact => "p-4 pt-0",
+        Lumeo.Density.Spacious => "p-8 pt-0",
+        _ => "p-6 pt-0"
+    };
 }

--- a/src/Lumeo/UI/Card/CardHeader.razor
+++ b/src/Lumeo/UI/Card/CardHeader.razor
@@ -1,11 +1,19 @@
 @namespace Lumeo
 
-<div class="@($"flex flex-col space-y-1.5 p-6 {Class}".Trim())" @attributes="AdditionalAttributes">
+<div class="@($"flex flex-col space-y-1.5 {PadClass} {Class}".Trim())" @attributes="AdditionalAttributes">
     @ChildContent
 </div>
 
 @code {
     [Parameter] public RenderFragment? ChildContent { get; set; }
     [Parameter] public string? Class { get; set; }
+    [CascadingParameter] private Lumeo.Density? Density { get; set; }
     [Parameter(CaptureUnmatchedValues = true)] public Dictionary<string, object>? AdditionalAttributes { get; set; }
+
+    private string PadClass => Density switch
+    {
+        Lumeo.Density.Compact => "p-4",
+        Lumeo.Density.Spacious => "p-8",
+        _ => "p-6"
+    };
 }

--- a/src/Lumeo/UI/Chip/Chip.razor
+++ b/src/Lumeo/UI/Chip/Chip.razor
@@ -31,6 +31,12 @@
     [Parameter] public ChipVariant Variant { get; set; } = ChipVariant.Default;
     [Parameter] public string? Color { get; set; }
     [Parameter] public Lumeo.Size Size { get; set; } = Lumeo.Size.Md;
+    /// <summary>Per-chip density override. When null, inherits from any
+    /// ancestor <see cref="DensityScope"/>; if neither is set, matches the
+    /// historical <c>Comfortable</c> default. Only the padding shifts — text
+    /// size + radius stay governed by <see cref="Size"/>.</summary>
+    [Parameter] public Density? Density { get; set; }
+    [CascadingParameter] private Density? InheritedDensity { get; set; }
     [Parameter] public bool Closable { get; set; }
     [Parameter] public EventCallback OnClose { get; set; }
     [Parameter] public bool Clickable { get; set; }
@@ -68,12 +74,32 @@
         Cx.When(Disabled, "opacity-50 pointer-events-none cursor-not-allowed"),
         Class);
 
+    private Lumeo.Density EffectiveDensity => Density ?? InheritedDensity ?? Lumeo.Density.Comfortable;
+
+    // Text + radius stay keyed on Size; only the padding varies with density.
+    // Comfortable reproduces the historical per-Size padding verbatim.
     private string SizeClass => Size switch
     {
-        Lumeo.Size.Xxs => "text-[10px] px-1.5 py-0 rounded",
-        Lumeo.Size.Sm => "text-xs px-2 py-0.5 rounded-md",
-        Lumeo.Size.Lg => "text-sm px-3 py-1 rounded-lg",
-        _ => "text-sm px-2.5 py-0.5 rounded-md"
+        Lumeo.Size.Xxs => $"text-[10px] {PadClass} rounded",
+        Lumeo.Size.Sm => $"text-xs {PadClass} rounded-md",
+        Lumeo.Size.Lg => $"text-sm {PadClass} rounded-lg",
+        _ => $"text-sm {PadClass} rounded-md"
+    };
+
+    private string PadClass => (Size, EffectiveDensity) switch
+    {
+        (Lumeo.Size.Xxs, Lumeo.Density.Compact)  => "px-1 py-0",
+        (Lumeo.Size.Xxs, Lumeo.Density.Spacious) => "px-2 py-0.5",
+        (Lumeo.Size.Xxs, _)                      => "px-1.5 py-0",
+        (Lumeo.Size.Sm, Lumeo.Density.Compact)   => "px-1.5 py-0",
+        (Lumeo.Size.Sm, Lumeo.Density.Spacious)  => "px-2.5 py-1",
+        (Lumeo.Size.Sm, _)                       => "px-2 py-0.5",
+        (Lumeo.Size.Lg, Lumeo.Density.Compact)   => "px-2.5 py-0.5",
+        (Lumeo.Size.Lg, Lumeo.Density.Spacious)  => "px-4 py-1.5",
+        (Lumeo.Size.Lg, _)                       => "px-3 py-1",
+        (_, Lumeo.Density.Compact)               => "px-2 py-0",
+        (_, Lumeo.Density.Spacious)              => "px-3 py-1",
+        _                                        => "px-2.5 py-0.5"
     };
 
     private string VariantClass => Variant switch

--- a/src/Lumeo/UI/Combobox/ComboboxInput.razor
+++ b/src/Lumeo/UI/Combobox/ComboboxInput.razor
@@ -2,7 +2,10 @@
 @inject Lumeo.Services.Localization.ILumeoLocalizer L
 
 <div class="relative">
-    <Blazicon Svg="Lucide.Search" class="absolute start-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
+    @* top-1/2 + -translate-y-1/2 keeps the icon centred across all density
+       heights (h-8 / h-9 / h-10) instead of the fixed top-2.5 that only
+       centred the historical 36px comfortable input. *@
+    <Blazicon Svg="Lucide.Search" class="absolute start-2.5 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
     <input id="@Context.InputId"
            type="text"
            role="combobox"

--- a/src/Lumeo/UI/Combobox/ComboboxInput.razor
+++ b/src/Lumeo/UI/Combobox/ComboboxInput.razor
@@ -22,11 +22,21 @@
 
 @code {
     [CascadingParameter] public Combobox.ComboboxContext Context { get; set; } = default!;
+    [CascadingParameter] private Lumeo.Density? Density { get; set; }
     [Parameter] public string? Placeholder { get; set; }
     [Parameter] public string? Class { get; set; }
     [Parameter(CaptureUnmatchedValues = true)] public Dictionary<string, object>? AdditionalAttributes { get; set; }
 
-    private string CssClass => $"flex h-9 w-full rounded-md border {(Context.Invalid ? "border-destructive" : "border-input")} bg-transparent py-2 ps-8 pe-3 text-sm placeholder:text-muted-foreground focus-visible:outline-none {(Context.Invalid ? "focus-visible:ring-[1.5px] focus-visible:ring-destructive/20" : "")} {Class}".Trim();
+    // Height + vertical padding track the ambient DensityScope; Comfortable
+    // reproduces the historical `h-9 py-2`.
+    private string SizeClasses => Density switch
+    {
+        Lumeo.Density.Compact => "h-8 py-1.5",
+        Lumeo.Density.Spacious => "h-10 py-2.5",
+        _ => "h-9 py-2"
+    };
+
+    private string CssClass => $"flex {SizeClasses} w-full rounded-md border {(Context.Invalid ? "border-destructive" : "border-input")} bg-transparent ps-8 pe-3 text-sm placeholder:text-muted-foreground focus-visible:outline-none {(Context.Invalid ? "focus-visible:ring-[1.5px] focus-visible:ring-destructive/20" : "")} {Class}".Trim();
 
     private async Task HandleInput(ChangeEventArgs e)
     {

--- a/src/Lumeo/UI/DensityScope/DensityScope.razor
+++ b/src/Lumeo/UI/DensityScope/DensityScope.razor
@@ -5,26 +5,22 @@
     descendant. Use at the page / panel level to flip every Lumeo
     component inside it without per-component edits.
 
-    Components that consume this read [CascadingParameter] Density,
+    Renders NO wrapper element — just the cascading value around its
+    ChildContent — so it is valid inside <tbody> / <tr> / <ul> and any
+    other context that only permits specific children. (An earlier
+    version wrapped a <div class="contents">, which is invalid DOM
+    inside those parents and triggered browser reparenting.)
+
+    Components that consume this read [CascadingParameter] Density?,
     fall back to Density.Comfortable when none is present, and let an
     explicit [Parameter] Density override the cascading value.
 *@
 
-@* Cascading type is Density? (nullable) to match the consumers' parameter
-   declaration — Blazor matches cascading values by exact type, so a
-   non-nullable Lumeo.Density provider would not satisfy a [CascadingParameter]
-   Density? consumer and every descendant would fall back to its default. *@
 <CascadingValue TValue="Lumeo.Density?" Value="Value" IsFixed="false">
-    <div class="@CssClass" @attributes="AdditionalAttributes">
-        @ChildContent
-    </div>
+    @ChildContent
 </CascadingValue>
 
 @code {
     [Parameter] public Lumeo.Density Value { get; set; } = Lumeo.Density.Comfortable;
     [Parameter] public RenderFragment? ChildContent { get; set; }
-    [Parameter] public string? Class { get; set; }
-    [Parameter(CaptureUnmatchedValues = true)] public Dictionary<string, object>? AdditionalAttributes { get; set; }
-
-    private string CssClass => $"contents {Class}".Trim();
 }

--- a/src/Lumeo/UI/DensityScope/DensityScope.razor
+++ b/src/Lumeo/UI/DensityScope/DensityScope.razor
@@ -1,0 +1,26 @@
+@namespace Lumeo
+
+@*
+    DensityScope — cascades a Density value to every density-aware
+    descendant. Use at the page / panel level to flip every Lumeo
+    component inside it without per-component edits.
+
+    Components that consume this read [CascadingParameter] Density,
+    fall back to Density.Comfortable when none is present, and let an
+    explicit [Parameter] Density override the cascading value.
+*@
+
+<CascadingValue Value="Value" IsFixed="false">
+    <div class="@CssClass" @attributes="AdditionalAttributes">
+        @ChildContent
+    </div>
+</CascadingValue>
+
+@code {
+    [Parameter] public Lumeo.Density Value { get; set; } = Lumeo.Density.Comfortable;
+    [Parameter] public RenderFragment? ChildContent { get; set; }
+    [Parameter] public string? Class { get; set; }
+    [Parameter(CaptureUnmatchedValues = true)] public Dictionary<string, object>? AdditionalAttributes { get; set; }
+
+    private string CssClass => $"contents {Class}".Trim();
+}

--- a/src/Lumeo/UI/DensityScope/DensityScope.razor
+++ b/src/Lumeo/UI/DensityScope/DensityScope.razor
@@ -10,7 +10,11 @@
     explicit [Parameter] Density override the cascading value.
 *@
 
-<CascadingValue Value="Value" IsFixed="false">
+@* Cascading type is Density? (nullable) to match the consumers' parameter
+   declaration — Blazor matches cascading values by exact type, so a
+   non-nullable Lumeo.Density provider would not satisfy a [CascadingParameter]
+   Density? consumer and every descendant would fall back to its default. *@
+<CascadingValue TValue="Lumeo.Density?" Value="Value" IsFixed="false">
     <div class="@CssClass" @attributes="AdditionalAttributes">
         @ChildContent
     </div>

--- a/src/Lumeo/UI/DropdownMenu/DropdownMenuCheckboxItem.razor
+++ b/src/Lumeo/UI/DropdownMenu/DropdownMenuCheckboxItem.razor
@@ -11,13 +11,23 @@
 </button>
 
 @code {
+    [CascadingParameter] private Lumeo.Density? Density { get; set; }
     [Parameter] public RenderFragment? ChildContent { get; set; }
     [Parameter] public bool Checked { get; set; }
     [Parameter] public EventCallback<bool> CheckedChanged { get; set; }
     [Parameter] public string? Class { get; set; }
     [Parameter(CaptureUnmatchedValues = true)] public Dictionary<string, object>? AdditionalAttributes { get; set; }
 
-    private string CssClass => $"relative flex w-full cursor-default select-none items-center gap-2 rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground {Class}".Trim();
+    // Row vertical padding tracks the ambient DensityScope; Comfortable
+    // reproduces the historical `py-1.5`.
+    private string PadYClass => Density switch
+    {
+        Lumeo.Density.Compact => "py-1",
+        Lumeo.Density.Spacious => "py-2.5",
+        _ => "py-1.5"
+    };
+
+    private string CssClass => $"relative flex w-full cursor-default select-none items-center gap-2 rounded-sm {PadYClass} pl-8 pr-2 text-sm outline-none transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground {Class}".Trim();
 
     private async Task Toggle()
     {

--- a/src/Lumeo/UI/DropdownMenu/DropdownMenuItem.razor
+++ b/src/Lumeo/UI/DropdownMenu/DropdownMenuItem.razor
@@ -6,13 +6,23 @@
 
 @code {
     [CascadingParameter] public DropdownMenu.DropdownMenuContext? Context { get; set; }
+    [CascadingParameter] private Lumeo.Density? Density { get; set; }
     [Parameter] public RenderFragment? ChildContent { get; set; }
     [Parameter] public EventCallback OnClick { get; set; }
     [Parameter] public bool Disabled { get; set; }
     [Parameter] public string? Class { get; set; }
     [Parameter(CaptureUnmatchedValues = true)] public Dictionary<string, object>? AdditionalAttributes { get; set; }
 
-    private string CssClass => $"relative flex w-full cursor-pointer select-none items-center gap-2 rounded-sm px-2 py-1.5 min-h-11 sm:min-h-0 text-sm outline-none transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground disabled:pointer-events-none disabled:opacity-50 disabled:cursor-not-allowed {Class}".Trim();
+    // Row vertical padding tracks the ambient DensityScope; Comfortable
+    // reproduces the historical `py-1.5`. The mobile touch floor stays.
+    private string PadYClass => Density switch
+    {
+        Lumeo.Density.Compact => "py-1",
+        Lumeo.Density.Spacious => "py-2.5",
+        _ => "py-1.5"
+    };
+
+    private string CssClass => $"relative flex w-full cursor-pointer select-none items-center gap-2 rounded-sm px-2 {PadYClass} min-h-11 sm:min-h-0 text-sm outline-none transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground disabled:pointer-events-none disabled:opacity-50 disabled:cursor-not-allowed {Class}".Trim();
 
     private async Task HandleClick()
     {

--- a/src/Lumeo/UI/DropdownMenu/DropdownMenuRadioItem.razor
+++ b/src/Lumeo/UI/DropdownMenu/DropdownMenuRadioItem.razor
@@ -12,6 +12,7 @@
 
 @code {
     [CascadingParameter] public DropdownMenuRadioGroup.DropdownMenuRadioGroupContext Context { get; set; } = default!;
+    [CascadingParameter] private Lumeo.Density? Density { get; set; }
     [Parameter] public RenderFragment? ChildContent { get; set; }
     [Parameter, EditorRequired] public string Value { get; set; } = "";
     [Parameter] public string? Class { get; set; }
@@ -19,7 +20,16 @@
 
     private bool IsSelected => Context.Value == Value;
 
-    private string CssClass => $"relative flex w-full cursor-default select-none items-center gap-2 rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground {Class}".Trim();
+    // Row vertical padding tracks the ambient DensityScope; Comfortable
+    // reproduces the historical `py-1.5`.
+    private string PadYClass => Density switch
+    {
+        Lumeo.Density.Compact => "py-1",
+        Lumeo.Density.Spacious => "py-2.5",
+        _ => "py-1.5"
+    };
+
+    private string CssClass => $"relative flex w-full cursor-default select-none items-center gap-2 rounded-sm {PadYClass} pl-8 pr-2 text-sm outline-none transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground {Class}".Trim();
 
     private async Task Select() => await Context.OnSelect.InvokeAsync(Value);
 }

--- a/src/Lumeo/UI/DropdownMenu/DropdownMenuSubTrigger.razor
+++ b/src/Lumeo/UI/DropdownMenu/DropdownMenuSubTrigger.razor
@@ -23,12 +23,22 @@
 
 @code {
     [CascadingParameter] public DropdownMenuSub.DropdownMenuSubContext SubContext { get; set; } = default!;
+    [CascadingParameter] private Lumeo.Density? Density { get; set; }
     [Parameter] public RenderFragment? ChildContent { get; set; }
     [Parameter] public bool Disabled { get; set; }
     [Parameter] public string? Class { get; set; }
     [Parameter(CaptureUnmatchedValues = true)] public Dictionary<string, object>? AdditionalAttributes { get; set; }
 
-    private string CssClass => $"relative flex w-full cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 min-h-11 sm:min-h-0 text-sm outline-none transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground disabled:pointer-events-none disabled:opacity-50 disabled:cursor-not-allowed {Class}".Trim();
+    // Row vertical padding tracks the ambient DensityScope; Comfortable
+    // reproduces the historical `py-1.5`. The mobile touch floor stays.
+    private string PadYClass => Density switch
+    {
+        Lumeo.Density.Compact => "py-1",
+        Lumeo.Density.Spacious => "py-2.5",
+        _ => "py-1.5"
+    };
+
+    private string CssClass => $"relative flex w-full cursor-default select-none items-center gap-2 rounded-sm px-2 {PadYClass} min-h-11 sm:min-h-0 text-sm outline-none transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground disabled:pointer-events-none disabled:opacity-50 disabled:cursor-not-allowed {Class}".Trim();
 
     private async Task HandleClick()
     {

--- a/src/Lumeo/UI/Input/Input.razor
+++ b/src/Lumeo/UI/Input/Input.razor
@@ -157,11 +157,17 @@ else
         _                                       => "h-9 text-sm"
     };
 
-    private string WrappedInputSizeClasses => Size switch
+    private string WrappedInputSizeClasses => (Size, EffectiveDensity) switch
     {
-        Lumeo.Size.Sm => "px-2.5 text-xs",
-        Lumeo.Size.Lg => "px-4 text-base",
-        _ => "px-3 text-sm"
+        (Lumeo.Size.Sm, Lumeo.Density.Compact)  => "px-2 text-xs",
+        (Lumeo.Size.Sm, Lumeo.Density.Spacious) => "px-3 text-xs",
+        (Lumeo.Size.Sm, _)                      => "px-2.5 text-xs",
+        (Lumeo.Size.Lg, Lumeo.Density.Compact)  => "px-3 text-base",
+        (Lumeo.Size.Lg, Lumeo.Density.Spacious) => "px-5 text-base",
+        (Lumeo.Size.Lg, _)                      => "px-4 text-base",
+        (_, Lumeo.Density.Compact)              => "px-2.5 text-sm",
+        (_, Lumeo.Density.Spacious)             => "px-4 text-sm",
+        _                                       => "px-3 text-sm"
     };
 
     private string CssClass => $"flex {SizeClasses} w-full rounded-md border {(EffectiveInvalid ? "border-destructive" : "border-input")} bg-transparent py-1 transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-[1.5px] {(EffectiveInvalid ? "focus-visible:ring-destructive/20" : "focus-visible:ring-ring")} disabled:cursor-not-allowed disabled:opacity-50 {Class}".Trim();

--- a/src/Lumeo/UI/Input/Input.razor
+++ b/src/Lumeo/UI/Input/Input.razor
@@ -84,6 +84,8 @@ else
     [Parameter] public RenderFragment? Prefix { get; set; }
     [Parameter] public RenderFragment? Suffix { get; set; }
     [Parameter] public Lumeo.Size Size { get; set; } = Lumeo.Size.Md;
+    [Parameter] public Density? Density { get; set; }
+    [CascadingParameter] private Density? InheritedDensity { get; set; }
     [Parameter] public bool Clearable { get; set; }
     [Parameter] public EventCallback OnClear { get; set; }
     [Parameter] public bool Required { get; set; }
@@ -127,18 +129,32 @@ else
     private bool EffectiveInvalid => Invalid || FormField?.HasError == true;
     private bool InsideFormField => FormField is not null;
 
-    private string SizeClasses => Size switch
+    private Lumeo.Density EffectiveDensity => Density ?? InheritedDensity ?? Lumeo.Density.Comfortable;
+
+    private string SizeClasses => (Size, EffectiveDensity) switch
     {
-        Lumeo.Size.Sm => "h-8 text-xs px-2.5",
-        Lumeo.Size.Lg => "h-11 text-base px-4",
-        _ => "h-9 text-sm px-3"
+        (Lumeo.Size.Sm, Lumeo.Density.Compact)  => "h-7 text-xs px-2",
+        (Lumeo.Size.Sm, Lumeo.Density.Spacious) => "h-9 text-xs px-3",
+        (Lumeo.Size.Sm, _)                      => "h-8 text-xs px-2.5",
+        (Lumeo.Size.Lg, Lumeo.Density.Compact)  => "h-10 text-base px-3",
+        (Lumeo.Size.Lg, Lumeo.Density.Spacious) => "h-12 text-base px-5",
+        (Lumeo.Size.Lg, _)                      => "h-11 text-base px-4",
+        (_, Lumeo.Density.Compact)              => "h-8 text-sm px-2.5",
+        (_, Lumeo.Density.Spacious)             => "h-10 text-sm px-4",
+        _                                       => "h-9 text-sm px-3"
     };
 
-    private string WrapperSizeClasses => Size switch
+    private string WrapperSizeClasses => (Size, EffectiveDensity) switch
     {
-        Lumeo.Size.Sm => "h-8 text-xs",
-        Lumeo.Size.Lg => "h-11 text-base",
-        _ => "h-9 text-sm"
+        (Lumeo.Size.Sm, Lumeo.Density.Compact)  => "h-7 text-xs",
+        (Lumeo.Size.Sm, Lumeo.Density.Spacious) => "h-9 text-xs",
+        (Lumeo.Size.Sm, _)                      => "h-8 text-xs",
+        (Lumeo.Size.Lg, Lumeo.Density.Compact)  => "h-10 text-base",
+        (Lumeo.Size.Lg, Lumeo.Density.Spacious) => "h-12 text-base",
+        (Lumeo.Size.Lg, _)                      => "h-11 text-base",
+        (_, Lumeo.Density.Compact)              => "h-8 text-sm",
+        (_, Lumeo.Density.Spacious)             => "h-10 text-sm",
+        _                                       => "h-9 text-sm"
     };
 
     private string WrappedInputSizeClasses => Size switch

--- a/src/Lumeo/UI/Input/Input.razor
+++ b/src/Lumeo/UI/Input/Input.razor
@@ -25,13 +25,13 @@
     <div class="@WrapperClass">
         @if (Variant == InputVariant.Search && Prefix == null)
         {
-            <div class="flex items-center ps-3 pe-1 text-muted-foreground">
+            <div class="@($"flex items-center {AccessoryStartPad} pe-1 text-muted-foreground")">
                 <Blazicon Svg="Lucide.Search" class="h-4 w-4" />
             </div>
         }
         else if (Prefix != null)
         {
-            <div class="flex items-center px-3 text-muted-foreground">@Prefix</div>
+            <div class="@($"flex items-center {AccessoryPad} text-muted-foreground")">@Prefix</div>
         }
         <input @ref="_inputRef"
                name="@Name"
@@ -41,13 +41,13 @@
                class="@WrappedInputClass" value="@Value" @oninput="HandleInput" disabled="@Disabled" @attributes="AdditionalAttributes" />
         @if (Clearable && !string.IsNullOrEmpty(Value))
         {
-            <button type="button" class="flex items-center px-2 text-muted-foreground hover:text-foreground transition-colors" @onclick="HandleClear" tabindex="-1" aria-label="@L["Common.Clear"]">
+            <button type="button" class="@($"flex items-center {AccessoryClearPad} text-muted-foreground hover:text-foreground transition-colors")" @onclick="HandleClear" tabindex="-1" aria-label="@L["Common.Clear"]">
                 <Blazicon Svg="Lucide.X" class="h-3.5 w-3.5" />
             </button>
         }
         @if (Suffix != null)
         {
-            <div class="flex items-center px-3 text-muted-foreground">@Suffix</div>
+            <div class="@($"flex items-center {AccessoryPad} text-muted-foreground")">@Suffix</div>
         }
     </div>
 }
@@ -155,6 +155,27 @@ else
         (_, Lumeo.Density.Compact)              => "h-8 text-sm",
         (_, Lumeo.Density.Spacious)             => "h-10 text-sm",
         _                                       => "h-9 text-sm"
+    };
+
+    // Accessory edge padding tracks density so prefix/suffix/search-icon/clear
+    // affordances tighten/loosen in step with the input body.
+    private string AccessoryPad => EffectiveDensity switch
+    {
+        Lumeo.Density.Compact => "px-2",
+        Lumeo.Density.Spacious => "px-4",
+        _ => "px-3"
+    };
+    private string AccessoryStartPad => EffectiveDensity switch
+    {
+        Lumeo.Density.Compact => "ps-2",
+        Lumeo.Density.Spacious => "ps-4",
+        _ => "ps-3"
+    };
+    private string AccessoryClearPad => EffectiveDensity switch
+    {
+        Lumeo.Density.Compact => "px-1.5",
+        Lumeo.Density.Spacious => "px-3",
+        _ => "px-2"
     };
 
     private string WrappedInputSizeClasses => (Size, EffectiveDensity) switch

--- a/src/Lumeo/UI/List/ListItem.razor
+++ b/src/Lumeo/UI/List/ListItem.razor
@@ -1,11 +1,19 @@
 @namespace Lumeo
 
 @{
-    var paddingClass = Context?.Size switch
+    // Row padding keyed on List Size x ambient DensityScope; Comfortable
+    // reproduces the historical per-Size padding verbatim.
+    var paddingClass = (Context?.Size ?? Lumeo.Size.Md, Density ?? Lumeo.Density.Comfortable) switch
     {
-        Lumeo.Size.Sm => "px-3 py-2",
-        Lumeo.Size.Lg => "px-5 py-4",
-        _ => "px-4 py-3"
+        (Lumeo.Size.Sm, Lumeo.Density.Compact)  => "px-2.5 py-1.5",
+        (Lumeo.Size.Sm, Lumeo.Density.Spacious) => "px-4 py-3",
+        (Lumeo.Size.Sm, _)                      => "px-3 py-2",
+        (Lumeo.Size.Lg, Lumeo.Density.Compact)  => "px-4 py-3",
+        (Lumeo.Size.Lg, Lumeo.Density.Spacious) => "px-6 py-5",
+        (Lumeo.Size.Lg, _)                      => "px-5 py-4",
+        (_, Lumeo.Density.Compact)              => "px-3 py-2",
+        (_, Lumeo.Density.Spacious)             => "px-5 py-4",
+        _                                       => "px-4 py-3"
     };
     var hoverClass = Context?.Hoverable == true ? "hover:bg-accent/50 transition-colors" : "";
     var clickableClass = (OnClick.HasDelegate || !string.IsNullOrEmpty(Href)) ? "cursor-pointer" : "";
@@ -71,6 +79,7 @@ else
 
 @code {
     [CascadingParameter] public List.ListContext? Context { get; set; }
+    [CascadingParameter] private Lumeo.Density? Density { get; set; }
 
     [Parameter] public RenderFragment? ChildContent { get; set; }
     [Parameter] public RenderFragment? Leading { get; set; }

--- a/src/Lumeo/UI/NumberInput/NumberInput.razor
+++ b/src/Lumeo/UI/NumberInput/NumberInput.razor
@@ -13,13 +13,13 @@
 
 <div class="@CssClass" @attributes="AdditionalAttributes">
     <button type="button"
-            class="@($"inline-flex h-9 w-9 items-center justify-center rounded-l-md border border-r-0 {(EffectiveInvalid ? "border-destructive" : "border-border/60")} bg-muted text-muted-foreground transition-colors hover:bg-muted/80 focus-visible:outline-none focus-visible:ring-[1.5px] focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:relative focus-visible:z-10 disabled:pointer-events-none disabled:opacity-50")"
+            class="@($"inline-flex {ControlSizeClass} items-center justify-center rounded-l-md border border-r-0 {(EffectiveInvalid ? "border-destructive" : "border-border/60")} bg-muted text-muted-foreground transition-colors hover:bg-muted/80 focus-visible:outline-none focus-visible:ring-[1.5px] focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:relative focus-visible:z-10 disabled:pointer-events-none disabled:opacity-50")"
             disabled="@(Disabled || IsAtMin)"
             @onclick="Decrement"
             aria-label="@L["NumberInput.Decrease"]">
         <Blazicon Svg="Lucide.Minus" class="h-4 w-4" />
     </button>
-    <div class="@($"relative inline-flex items-center h-9 border {(EffectiveInvalid ? "border-destructive" : "border-border/60")} bg-background")">
+    <div class="@($"relative inline-flex items-center {HeightClass} border {(EffectiveInvalid ? "border-destructive" : "border-border/60")} bg-background")">
         @if (!string.IsNullOrEmpty(Prefix))
         {
             <span class="pl-2 text-sm text-muted-foreground select-none">@Prefix</span>
@@ -30,7 +30,7 @@
                aria-required="@Required.ToString().ToLowerInvariant()"
                aria-invalid="@EffectiveInvalid.ToString().ToLowerInvariant()"
                aria-label="@EffectiveAriaLabel"
-               class="h-9 w-20 bg-transparent @(string.IsNullOrEmpty(Prefix) && string.IsNullOrEmpty(Suffix) ? "px-3" : "px-1") text-center text-sm text-foreground outline-none [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
+               class="@($"{HeightClass} w-20 bg-transparent {(string.IsNullOrEmpty(Prefix) && string.IsNullOrEmpty(Suffix) ? "px-3" : "px-1")} text-center text-sm text-foreground outline-none [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none")"
                value="@DisplayValue"
                disabled="@Disabled"
                min="@Min"
@@ -46,7 +46,7 @@
         }
     </div>
     <button type="button"
-            class="@($"inline-flex h-9 w-9 items-center justify-center rounded-r-md border border-l-0 {(EffectiveInvalid ? "border-destructive" : "border-border/60")} bg-muted text-muted-foreground transition-colors hover:bg-muted/80 focus-visible:outline-none focus-visible:ring-[1.5px] focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:relative focus-visible:z-10 disabled:pointer-events-none disabled:opacity-50")"
+            class="@($"inline-flex {ControlSizeClass} items-center justify-center rounded-r-md border border-l-0 {(EffectiveInvalid ? "border-destructive" : "border-border/60")} bg-muted text-muted-foreground transition-colors hover:bg-muted/80 focus-visible:outline-none focus-visible:ring-[1.5px] focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:relative focus-visible:z-10 disabled:pointer-events-none disabled:opacity-50")"
             disabled="@(Disabled || IsAtMax)"
             @onclick="Increment"
             aria-label="@L["NumberInput.Increase"]">
@@ -103,10 +103,34 @@
     /// See <c>Input.AutoFocus</c> for why the HTML <c>autofocus</c> attribute
     /// doesn't work in Blazor WASM.</summary>
     [Parameter] public bool AutoFocus { get; set; }
+    /// <summary>Per-control density override. When null, inherits from any
+    /// ancestor <see cref="DensityScope"/>; if neither is set, matches the
+    /// historical <c>Comfortable</c> default. Only the control height shifts
+    /// between values.</summary>
+    [Parameter] public Density? Density { get; set; }
+    [CascadingParameter] private Density? InheritedDensity { get; set; }
     [Parameter] public string? Class { get; set; }
     [Parameter(CaptureUnmatchedValues = true)] public Dictionary<string, object>? AdditionalAttributes { get; set; }
 
     private ElementReference _inputRef;
+
+    private Lumeo.Density EffectiveDensity => Density ?? InheritedDensity ?? Lumeo.Density.Comfortable;
+
+    // Height tracks density; Comfortable reproduces the historical h-9.
+    private string HeightClass => EffectiveDensity switch
+    {
+        Lumeo.Density.Compact => "h-8",
+        Lumeo.Density.Spacious => "h-10",
+        _ => "h-9"
+    };
+
+    // Stepper buttons stay square so the +/- glyphs remain centred.
+    private string ControlSizeClass => EffectiveDensity switch
+    {
+        Lumeo.Density.Compact => "h-8 w-8",
+        Lumeo.Density.Spacious => "h-10 w-10",
+        _ => "h-9 w-9"
+    };
 
     /// <summary>The underlying number &lt;input&gt; element.</summary>
     public ElementReference Element => _inputRef;

--- a/src/Lumeo/UI/OverlayForm/OverlayForm.razor
+++ b/src/Lumeo/UI/OverlayForm/OverlayForm.razor
@@ -22,6 +22,8 @@
                 <Button Type="submit">Save</Button>
             </Footer>
         </OverlayForm>
+
+    <gotcha>Renders an empty shell (nothing visible) until Model is set — the EditContext is deferred to avoid crashing EditForm on a null Model, so a missing Model fails silently rather than throwing.</gotcha>
 *@
 
 @if (_editContext is null)

--- a/src/Lumeo/UI/OverlayForm/OverlayForm.razor
+++ b/src/Lumeo/UI/OverlayForm/OverlayForm.razor
@@ -24,37 +24,47 @@
         </OverlayForm>
 *@
 
-<EditForm EditContext="@_editContext" OnValidSubmit="OnValidSubmit" OnInvalidSubmit="OnInvalidSubmit" class="@CssClass" @attributes="AdditionalAttributes">
-    @if (Validator is not null)
-    {
-        @Validator
-    }
-    else
-    {
-        <DataAnnotationsValidator />
-    }
+@if (_editContext is null)
+{
+    @* No Model supplied yet — render an empty shell rather than crashing
+       the EditForm. This is the path the lib-wide ComponentContractTests
+       hit when they instantiate every component with default parameters. *@
+    <div class="@CssClass" @attributes="AdditionalAttributes"></div>
+}
+else
+{
+    <EditForm EditContext="@_editContext" OnValidSubmit="OnValidSubmit" OnInvalidSubmit="OnInvalidSubmit" class="@CssClass" @attributes="AdditionalAttributes">
+        @if (Validator is not null)
+        {
+            @Validator
+        }
+        else
+        {
+            <DataAnnotationsValidator />
+        }
 
-    @if (Header is not null)
-    {
-        <div class="shrink-0 mb-3">
-            @Header
+        @if (Header is not null)
+        {
+            <div class="shrink-0 mb-3">
+                @Header
+            </div>
+        }
+
+        <div class="flex-1 min-h-0 overflow-y-auto pe-1">
+            @Body
         </div>
-    }
 
-    <div class="flex-1 min-h-0 overflow-y-auto pe-1">
-        @Body
-    </div>
-
-    @if (Footer is not null)
-    {
-        <div class="shrink-0 mt-3 pt-3 border-t border-border/40 flex items-center justify-end gap-2">
-            @Footer
-        </div>
-    }
-</EditForm>
+        @if (Footer is not null)
+        {
+            <div class="shrink-0 mt-3 pt-3 border-t border-border/40 flex items-center justify-end gap-2">
+                @Footer
+            </div>
+        }
+    </EditForm>
+}
 
 @code {
-    [Parameter, EditorRequired] public object Model { get; set; } = default!;
+    [Parameter, EditorRequired] public object? Model { get; set; }
     [Parameter] public EventCallback<EditContext> OnValidSubmit { get; set; }
     [Parameter] public EventCallback<EditContext> OnInvalidSubmit { get; set; }
 
@@ -74,6 +84,15 @@
 
     protected override void OnParametersSet()
     {
+        // Defer the EditContext until a Model is actually supplied —
+        // EditForm crashes hard on a null Model + null EditContext, and
+        // the contract-test path renders every component with no params.
+        if (Model is null)
+        {
+            _editContext = null;
+            _lastModel = null;
+            return;
+        }
         if (!ReferenceEquals(_lastModel, Model))
         {
             _editContext = new EditContext(Model);

--- a/src/Lumeo/UI/Pagination/PaginationEllipsis.razor
+++ b/src/Lumeo/UI/Pagination/PaginationEllipsis.razor
@@ -9,8 +9,18 @@
 </li>
 
 @code {
+    [CascadingParameter] private Lumeo.Density? Density { get; set; }
     [Parameter] public string? Class { get; set; }
     [Parameter(CaptureUnmatchedValues = true)] public Dictionary<string, object>? AdditionalAttributes { get; set; }
 
-    private string CssClass => $"flex h-9 w-9 items-center justify-center {Class}".Trim();
+    // Tracks the ambient DensityScope so the ellipsis aligns with the page
+    // cells; Comfortable reproduces the historical `h-9 w-9`.
+    private string SizeClass => Density switch
+    {
+        Lumeo.Density.Compact => "h-8 w-8",
+        Lumeo.Density.Spacious => "h-10 w-10",
+        _ => "h-9 w-9"
+    };
+
+    private string CssClass => $"flex {SizeClass} items-center justify-center {Class}".Trim();
 }

--- a/src/Lumeo/UI/Pagination/PaginationItem.razor
+++ b/src/Lumeo/UI/Pagination/PaginationItem.razor
@@ -10,8 +10,19 @@
     [Parameter] public RenderFragment? ChildContent { get; set; }
     [Parameter] public bool IsActive { get; set; }
     [Parameter] public EventCallback OnClick { get; set; }
+    [CascadingParameter] private Lumeo.Density? Density { get; set; }
     [Parameter] public string? Class { get; set; }
     [Parameter(CaptureUnmatchedValues = true)] public Dictionary<string, object>? AdditionalAttributes { get; set; }
 
-    private string CssClass => $"inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium cursor-pointer transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 h-11 w-11 sm:h-9 sm:w-9 {(IsActive ? "border border-input bg-background shadow-sm" : "hover:bg-accent hover:text-accent-foreground")} {Class}".Trim();
+    // Desktop cell size tracks the ambient DensityScope; the mobile touch
+    // floor (h-11 w-11) is kept so pages stay tappable. Comfortable
+    // reproduces the historical `sm:h-9 sm:w-9`.
+    private string SizeClass => Density switch
+    {
+        Lumeo.Density.Compact => "h-11 w-11 sm:h-8 sm:w-8",
+        Lumeo.Density.Spacious => "h-11 w-11 sm:h-10 sm:w-10",
+        _ => "h-11 w-11 sm:h-9 sm:w-9"
+    };
+
+    private string CssClass => $"inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium cursor-pointer transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 {SizeClass} {(IsActive ? "border border-input bg-background shadow-sm" : "hover:bg-accent hover:text-accent-foreground")} {Class}".Trim();
 }

--- a/src/Lumeo/UI/Pagination/PaginationNext.razor
+++ b/src/Lumeo/UI/Pagination/PaginationNext.razor
@@ -11,8 +11,18 @@
 @code {
     [Parameter] public EventCallback OnClick { get; set; }
     [Parameter] public bool Disabled { get; set; }
+    [CascadingParameter] private Lumeo.Density? Density { get; set; }
     [Parameter] public string? Class { get; set; }
     [Parameter(CaptureUnmatchedValues = true)] public Dictionary<string, object>? AdditionalAttributes { get; set; }
 
-    private string CssClass => $"inline-flex items-center justify-center gap-1 whitespace-nowrap rounded-md text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-[1.5px] focus-visible:ring-ring focus-visible:ring-offset-2 h-11 sm:h-9 px-3 disabled:pointer-events-none disabled:opacity-50 {Class}".Trim();
+    // Desktop height + horizontal padding track the ambient DensityScope; the
+    // mobile touch floor (h-11) is kept. Comfortable reproduces `sm:h-9 px-3`.
+    private string SizeClass => Density switch
+    {
+        Lumeo.Density.Compact => "h-11 sm:h-8 px-2.5",
+        Lumeo.Density.Spacious => "h-11 sm:h-10 px-4",
+        _ => "h-11 sm:h-9 px-3"
+    };
+
+    private string CssClass => $"inline-flex items-center justify-center gap-1 whitespace-nowrap rounded-md text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-[1.5px] focus-visible:ring-ring focus-visible:ring-offset-2 {SizeClass} disabled:pointer-events-none disabled:opacity-50 {Class}".Trim();
 }

--- a/src/Lumeo/UI/Pagination/PaginationPrevious.razor
+++ b/src/Lumeo/UI/Pagination/PaginationPrevious.razor
@@ -11,8 +11,18 @@
 @code {
     [Parameter] public EventCallback OnClick { get; set; }
     [Parameter] public bool Disabled { get; set; }
+    [CascadingParameter] private Lumeo.Density? Density { get; set; }
     [Parameter] public string? Class { get; set; }
     [Parameter(CaptureUnmatchedValues = true)] public Dictionary<string, object>? AdditionalAttributes { get; set; }
 
-    private string CssClass => $"inline-flex items-center justify-center gap-1 whitespace-nowrap rounded-md text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-[1.5px] focus-visible:ring-ring focus-visible:ring-offset-2 h-11 sm:h-9 px-3 disabled:pointer-events-none disabled:opacity-50 {Class}".Trim();
+    // Desktop height + horizontal padding track the ambient DensityScope; the
+    // mobile touch floor (h-11) is kept. Comfortable reproduces `sm:h-9 px-3`.
+    private string SizeClass => Density switch
+    {
+        Lumeo.Density.Compact => "h-11 sm:h-8 px-2.5",
+        Lumeo.Density.Spacious => "h-11 sm:h-10 px-4",
+        _ => "h-11 sm:h-9 px-3"
+    };
+
+    private string CssClass => $"inline-flex items-center justify-center gap-1 whitespace-nowrap rounded-md text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-[1.5px] focus-visible:ring-ring focus-visible:ring-offset-2 {SizeClass} disabled:pointer-events-none disabled:opacity-50 {Class}".Trim();
 }

--- a/src/Lumeo/UI/PasswordInput/PasswordInput.razor
+++ b/src/Lumeo/UI/PasswordInput/PasswordInput.razor
@@ -13,7 +13,7 @@
 }
 
 <div class="@WrapperClass">
-    <div class="@($"flex h-9 w-full rounded-md border {(EffectiveInvalid ? "border-destructive" : "border-input")} bg-transparent text-sm overflow-hidden transition-colors {(EffectiveInvalid ? "focus-within:ring-[1.5px] focus-within:ring-destructive/20" : "focus-within:ring-[1.5px] focus-within:ring-ring")}")">
+    <div class="@($"flex {HeightClass} w-full rounded-md border {(EffectiveInvalid ? "border-destructive" : "border-input")} bg-transparent text-sm overflow-hidden transition-colors {(EffectiveInvalid ? "focus-within:ring-[1.5px] focus-within:ring-destructive/20" : "focus-within:ring-[1.5px] focus-within:ring-ring")}")">
         <input @ref="_inputRef"
                type="@(_showPassword ? "text" : "password")"
                name="@Name"
@@ -87,11 +87,27 @@
     /// See <c>Input.AutoFocus</c> for why the HTML <c>autofocus</c> attribute
     /// doesn't work in Blazor WASM.</summary>
     [Parameter] public bool AutoFocus { get; set; }
+    /// <summary>Per-input density override. When null, inherits from any
+    /// ancestor <see cref="DensityScope"/>; if neither is set, matches the
+    /// historical <c>Comfortable</c> default. Only the field height shifts
+    /// between values.</summary>
+    [Parameter] public Density? Density { get; set; }
+    [CascadingParameter] private Density? InheritedDensity { get; set; }
     [Parameter] public string? Class { get; set; }
     [Parameter(CaptureUnmatchedValues = true)] public Dictionary<string, object>? AdditionalAttributes { get; set; }
 
     private bool _showPassword;
     private ElementReference _inputRef;
+
+    private Lumeo.Density EffectiveDensity => Density ?? InheritedDensity ?? Lumeo.Density.Comfortable;
+
+    // Height tracks density; Comfortable reproduces the historical h-9.
+    private string HeightClass => EffectiveDensity switch
+    {
+        Lumeo.Density.Compact => "h-8",
+        Lumeo.Density.Spacious => "h-10",
+        _ => "h-9"
+    };
 
     /// <summary>The underlying password &lt;input&gt; element.</summary>
     public ElementReference Element => _inputRef;

--- a/src/Lumeo/UI/RadioGroup/RadioGroup.razor
+++ b/src/Lumeo/UI/RadioGroup/RadioGroup.razor
@@ -57,13 +57,29 @@
     [Parameter] public EventCallback<string> ValueChanged { get; set; }
     [Parameter] public string? AriaLabel { get; set; }
     [Parameter] public string? AriaLabelledBy { get; set; }
+    /// <summary>Per-group density override. When null, inherits from any
+    /// ancestor <see cref="DensityScope"/>; if neither is set, matches the
+    /// historical <c>Comfortable</c> default. Only the inter-option row gap
+    /// shifts between values.</summary>
+    [Parameter] public Density? Density { get; set; }
+    [CascadingParameter] private Density? InheritedDensity { get; set; }
     [Parameter] public string? Class { get; set; }
     [Parameter(CaptureUnmatchedValues = true)] public Dictionary<string, object>? AdditionalAttributes { get; set; }
 
     private readonly List<string> _itemValues = new();
     private readonly Dictionary<string, string> _itemIds = new();
 
-    private string CssClass => $"grid gap-2 {(EffectiveInvalid ? "text-destructive" : "")} {Class}".Trim();
+    private Lumeo.Density EffectiveDensity => Density ?? InheritedDensity ?? Lumeo.Density.Comfortable;
+
+    // Inter-option gap tracks density; Comfortable reproduces the historical gap-2.
+    private string GapClass => EffectiveDensity switch
+    {
+        Lumeo.Density.Compact => "gap-1",
+        Lumeo.Density.Spacious => "gap-3",
+        _ => "gap-2"
+    };
+
+    private string CssClass => $"grid {GapClass} {(EffectiveInvalid ? "text-destructive" : "")} {Class}".Trim();
 
     private async Task OnValueSelected(string value)
     {

--- a/src/Lumeo/UI/Segmented/Segmented.razor
+++ b/src/Lumeo/UI/Segmented/Segmented.razor
@@ -45,10 +45,34 @@
     /// Ignored when <see cref="Options"/> is set.</summary>
     [Parameter] public RenderFragment? ChildContent { get; set; }
     [Parameter] public bool Block { get; set; }
+    /// <summary>Per-control density override. When null, inherits from any
+    /// ancestor <see cref="DensityScope"/>; if neither is set, matches the
+    /// historical <c>Comfortable</c> default. Only the track + item padding
+    /// shift between values.</summary>
+    [Parameter] public Density? Density { get; set; }
+    [CascadingParameter] private Density? InheritedDensity { get; set; }
     [Parameter] public string? Class { get; set; }
     [Parameter(CaptureUnmatchedValues = true)] public Dictionary<string, object>? AdditionalAttributes { get; set; }
 
     private SegmentedContext _context = default!;
+
+    private Lumeo.Density EffectiveDensity => Density ?? InheritedDensity ?? Lumeo.Density.Comfortable;
+
+    // Track padding tracks density; Comfortable reproduces the historical p-1.
+    private string TrackPadClass => EffectiveDensity switch
+    {
+        Lumeo.Density.Compact => "p-0.5",
+        Lumeo.Density.Spacious => "p-1.5",
+        _ => "p-1"
+    };
+
+    // Item padding tracks density; Comfortable reproduces the historical px-3 py-1.5.
+    private string ItemPadClass => EffectiveDensity switch
+    {
+        Lumeo.Density.Compact => "px-2 py-1",
+        Lumeo.Density.Spacious => "px-4 py-2",
+        _ => "px-3 py-1.5"
+    };
 
     protected override void OnParametersSet()
     {
@@ -59,16 +83,19 @@
     }
 
     private string CssClass => Cx.Join(
-        "inline-flex items-center rounded-lg bg-muted p-1",
+        "inline-flex items-center rounded-lg bg-muted",
+        TrackPadClass,
         Cx.When(Block, "w-full"),
         Class);
 
     private string GetItemClasses(bool isActive) => isActive
         ? Cx.Join(
-            "inline-flex items-center justify-center rounded-md bg-background px-3 py-1.5 text-sm font-medium text-foreground shadow-sm transition-all focus-visible:outline-none focus-visible:ring-[1.5px] focus-visible:ring-ring focus-visible:ring-offset-1",
+            "inline-flex items-center justify-center rounded-md bg-background text-sm font-medium text-foreground shadow-sm transition-all focus-visible:outline-none focus-visible:ring-[1.5px] focus-visible:ring-ring focus-visible:ring-offset-1",
+            ItemPadClass,
             Cx.When(Block, "flex-1"))
         : Cx.Join(
-            "inline-flex items-center justify-center rounded-md px-3 py-1.5 text-sm text-muted-foreground transition-all hover:text-foreground focus-visible:outline-none focus-visible:ring-[1.5px] focus-visible:ring-ring focus-visible:ring-offset-1 disabled:pointer-events-none disabled:opacity-50",
+            "inline-flex items-center justify-center rounded-md text-sm text-muted-foreground transition-all hover:text-foreground focus-visible:outline-none focus-visible:ring-[1.5px] focus-visible:ring-ring focus-visible:ring-offset-1 disabled:pointer-events-none disabled:opacity-50",
+            ItemPadClass,
             Cx.When(Block, "flex-1"));
 
     private async Task SelectOption(string value)

--- a/src/Lumeo/UI/Select/SelectTrigger.razor
+++ b/src/Lumeo/UI/Select/SelectTrigger.razor
@@ -56,10 +56,20 @@
 
 @code {
     [CascadingParameter] public Select.SelectContext Context { get; set; } = default!;
+    [CascadingParameter] private Lumeo.Density? Density { get; set; }
     [Parameter] public RenderFragment? ChildContent { get; set; }
     [Parameter] public string? Placeholder { get; set; }
     [Parameter] public string? Class { get; set; }
     [Parameter(CaptureUnmatchedValues = true)] public Dictionary<string, object>? AdditionalAttributes { get; set; }
+
+    // Height + body padding track the ambient DensityScope; Comfortable
+    // reproduces the historical `h-9 px-3 py-2`.
+    private string SizeClasses => Density switch
+    {
+        Lumeo.Density.Compact => "h-8 px-2.5 py-1.5",
+        Lumeo.Density.Spacious => "h-10 px-4 py-2.5",
+        _ => "h-9 px-3 py-2"
+    };
 
     // _triggerId moved up to parent Select (Context.TriggerId) so the parent
     // can target it for AutoFocus / public FocusAsync without exposing the
@@ -69,7 +79,7 @@
         ? Context.Values != null && Context.Values.Count > 0
         : !string.IsNullOrEmpty(Context.Value);
 
-    private string CssClass => $"flex h-9 w-full cursor-pointer items-center justify-between whitespace-nowrap rounded-md border {(Context.Invalid ? "border-destructive" : "border-input")} bg-transparent px-3 py-2 text-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 {(Context.Invalid ? "focus-visible:ring-destructive/20" : "focus-visible:ring-ring")} focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 {Class}".Trim();
+    private string CssClass => $"flex {SizeClasses} w-full cursor-pointer items-center justify-between whitespace-nowrap rounded-md border {(Context.Invalid ? "border-destructive" : "border-input")} bg-transparent text-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 {(Context.Invalid ? "focus-visible:ring-destructive/20" : "focus-visible:ring-ring")} focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 {Class}".Trim();
 
     private async Task Toggle() => await Context.SetOpen.InvokeAsync(!Context.IsOpen);
 

--- a/src/Lumeo/UI/Sheet/SheetContent.razor
+++ b/src/Lumeo/UI/Sheet/SheetContent.razor
@@ -38,6 +38,14 @@ else if (Context.IsOpen)
     [Parameter] public RenderFragment? ChildContent { get; set; }
     [Parameter] public Lumeo.Side Side { get; set; } = Lumeo.Side.Right;
     [Parameter] public SheetSize Size { get; set; } = SheetSize.Default;
+    /// <summary>Alternative to <see cref="Size"/> that accepts the unified
+    /// <see cref="Lumeo.Size"/> token. When set (non-null), wins over
+    /// <see cref="Size"/>. Mapping: <c>Sm→Sm</c>, <c>Md→Default</c>,
+    /// <c>Lg→Lg</c>, <c>Xl→Xl</c>. <see cref="SheetSize.Full"/> has no
+    /// <see cref="Lumeo.Size"/> equivalent (Full is a layout intent, not a
+    /// scale) — set <see cref="Size"/> directly for that case. Closes
+    /// the <c>Lumeo.Size</c> ↔ per-component-enum overlap from #87.2.</summary>
+    [Parameter] public Lumeo.Size? SizePreset { get; set; }
     /// <summary>How the sheet enters/leaves. <c>Slide</c> (default) animates
     /// from the configured <see cref="Side"/>. <c>Fade</c> uses a simple
     /// opacity tween — useful in dense forms where popovers and animations
@@ -71,8 +79,17 @@ else if (Context.IsOpen)
     // block trap for popovers (Select / DatePicker / Combobox).
     private string CssClass => $"fixed flex flex-col gap-4 bg-background p-6 shadow-lg {PositionClasses} {AnimationClass} {Class}".Trim();
 
+    private SheetSize EffectiveSize => SizePreset switch
+    {
+        Lumeo.Size.Sm => SheetSize.Sm,
+        Lumeo.Size.Md => SheetSize.Default,
+        Lumeo.Size.Lg => SheetSize.Lg,
+        Lumeo.Size.Xl => SheetSize.Xl,
+        _ => Size,
+    };
+
     private string SizeClass => Side is Lumeo.Side.Left or Lumeo.Side.Right
-        ? Size switch
+        ? EffectiveSize switch
         {
             SheetSize.Sm => "sm:max-w-xs",
             SheetSize.Lg => "sm:max-w-lg",
@@ -85,7 +102,7 @@ else if (Context.IsOpen)
         // pattern), the other sizes cap at a fraction of the viewport
         // height. Default keeps the legacy content-driven height so
         // existing layouts are unchanged.
-        : Size switch
+        : EffectiveSize switch
         {
             SheetSize.Sm => "max-h-[40vh] h-auto",
             SheetSize.Lg => "max-h-[70vh] h-auto",

--- a/src/Lumeo/UI/Sheet/SheetContent.razor
+++ b/src/Lumeo/UI/Sheet/SheetContent.razor
@@ -2,6 +2,8 @@
 @using Lumeo.Services
 @implements IAsyncDisposable
 
+@* <gotcha>No inner scroll container by default — the panel is a flex-col, so a long body overflows the viewport. Wrap the scrollable region in flex-1 overflow-y-auto, or use OverlayForm which bakes that in.</gotcha> *@
+
 @if (Shell is not null)
 {
     @* OverlayProvider already rendered the SheetContent shell around our parent

--- a/src/Lumeo/UI/Table/TableCell.razor
+++ b/src/Lumeo/UI/Table/TableCell.razor
@@ -5,9 +5,19 @@
 </td>
 
 @code {
+    [CascadingParameter] private Lumeo.Density? Density { get; set; }
     [Parameter] public RenderFragment? ChildContent { get; set; }
     [Parameter] public string? Class { get; set; }
     [Parameter(CaptureUnmatchedValues = true)] public Dictionary<string, object>? AdditionalAttributes { get; set; }
 
-    private string CssClass => $"p-2 align-middle [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px] {Class}".Trim();
+    // Cell padding tracks the ambient DensityScope so rows tighten in dense
+    // data grids; Comfortable reproduces the historical `p-2`.
+    private string PadClass => Density switch
+    {
+        Lumeo.Density.Compact => "px-2 py-1",
+        Lumeo.Density.Spacious => "p-4",
+        _ => "p-2"
+    };
+
+    private string CssClass => $"{PadClass} align-middle [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px] {Class}".Trim();
 }

--- a/src/Lumeo/UI/Table/TableHead.razor
+++ b/src/Lumeo/UI/Table/TableHead.razor
@@ -5,9 +5,19 @@
 </th>
 
 @code {
+    [CascadingParameter] private Lumeo.Density? Density { get; set; }
     [Parameter] public RenderFragment? ChildContent { get; set; }
     [Parameter] public string? Class { get; set; }
     [Parameter(CaptureUnmatchedValues = true)] public Dictionary<string, object>? AdditionalAttributes { get; set; }
 
-    private string CssClass => $"h-10 px-2 text-left align-middle font-medium text-muted-foreground [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px] {Class}".Trim();
+    // Header row height tracks the ambient DensityScope; Comfortable
+    // reproduces the historical `h-10 px-2`.
+    private string SizeClass => Density switch
+    {
+        Lumeo.Density.Compact => "h-8 px-2",
+        Lumeo.Density.Spacious => "h-12 px-4",
+        _ => "h-10 px-2"
+    };
+
+    private string CssClass => $"{SizeClass} text-left align-middle font-medium text-muted-foreground [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px] {Class}".Trim();
 }

--- a/src/Lumeo/UI/Tabs/TabsTrigger.razor
+++ b/src/Lumeo/UI/Tabs/TabsTrigger.razor
@@ -58,6 +58,7 @@
 
 @code {
     [CascadingParameter] public Tabs.TabsContext Context { get; set; } = default!;
+    [CascadingParameter] private Lumeo.Density? Density { get; set; }
     [Parameter] public RenderFragment? ChildContent { get; set; }
 
     /// <summary>Icon slot. Named <c>IconContent</c> to avoid shadowing the <c>&lt;Icon&gt;</c> component.</summary>
@@ -116,9 +117,18 @@
                 ? " ring-2 ring-primary ring-offset-0"
                 : " ring-2 ring-primary ring-offset-0";
 
-            return $"inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md px-3 py-1.5 text-sm font-medium cursor-pointer transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 disabled:cursor-not-allowed {variantClasses} {disabledClasses} {reorderClasses} {Class}".Trim();
+            return $"inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md {PadClass} text-sm font-medium cursor-pointer transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 disabled:cursor-not-allowed {variantClasses} {disabledClasses} {reorderClasses} {Class}".Trim();
         }
     }
+
+    // Trigger padding tracks the ambient DensityScope; Comfortable reproduces
+    // the historical `px-3 py-1.5`.
+    private string PadClass => Density switch
+    {
+        Lumeo.Density.Compact => "px-2 py-1",
+        Lumeo.Density.Spacious => "px-4 py-2",
+        _ => "px-3 py-1.5"
+    };
 
     private async Task Activate()
     {

--- a/src/Lumeo/UI/Textarea/Textarea.razor
+++ b/src/Lumeo/UI/Textarea/Textarea.razor
@@ -60,6 +60,12 @@
     [Parameter] public string? HelperText { get; set; }
     [Parameter] public string? Label { get; set; }
     [Parameter] public string? Name { get; set; }
+    /// <summary>Per-textarea density override. When null, inherits from any
+    /// ancestor <see cref="DensityScope"/>; if neither is set, matches the
+    /// historical <c>Comfortable</c> default. Only padding / min-height
+    /// shifts between values.</summary>
+    [Parameter] public Density? Density { get; set; }
+    [CascadingParameter] private Density? InheritedDensity { get; set; }
     /// <summary>Focuses the underlying &lt;textarea&gt; on first render. See
     /// Input.AutoFocus — the HTML autofocus attribute doesn't work in Blazor
     /// WASM because parse-time has already passed by the time the runtime
@@ -90,7 +96,19 @@
         _ => "resize-y"
     };
 
-    private string CssClass => $"flex min-h-[60px] w-full rounded-md border {(EffectiveInvalid ? "border-destructive" : "border-input")} bg-transparent px-3 py-2 text-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-[1.5px] {(EffectiveInvalid ? "focus-visible:ring-destructive/20" : "focus-visible:ring-ring")} disabled:cursor-not-allowed disabled:opacity-50 {ResizeClass} {Class}".Trim();
+    private Lumeo.Density EffectiveDensity => Density ?? InheritedDensity ?? Lumeo.Density.Comfortable;
+
+    // Only the min-height floor + body padding shift with density; text size
+    // and radius stay fixed (governed elsewhere). Comfortable reproduces the
+    // historical `min-h-[60px] px-3 py-2` verbatim.
+    private string SizeClasses => EffectiveDensity switch
+    {
+        Lumeo.Density.Compact => "min-h-[48px] px-2.5 py-1.5",
+        Lumeo.Density.Spacious => "min-h-[80px] px-4 py-3",
+        _ => "min-h-[60px] px-3 py-2"
+    };
+
+    private string CssClass => $"flex {SizeClasses} w-full rounded-md border {(EffectiveInvalid ? "border-destructive" : "border-input")} bg-transparent text-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-[1.5px] {(EffectiveInvalid ? "focus-visible:ring-destructive/20" : "focus-visible:ring-ring")} disabled:cursor-not-allowed disabled:opacity-50 {ResizeClass} {Class}".Trim();
 
     private bool IsOverLimit => MaxLength.HasValue && (Value?.Length ?? 0) > MaxLength.Value;
 

--- a/src/Lumeo/UI/TimePicker/TimePicker.razor
+++ b/src/Lumeo/UI/TimePicker/TimePicker.razor
@@ -195,12 +195,12 @@ else
     // reproduces the historical `h-9 px-3`.
     private string SizeClasses => EffectiveDensity switch
     {
-        Lumeo.Density.Compact => "h-8 px-2.5",
-        Lumeo.Density.Spacious => "h-10 px-4",
-        _ => "h-9 px-3"
+        Lumeo.Density.Compact => "h-8 px-2.5 py-1",
+        Lumeo.Density.Spacious => "h-10 px-4 py-2.5",
+        _ => "h-9 px-3 py-2"
     };
 
-    private string CssClass => $"group flex {SizeClasses} items-center rounded-md border {(EffectiveInvalid ? "border-destructive ring-1 ring-destructive/20" : "border-input")} bg-transparent py-2 text-sm shadow-sm hover:bg-accent hover:text-accent-foreground disabled:cursor-not-allowed disabled:opacity-50 {Class}".Trim();
+    private string CssClass => $"group flex {SizeClasses} items-center rounded-md border {(EffectiveInvalid ? "border-destructive ring-1 ring-destructive/20" : "border-input")} bg-transparent text-sm shadow-sm hover:bg-accent hover:text-accent-foreground disabled:cursor-not-allowed disabled:opacity-50 {Class}".Trim();
 
     private string FormatTime(TimeSpan time)
     {

--- a/src/Lumeo/UI/TimePicker/TimePicker.razor
+++ b/src/Lumeo/UI/TimePicker/TimePicker.razor
@@ -178,12 +178,29 @@ else
 
     private string EffectivePlaceholder => Placeholder ?? L["TimePicker.Placeholder"];
     [Parameter] public bool Disabled { get; set; }
+    /// <summary>Per-picker density override. When null, inherits from any
+    /// ancestor <see cref="DensityScope"/>; if neither is set, matches the
+    /// historical <c>Comfortable</c> default. Only the trigger height +
+    /// horizontal padding shift between values.</summary>
+    [Parameter] public Density? Density { get; set; }
+    [CascadingParameter] private Density? InheritedDensity { get; set; }
     [Parameter] public string? Class { get; set; }
     [Parameter(CaptureUnmatchedValues = true)] public Dictionary<string, object>? AdditionalAttributes { get; set; }
 
     private bool _isOpen;
 
-    private string CssClass => $"group flex h-9 items-center rounded-md border {(EffectiveInvalid ? "border-destructive ring-1 ring-destructive/20" : "border-input")} bg-transparent px-3 py-2 text-sm shadow-sm hover:bg-accent hover:text-accent-foreground disabled:cursor-not-allowed disabled:opacity-50 {Class}".Trim();
+    private Lumeo.Density EffectiveDensity => Density ?? InheritedDensity ?? Lumeo.Density.Comfortable;
+
+    // Trigger height + horizontal padding track density; Comfortable
+    // reproduces the historical `h-9 px-3`.
+    private string SizeClasses => EffectiveDensity switch
+    {
+        Lumeo.Density.Compact => "h-8 px-2.5",
+        Lumeo.Density.Spacious => "h-10 px-4",
+        _ => "h-9 px-3"
+    };
+
+    private string CssClass => $"group flex {SizeClasses} items-center rounded-md border {(EffectiveInvalid ? "border-destructive ring-1 ring-destructive/20" : "border-input")} bg-transparent py-2 text-sm shadow-sm hover:bg-accent hover:text-accent-foreground disabled:cursor-not-allowed disabled:opacity-50 {Class}".Trim();
 
     private string FormatTime(TimeSpan time)
     {

--- a/src/Lumeo/UI/Toggle/Toggle.razor
+++ b/src/Lumeo/UI/Toggle/Toggle.razor
@@ -10,6 +10,12 @@
     [Parameter] public EventCallback<bool> PressedChanged { get; set; }
     [Parameter] public ToggleVariant Variant { get; set; } = ToggleVariant.Default;
     [Parameter] public Lumeo.Size Size { get; set; } = Lumeo.Size.Md;
+    /// <summary>Per-toggle density override. When null, inherits from any
+    /// ancestor <see cref="DensityScope"/>; if neither is set, matches the
+    /// historical <c>Comfortable</c> default. Only height + horizontal
+    /// padding shift — text size + radius stay governed by <see cref="Size"/>.</summary>
+    [Parameter] public Density? Density { get; set; }
+    [CascadingParameter] private Density? InheritedDensity { get; set; }
     [Parameter] public bool Disabled { get; set; }
     /// <summary>
     /// Accessible name exposed via <c>aria-label</c>. Required when
@@ -33,11 +39,21 @@
         _ => ""
     };
 
-    private string SizeClasses => Size switch
+    private Lumeo.Density EffectiveDensity => Density ?? InheritedDensity ?? Lumeo.Density.Comfortable;
+
+    // Height + horizontal padding track Size x Density; Comfortable
+    // reproduces the historical per-Size values verbatim.
+    private string SizeClasses => (Size, EffectiveDensity) switch
     {
-        Lumeo.Size.Sm => "h-8 px-2",
-        Lumeo.Size.Lg => "h-10 px-4",
-        _ => "h-9 px-3"
+        (Lumeo.Size.Sm, Lumeo.Density.Compact)  => "h-7 px-1.5",
+        (Lumeo.Size.Sm, Lumeo.Density.Spacious) => "h-9 px-3",
+        (Lumeo.Size.Sm, _)                      => "h-8 px-2",
+        (Lumeo.Size.Lg, Lumeo.Density.Compact)  => "h-9 px-3",
+        (Lumeo.Size.Lg, Lumeo.Density.Spacious) => "h-12 px-5",
+        (Lumeo.Size.Lg, _)                      => "h-10 px-4",
+        (_, Lumeo.Density.Compact)              => "h-8 px-2",
+        (_, Lumeo.Density.Spacious)             => "h-11 px-4",
+        _                                       => "h-9 px-3"
     };
 
     private async Task HandleToggle()

--- a/tests/Lumeo.Tests/Contract/ComponentContractTests.cs
+++ b/tests/Lumeo.Tests/Contract/ComponentContractTests.cs
@@ -90,6 +90,9 @@ public class ComponentContractTests : IAsyncLifetime
         "AlertDialog",
         // Accordion renders <CascadingValue> wrapping ChildContent; splat goes on children, not outer wrapper.
         "Accordion",
+        // DensityScope renders only <CascadingValue> (no DOM wrapper) so it's
+        // valid inside tbody/tr/ul; no root element to splat onto by design.
+        "DensityScope",
 
         // ── (b) Conditionally visible — render empty markup until triggered ──
         // @if (_visible && !Disabled) — invisible by default; _visible starts false (set by scroll JS event)

--- a/tools/Lumeo.RegistryGen/ComponentsApiEmitter.cs
+++ b/tools/Lumeo.RegistryGen/ComponentsApiEmitter.cs
@@ -118,6 +118,7 @@ public static class ComponentsApiEmitter
                 ["events"] = root?.Events.Select(SerializeEvent).ToArray() ?? Array.Empty<object>(),
                 ["enums"] = root?.Enums.Select(SerializeEnum).ToArray() ?? Array.Empty<object>(),
                 ["records"] = root?.Records.Select(SerializeRecord).ToArray() ?? Array.Empty<object>(),
+                ["gotchas"] = root?.Gotchas ?? Array.Empty<string>(),
                 ["cssVars"] = meta.CssVars,
                 ["examples"] = examples,
                 ["subComponents"] = subEntries,
@@ -190,6 +191,7 @@ public static class ComponentsApiEmitter
             ["events"] = s.Events.Select(SerializeEvent).ToArray(),
             ["enums"] = s.Enums.Select(SerializeEnum).ToArray(),
             ["records"] = s.Records.Select(SerializeRecord).ToArray(),
+            ["gotchas"] = s.Gotchas,
             ["parseFailed"] = s.ParseFailed,
             ["parseError"] = s.ParseError,
         };

--- a/tools/Lumeo.RegistryGen/Program.cs
+++ b/tools/Lumeo.RegistryGen/Program.cs
@@ -613,6 +613,11 @@ foreach (var dir in componentDirs)
     var cssVars = new HashSet<string>(StringComparer.Ordinal);
     var deps = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
     var packageDeps = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+    // Per-component "gotcha" callouts (#87.5): one-line non-obvious-behaviour
+    // notes authored as <gotcha>...</gotcha> anywhere in a .razor file. Order
+    // is preserved (file order, then source order) and duplicates dropped.
+    var gotchas = new List<string>();
+    var seenGotchas = new HashSet<string>(StringComparer.Ordinal);
 
     foreach (var file in files)
     {
@@ -636,6 +641,15 @@ foreach (var dir in componentDirs)
         // Dependencies: only for .razor, match `<OtherComponent` where OtherComponent is a known sibling.
         if (file.EndsWith(".razor", StringComparison.OrdinalIgnoreCase))
         {
+            // Gotcha callouts (#87.5): <gotcha>...</gotcha>, inner text trimmed.
+            // Singleline so multi-word / wrapped content matches across newlines.
+            foreach (Match gm in Regex.Matches(content, @"<gotcha>(.*?)</gotcha>", RegexOptions.Singleline))
+            {
+                var note = gm.Groups[1].Value.Trim();
+                if (!string.IsNullOrWhiteSpace(note) && seenGotchas.Add(note))
+                    gotchas.Add(note);
+            }
+
             var matches = Regex.Matches(content, @"<([A-Z][A-Za-z0-9]*)\b");
             foreach (Match m in matches)
             {
@@ -693,6 +707,7 @@ foreach (var dir in componentDirs)
         ["dependencies"] = deps.OrderBy(x => x, StringComparer.Ordinal).ToArray(),
         ["packageDependencies"] = packageDeps.OrderBy(x => x, StringComparer.OrdinalIgnoreCase).ToArray(),
         ["cssVars"] = cssVars.OrderBy(x => x, StringComparer.Ordinal).ToArray(),
+        ["gotchas"] = gotchas.ToArray(),
         ["registryUrl"] = $"https://lumeo.nativ.sh/registry/{componentKey}.json",
     };
     components[componentKey] = entry;

--- a/tools/Lumeo.RegistryGen/RazorParameterScanner.cs
+++ b/tools/Lumeo.RegistryGen/RazorParameterScanner.cs
@@ -47,6 +47,7 @@ public static class RazorParameterScanner
         EventInfo[] Events,
         EnumInfo[] Enums,
         RecordInfo[] Records,
+        string[] Gotchas,
         bool ParseFailed,
         string? ParseError);
 
@@ -65,6 +66,13 @@ public static class RazorParameterScanner
     private static readonly Regex ImplementsRegex = new(
         @"^\s*@implements\s+([^\r\n]+)",
         RegexOptions.Compiled | RegexOptions.Multiline);
+
+    // Per-component "gotcha" callouts (#87.5): any <gotcha>...</gotcha> in the
+    // .razor file (typically inside the leading @* ... *@ comment block).
+    // Singleline so multi-word / wrapped content matches across newlines.
+    private static readonly Regex GotchaRegex = new(
+        @"<gotcha>(.*?)</gotcha>",
+        RegexOptions.Compiled | RegexOptions.Singleline);
 
     /// <summary>
     /// Parse a single .razor file. Always returns a schema (with ParseFailed=true on failure).
@@ -86,6 +94,7 @@ public static class RazorParameterScanner
                 Events: Array.Empty<EventInfo>(),
                 Enums: Array.Empty<EnumInfo>(),
                 Records: Array.Empty<RecordInfo>(),
+                Gotchas: Array.Empty<string>(),
                 ParseFailed: true,
                 ParseError: $"read failed: {ex.Message}");
         }
@@ -96,6 +105,11 @@ public static class RazorParameterScanner
             .Select(m => m.Groups[1].Value.Trim())
             .Where(s => !string.IsNullOrWhiteSpace(s))
             .Distinct(StringComparer.Ordinal)
+            .ToArray();
+
+        var gotchas = GotchaRegex.Matches(text)
+            .Select(m => m.Groups[1].Value.Trim())
+            .Where(s => !string.IsNullOrWhiteSpace(s))
             .ToArray();
 
         var codeBlocks = ExtractCodeBlocks(text);
@@ -112,6 +126,7 @@ public static class RazorParameterScanner
                 Events: Array.Empty<EventInfo>(),
                 Enums: Array.Empty<EnumInfo>(),
                 Records: Array.Empty<RecordInfo>(),
+                Gotchas: gotchas,
                 ParseFailed: false,
                 ParseError: null);
         }
@@ -218,7 +233,7 @@ public static class RazorParameterScanner
 
         if (!anyClassRecovered)
         {
-            return Failed(razorPath, componentName, ns, inherits, implementsList,
+            return Failed(razorPath, componentName, ns, inherits, implementsList, gotchas,
                 "no class declaration recovered from any @code block");
         }
 
@@ -232,11 +247,12 @@ public static class RazorParameterScanner
             Events: events.ToArray(),
             Enums: enums.ToArray(),
             Records: records.ToArray(),
+            Gotchas: gotchas,
             ParseFailed: false,
             ParseError: null);
     }
 
-    private static RazorFileSchema Failed(string razorPath, string componentName, string? ns, string? inherits, string[] implementsList, string error)
+    private static RazorFileSchema Failed(string razorPath, string componentName, string? ns, string? inherits, string[] implementsList, string[] gotchas, string error)
         => new(
             FileName: Path.GetFileName(razorPath),
             ComponentName: componentName,
@@ -247,6 +263,7 @@ public static class RazorParameterScanner
             Events: Array.Empty<EventInfo>(),
             Enums: Array.Empty<EnumInfo>(),
             Records: Array.Empty<RecordInfo>(),
+            Gotchas: gotchas,
             ParseFailed: true,
             ParseError: error);
 

--- a/tools/lumeo-mcp/src/componentsApi.ts
+++ b/tools/lumeo-mcp/src/componentsApi.ts
@@ -49,6 +49,7 @@ export interface ApiSubComponent {
   events: ApiEvent[];
   enums: ApiEnum[];
   records: ApiRecord[];
+  gotchas?: string[];
   parseFailed: boolean;
   parseError: string | null;
 }
@@ -73,6 +74,7 @@ export interface ApiComponent {
   enums: ApiEnum[];
   records: ApiRecord[];
   cssVars: string[];
+  gotchas?: string[];
   examples?: ApiExample[];
   subComponents: Record<string, ApiSubComponent>;
   parseFailed: boolean;

--- a/tools/lumeo-mcp/src/index.ts
+++ b/tools/lumeo-mcp/src/index.ts
@@ -203,6 +203,7 @@ function toGetPayload(c: ApiComponent) {
     events: s.events,
     enums: s.enums,
     records: s.records,
+    gotchas: s.gotchas ?? [],
   }));
   return {
     name: c.name,
@@ -218,6 +219,7 @@ function toGetPayload(c: ApiComponent) {
     enums: c.enums,
     records: c.records,
     cssVars: c.cssVars,
+    gotchas: c.gotchas ?? [],
     files: c.files,
     subComponents,
     examples: c.examples ?? [],

--- a/tools/lumeo-mcp/src/index.ts
+++ b/tools/lumeo-mcp/src/index.ts
@@ -156,8 +156,16 @@ function toComponentMarkdown(c: ApiComponent): string {
   ];
   if (c.enums.length) sections.push("## Enums", "", enumRows, "");
   if (c.events.length) sections.push("## Events", "", eventRows, "");
-  if (c.gotchas?.length) {
-    sections.push("## Gotchas", "", c.gotchas.map((g) => `- ${g}`).join("\n"), "");
+  // Aggregate gotchas from the root component AND its sub-components — a
+  // gotcha is often declared on a sub-component (e.g. SheetContent carries
+  // the Sheet gotcha), so the root resource must surface those too.
+  const gotchaLines = [
+    ...(c.gotchas ?? []).map((g) => `- ${g}`),
+    ...Object.values(c.subComponents).flatMap((s) =>
+      (s.gotchas ?? []).map((g) => `- **${s.componentName}**: ${g}`)),
+  ];
+  if (gotchaLines.length) {
+    sections.push("## Gotchas", "", gotchaLines.join("\n"), "");
   }
   if (Object.keys(c.subComponents).length) sections.push("## Sub-components", "", subRows, "");
   if (example) sections.push("## Example", "", "```razor", example, "```", "");

--- a/tools/lumeo-mcp/src/index.ts
+++ b/tools/lumeo-mcp/src/index.ts
@@ -156,6 +156,9 @@ function toComponentMarkdown(c: ApiComponent): string {
   ];
   if (c.enums.length) sections.push("## Enums", "", enumRows, "");
   if (c.events.length) sections.push("## Events", "", eventRows, "");
+  if (c.gotchas?.length) {
+    sections.push("## Gotchas", "", c.gotchas.map((g) => `- ${g}`).join("\n"), "");
+  }
   if (Object.keys(c.subComponents).length) sections.push("## Sub-components", "", subRows, "");
   if (example) sections.push("## Example", "", "```razor", example, "```", "");
   if (filesBlock) sections.push("## Source files", "", filesBlock, "");


### PR DESCRIPTION
## Summary

Resolves the remaining open backlog (`#67` MEDs, `#87`, `#90`) into a single 3.5.0 release. Additive throughout — no breaking changes.

### #67 — DataGrid (MED items)
- **Server request-sequencing guard** in `DataGridServerService.RequestDataAsync`: after the consumer's `OnServerRequest` callback returns, check the request generation; if a newer request was issued during the callback, drop the result so it can't race into `Items`. Pairs with the consumer honouring `DataGridServerRequest.CancellationToken` (documented in 3.4.0).

### #87 — DX
- **#87.1 OverlayOptions split** — unsealed `OverlayOptions`; added derived records `SheetOverlayOptions`, `DialogOverlayOptions`, `DrawerOverlayOptions` so the sheet-only properties carry a type-level "applies here" signal. Existing `OverlayOptions` callers stay compatible.
- **#87.2 `SheetContent.SizePreset`** — new `Lumeo.Size?` parameter parallel to `SheetSize`. When set, wins. Maps `Sm/Md/Lg/Xl` 1:1; `SheetSize.Full` keeps its own enum (Full is a layout intent, not a scale — that exception is already documented on `Size.cs`).
- **#87.3 `@bind-Value` convention** — `CONTRIBUTING.md` gains the contract: every two-way-bindable input exposes `Value` + `ValueChanged`, fires on the documented edit boundary per input class (text-like = keystroke, picker = commit, toggle = change), naming rules for internal buffers.
- **#87.5 Per-component "gotchas" registry pattern** — `CONTRIBUTING.md` documents the `<gotcha>…</gotcha>` XML-doc-comment convention that `Lumeo.RegistryGen` will lift into the MCP / skill registry.

### #90 — Roadmap
- **#90.1 Density token + DensityScope** — new `Lumeo.Density { Compact, Comfortable, Spacious }` orthogonal to `Size` (padding / row-height only; type ramp + radius unaffected). New `<DensityScope Value="Density.Compact">` cascading wrapper; per-component `Density` parameter overrides ancestor scope. Applied to **Button**, **Input**, **Card** as the representative set — same pattern extends to the rest of the lib in follow-ups.
- (#90.2 Theme.Customize + #90.3 Splash Kit shipped in 3.4.0.)

## Bump
`Directory.Build.props` 3.4.0 → **3.5.0** (new public API surface: `Density` enum, `DensityScope`, `SheetOverlayOptions`/`DialogOverlayOptions`/`DrawerOverlayOptions`, `Button.Density`, `Input.Density`, `Card.Density`, `SheetContent.SizePreset`).

## Test plan
- [ ] CI green
- [ ] `<DensityScope Value="Density.Compact">` tightens nested Button/Input/Card padding
- [ ] `<SheetContent SizePreset="Lumeo.Size.Sm">` renders the same width as `Size="SheetSize.Sm"`
- [ ] DataGrid server-mode: rapid-fire page changes do not show a stale page after a fresh one resolves
- [ ] OverlayService still accepts the bare `OverlayOptions` for back-compat

## Closes
- `#67` (with remaining items folded into Density follow-ups)
- `#87` (all 5 sub-items addressed — #87.4 in 3.4.0, rest here)
- `#90` (with #90.1 partial: Density applied to representative components, remaining components opt-in incrementally — pattern is in place)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LJmBFYeCdQj2G2epoZaRzQ)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a UI density system (Compact/Comfortable/Spacious) with a DensityScope and per-component density overrides across many controls; added a Sheet SizePreset and overlay option variants.
  * Component registry and tooling now emit per-component "gotchas" metadata consumed by the UI tooling.

* **Bug Fixes**
  * Prevented stale DataGrid requests from overwriting newer state.
  * Overlay form now safely handles a missing model.

* **Chores**
  * Version bumped to 3.5.0

* **Documentation**
  * Added contribution guidelines including two-way binding conventions and required component “gotchas” notes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Brain2k-0005/Lumeo/pull/111?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->