### PR TITLE
hotfix: OverlayForm contract test — unblock 3.4.0 NuGet publish

### DIFF
--- a/src/Lumeo/UI/OverlayForm/OverlayForm.razor
+++ b/src/Lumeo/UI/OverlayForm/OverlayForm.razor
@@ -24,37 +24,47 @@
         </OverlayForm>
 *@
 
-<EditForm EditContext="@_editContext" OnValidSubmit="OnValidSubmit" OnInvalidSubmit="OnInvalidSubmit" class="@CssClass" @attributes="AdditionalAttributes">
-    @if (Validator is not null)
-    {
-        @Validator
-    }
-    else
-    {
-        <DataAnnotationsValidator />
-    }
+@if (_editContext is null)
+{
+    @* No Model supplied yet — render an empty shell rather than crashing
+       the EditForm. This is the path the lib-wide ComponentContractTests
+       hit when they instantiate every component with default parameters. *@
+    <div class="@CssClass" @attributes="AdditionalAttributes"></div>
+}
+else
+{
+    <EditForm EditContext="@_editContext" OnValidSubmit="OnValidSubmit" OnInvalidSubmit="OnInvalidSubmit" class="@CssClass" @attributes="AdditionalAttributes">
+        @if (Validator is not null)
+        {
+            @Validator
+        }
+        else
+        {
+            <DataAnnotationsValidator />
+        }
 
-    @if (Header is not null)
-    {
-        <div class="shrink-0 mb-3">
-            @Header
+        @if (Header is not null)
+        {
+            <div class="shrink-0 mb-3">
+                @Header
+            </div>
+        }
+
+        <div class="flex-1 min-h-0 overflow-y-auto pe-1">
+            @Body
         </div>
-    }
 
-    <div class="flex-1 min-h-0 overflow-y-auto pe-1">
-        @Body
-    </div>
-
-    @if (Footer is not null)
-    {
-        <div class="shrink-0 mt-3 pt-3 border-t border-border/40 flex items-center justify-end gap-2">
-            @Footer
-        </div>
-    }
-</EditForm>
+        @if (Footer is not null)
+        {
+            <div class="shrink-0 mt-3 pt-3 border-t border-border/40 flex items-center justify-end gap-2">
+                @Footer
+            </div>
+        }
+    </EditForm>
+}
 
 @code {
-    [Parameter, EditorRequired] public object Model { get; set; } = default!;
+    [Parameter, EditorRequired] public object? Model { get; set; }
     [Parameter] public EventCallback<EditContext> OnValidSubmit { get; set; }
     [Parameter] public EventCallback<EditContext> OnInvalidSubmit { get; set; }
 
@@ -74,6 +84,15 @@
 
     protected override void OnParametersSet()
     {
+        // Defer the EditContext until a Model is actually supplied —
+        // EditForm crashes hard on a null Model + null EditContext, and
+        // the contract-test path renders every component with no params.
+        if (Model is null)
+        {
+            _editContext = null;
+            _lastModel = null;
+            return;
+        }
         if (!ReferenceEquals(_lastModel, Model))
         {
             _editContext = new EditContext(Model);


### PR DESCRIPTION
## Summary

**Hotfix for the 3.4.0 NuGet publish failure.** The release workflow shipped `Lumeo.Cli`, `Lumeo.Templates`, and `@lumeo-ui/mcp-server` (npm) successfully — but `publish-lumeo` (which packs and pushes the core lib + all 10 satellites) failed because `ComponentContractTests.Component_renders_with_defaults(componentName: "OverlayForm")` crashed with:

```
EditForm requires either a Model parameter, or an EditContext parameter
```

The contract test instantiates every public component with no params. `OverlayForm` had `[EditorRequired] object Model` declared as non-nullable with `default!`, so the test path hit `new EditContext(null)` → throw → test failed → `Pack core` + `Push to NuGet` steps skipped → 3.4.0 NuGet packages never landed.

## Fix

- `Model` is now `object?` and the component renders an empty shell (same `CssClass` + `AdditionalAttributes` splat) when no model is supplied. Real consumers passing a `Model` are unaffected.

## Recovery plan

After this merges:
1. `workflow_dispatch` the **Publish 2.0 packages** workflow → reads `Version=3.4.0` from `Directory.Build.props` (unchanged on master) → publishes the missing 3.4.0 Lumeo + satellite NuGet packages with `--skip-duplicate` (no-op for the already-published CLI/Templates/MCP).

## Test plan
- [ ] CI green (ContractTests for OverlayForm passes with empty render)
- [ ] After merge: workflow_dispatch on publish.yml → all 11 NuGet packages on nuget.org as v3.4.0

---
_Generated by [Claude Code](https://claude.ai/code/session_01LJmBFYeCdQj2G2epoZaRzQ)_