### PR TITLE
docs: 3.5.2/3.5.3 props + Cx.Merge class-override behavior

### DIFF
--- a/docs/Lumeo.Docs/Pages/Components/BadgePage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/BadgePage.razor
@@ -27,6 +27,21 @@
         </Flex>
     </ComponentDemo>
 
+    <ComponentDemo Title="Sizes &amp; Pill" Code="@_sizeCode">
+        <Stack Gap="4">
+            <Flex Wrap="true" Align="center" Gap="2">
+                <Badge Size="Badge.BadgeSize.Sm">Small</Badge>
+                <Badge Size="Badge.BadgeSize.Md">Medium</Badge>
+                <Badge Size="Badge.BadgeSize.Lg">Large</Badge>
+            </Flex>
+            <Flex Wrap="true" Align="center" Gap="2">
+                <Badge Pill="true">99+</Badge>
+                <Badge Pill="true" Variant="Badge.BadgeVariant.Secondary">New</Badge>
+                <Badge Pill="true" Size="Badge.BadgeSize.Lg" Variant="Badge.BadgeVariant.Success">Online</Badge>
+            </Flex>
+        </Stack>
+    </ComponentDemo>
+
     <ComponentDemo Title="Variant (interactive)" Code="@_variantInteractiveCode">
         <Stack Gap="4">
             <Lumeo.Text Size="sm" Color="muted">Switch variant to see the badge update live.</Lumeo.Text>
@@ -274,6 +289,14 @@
 <Badge Variant=""Badge.BadgeVariant.Destructive"">Destructive</Badge>
 <Badge Variant=""Badge.BadgeVariant.Success"">Success</Badge>
 <Badge Variant=""Badge.BadgeVariant.Warning"">Warning</Badge>";
+
+    private string _sizeCode = @"<Badge Size=""Badge.BadgeSize.Sm"">Small</Badge>
+<Badge Size=""Badge.BadgeSize.Md"">Medium</Badge>
+<Badge Size=""Badge.BadgeSize.Lg"">Large</Badge>
+
+<Badge Pill=""true"">99+</Badge>
+<Badge Pill=""true"" Variant=""Badge.BadgeVariant.Secondary"">New</Badge>
+<Badge Pill=""true"" Size=""Badge.BadgeSize.Lg"" Variant=""Badge.BadgeVariant.Success"">Online</Badge>";
 
     private string _usageCode = @"<Flex Align=""center"" Gap=""2"">
     <Lumeo.Text As=""span"" Size=""sm"" Weight=""medium"">Status</Lumeo.Text>

--- a/docs/Lumeo.Docs/Pages/Components/BadgePage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/BadgePage.razor
@@ -215,6 +215,18 @@
                             <td class="p-3 text-muted-foreground">Visual style of the badge. Values: Default, Secondary, Destructive, Outline, Success, Warning.</td>
                         </tr>
                         <tr>
+                            <td class="p-3 font-mono text-xs text-primary">Size</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">Badge.BadgeSize</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">Md</td>
+                            <td class="p-3 text-muted-foreground">Badge size. Values: Sm, Md, Lg.</td>
+                        </tr>
+                        <tr>
+                            <td class="p-3 font-mono text-xs text-primary">Pill</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">bool</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">false</td>
+                            <td class="p-3 text-muted-foreground">When true, renders fully rounded (pill shape) — ideal for count / quota chips.</td>
+                        </tr>
+                        <tr>
                             <td class="p-3 font-mono text-xs text-primary">IsDot</td>
                             <td class="p-3 font-mono text-xs text-muted-foreground">bool</td>
                             <td class="p-3 font-mono text-xs text-muted-foreground">false</td>

--- a/docs/Lumeo.Docs/Pages/Components/CardPage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/CardPage.razor
@@ -107,6 +107,28 @@
             </Card>
         </Container>
     </ComponentDemo>
+
+    <ComponentDemo Title="Flat variant" Code="@_flatCode">
+        <Container MaxWidth="sm" Center="false" Padding="">
+            <Stack Gap="2">
+                <Lumeo.Text Size="sm" Color="muted">A borderless, background-free surface. Paired with <code class="font-mono">OnClick</code> it is the natural primitive for clickable list rows — replacing the old <code class="font-mono">Ghost button + p-0</code> workaround.</Lumeo.Text>
+                <Stack Gap="0">
+                    @foreach (var item in _flatRows)
+                    {
+                        <Card Variant="Card.CardVariant.Flat" OnClick="@(() => _flatSelected = item)" Class="p-3">
+                            <Flex Align="center" Justify="between">
+                                <Lumeo.Text Size="sm" Weight="medium">@item</Lumeo.Text>
+                                @if (_flatSelected == item)
+                                {
+                                    <DynamicIcon Name="Check" Class="h-4 w-4 text-primary" />
+                                }
+                            </Flex>
+                        </Card>
+                    }
+                </Stack>
+            </Stack>
+        </Container>
+    </ComponentDemo>
 </Stack>
 
 <div class="mt-12">
@@ -240,6 +262,27 @@
 </div>
 
 @code {
+    private List<string> _flatRows = new() { "Profile", "Billing", "Notifications" };
+    private string? _flatSelected = "Billing";
+
+    private string _flatCode = @"@foreach (var item in _rows)
+{
+    <Card Variant=""Card.CardVariant.Flat"" OnClick=""@(() => _selected = item)"" Class=""p-3"">
+        <Flex Align=""center"" Justify=""between"">
+            <Lumeo.Text Size=""sm"" Weight=""medium"">@item</Lumeo.Text>
+            @if (_selected == item)
+            {
+                <Blazicon Svg=""Lucide.Check"" class=""h-4 w-4 text-primary"" />
+            }
+        </Flex>
+    </Card>
+}
+
+@code {
+    private List<string> _rows = new() { ""Profile"", ""Billing"", ""Notifications"" };
+    private string? _selected = ""Billing"";
+}";
+
     private string _defaultCode = @"<Card>
     <CardHeader>
         <Heading Level=""3"" Size=""lg"" Class=""leading-none tracking-tight"">Notifications</Heading>

--- a/docs/Lumeo.Docs/Pages/Components/CardPage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/CardPage.razor
@@ -142,11 +142,12 @@
                 </TableRow>
             </TableHeader>
             <TableBody>
-                <TableRow><TableCell><Kbd>Tab</Kbd></TableCell><TableCell>Move focus to the next interactive element inside the card</TableCell></TableRow>
+                <TableRow><TableCell><Kbd>Tab</Kbd></TableCell><TableCell>Move focus to the next interactive element inside the card (or, for an interactive card, to the card itself)</TableCell></TableRow>
+                <TableRow><TableCell><Kbd>Enter</Kbd> / <Kbd>Space</Kbd></TableCell><TableCell>Activate the card when <code class="font-mono">OnClick</code> is set (the card renders with <code class="font-mono">role="button"</code> and <code class="font-mono">tabindex="0"</code>)</TableCell></TableRow>
             </TableBody>
         </Table>
     </div>
-    <Lumeo.Text Size="sm" Color="muted" Class="mt-2">Card is a container component with no built-in keyboard interactions. Focus management depends on the interactive elements placed inside.</Lumeo.Text>
+    <Lumeo.Text Size="sm" Color="muted" Class="mt-2">By default a Card is a plain container with no built-in keyboard interactions — focus management depends on the interactive elements placed inside. When <code class="font-mono">OnClick</code> is set, the Card itself becomes focusable (button role) and responds to Enter/Space.</Lumeo.Text>
 </div>
 
 <!-- API Reference -->
@@ -168,7 +169,10 @@
                     </thead>
                     <tbody class="divide-y divide-border/40">
                         <tr>
-                            <td class="p-3 font-mono text-xs text-primary italic text-muted-foreground" colspan="4">No additional parameters beyond Class and AdditionalAttributes. Use sub-components to structure content.</td>
+                            <td class="p-3 font-mono text-xs text-primary">Variant</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">Card.CardVariant</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">Default</td>
+                            <td class="p-3 text-muted-foreground">Surface style. <code>Default</code> = bordered card with background; <code>Flat</code> = borderless, background-free content surface (pair with <code>OnClick</code> for clickable list rows).</td>
                         </tr>
                                             <tr>
                             <td class="p-3 font-mono text-xs text-primary">OnClick</td>

--- a/docs/Lumeo.Docs/Pages/Components/ScrollAreaPage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/ScrollAreaPage.razor
@@ -96,6 +96,7 @@
             </TableHeader>
             <TableBody>
                 <TableRow><TableCell Class="font-mono text-xs">ChildContent</TableCell><TableCell Class="font-mono text-xs">RenderFragment?</TableCell><TableCell Class="font-mono text-xs">null</TableCell><TableCell>Scrollable content.</TableCell></TableRow>
+                <TableRow><TableCell Class="font-mono text-xs">FocusRingGutter</TableCell><TableCell Class="font-mono text-xs">bool</TableCell><TableCell Class="font-mono text-xs">false</TableCell><TableCell>When true, applies a net-zero <code class="font-mono">-mx-1 px-1</code> gutter so focus rings of edge-touching controls don't clip against the overflow boundary. Put any padding on an inner wrapper, not the ScrollArea root.</TableCell></TableRow>
                 <TableRow><TableCell Class="font-mono text-xs">Class</TableCell><TableCell Class="font-mono text-xs">string?</TableCell><TableCell Class="font-mono text-xs">null</TableCell><TableCell>Additional CSS classes. Set height/width constraints here (e.g. "h-72 w-48").</TableCell></TableRow>
                 <TableRow><TableCell Class="font-mono text-xs">AdditionalAttributes</TableCell><TableCell Class="font-mono text-xs">Dictionary&lt;string, object&gt;?</TableCell><TableCell Class="font-mono text-xs">null</TableCell><TableCell>Additional HTML attributes.</TableCell></TableRow>
             </TableBody>

--- a/docs/Lumeo.Docs/Pages/Components/ScrollAreaPage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/ScrollAreaPage.razor
@@ -62,8 +62,10 @@
         <Container MaxWidth="xs">
             <Stack Gap="2">
                 <Lumeo.Text Size="sm" Color="muted">Enable <code class="font-mono">FocusRingGutter</code> when the scroll area holds focusable controls (inputs, buttons) whose focus ring would otherwise clip at the left/right edge. It applies a net-zero <code class="font-mono">-mx-1 px-1</code> gutter so the ring renders in full.</Lumeo.Text>
-                <ScrollArea FocusRingGutter="true" Class="h-64 rounded-md border bg-card p-4">
-                    <Stack Gap="3">
+                @* Padding goes on the inner wrapper, not the ScrollArea root —
+                   a p-* on the root would supersede the gutter's px-1 via Cx.Merge. *@
+                <ScrollArea FocusRingGutter="true" Class="h-64 rounded-md border bg-card">
+                    <Stack Gap="3" Class="p-4">
                         @foreach (var field in _gutterFields)
                         {
                             <FormField Label="@field">
@@ -123,8 +125,9 @@
         "Full name", "Email", "Company", "Role", "Phone", "City", "Country"
     ];
 
-    private string _gutterCode = @"<ScrollArea FocusRingGutter=""true"" Class=""h-64 rounded-md border p-4"">
-    <Stack Gap=""3"">
+    private string _gutterCode = @"@* padding on the inner wrapper, not the ScrollArea root *@
+<ScrollArea FocusRingGutter=""true"" Class=""h-64 rounded-md border"">
+    <Stack Gap=""3"" Class=""p-4"">
         <FormField Label=""Full name""><Input placeholder=""Full name"" /></FormField>
         <FormField Label=""Email""><Input placeholder=""Email"" /></FormField>
         <Button Class=""w-full"">Save</Button>

--- a/docs/Lumeo.Docs/Pages/Components/ScrollAreaPage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/ScrollAreaPage.razor
@@ -57,6 +57,25 @@
             </Flex>
         </ScrollArea>
     </ComponentDemo>
+
+    <ComponentDemo Title="Focus Ring Gutter" Code="@_gutterCode">
+        <Container MaxWidth="xs">
+            <Stack Gap="2">
+                <Lumeo.Text Size="sm" Color="muted">Enable <code class="font-mono">FocusRingGutter</code> when the scroll area holds focusable controls (inputs, buttons) whose focus ring would otherwise clip at the left/right edge. It applies a net-zero <code class="font-mono">-mx-1 px-1</code> gutter so the ring renders in full.</Lumeo.Text>
+                <ScrollArea FocusRingGutter="true" Class="h-64 rounded-md border bg-card p-4">
+                    <Stack Gap="3">
+                        @foreach (var field in _gutterFields)
+                        {
+                            <FormField Label="@field">
+                                <Input placeholder="@field" />
+                            </FormField>
+                        }
+                        <Button Class="w-full">Save</Button>
+                    </Stack>
+                </ScrollArea>
+            </Stack>
+        </Container>
+    </ComponentDemo>
 </Stack>
 
 <div class="mt-16">
@@ -98,6 +117,19 @@
         "MudBlazor", "Radzen", "FluentUI", "Lumeo", "MAUI",
         ".NET 10", "WebAssembly", "Server-side", "Auto render"
     ];
+
+    private readonly string[] _gutterFields =
+    [
+        "Full name", "Email", "Company", "Role", "Phone", "City", "Country"
+    ];
+
+    private string _gutterCode = @"<ScrollArea FocusRingGutter=""true"" Class=""h-64 rounded-md border p-4"">
+    <Stack Gap=""3"">
+        <FormField Label=""Full name""><Input placeholder=""Full name"" /></FormField>
+        <FormField Label=""Email""><Input placeholder=""Email"" /></FormField>
+        <Button Class=""w-full"">Save</Button>
+    </Stack>
+</ScrollArea>";
 
     private record ChatMsg(string Author, string Text, bool Mine);
     private readonly List<ChatMsg> _messages = new()

--- a/docs/Lumeo.Docs/Pages/Components/SidebarPage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/SidebarPage.razor
@@ -334,6 +334,7 @@
             </TableHeader>
             <TableBody>
                 <TableRow><TableCell Class="font-mono text-xs">ChildContent</TableCell><TableCell Class="font-mono text-xs">RenderFragment?</TableCell><TableCell Class="font-mono text-xs">null</TableCell><TableCell>The component content. All layout sub-components accept ChildContent.</TableCell></TableRow>
+                <TableRow><TableCell Class="font-mono text-xs">Bordered</TableCell><TableCell Class="font-mono text-xs">bool</TableCell><TableCell Class="font-mono text-xs">true</TableCell><TableCell><code class="font-mono">SidebarHeader</code> / <code class="font-mono">SidebarFooter</code> only. When false, drops the divider rule (bottom/top border) so the section flows seamlessly into the content.</TableCell></TableRow>
                 <TableRow><TableCell Class="font-mono text-xs">Class</TableCell><TableCell Class="font-mono text-xs">string?</TableCell><TableCell Class="font-mono text-xs">null</TableCell><TableCell>Additional CSS classes.</TableCell></TableRow>
                 <TableRow><TableCell Class="font-mono text-xs">AdditionalAttributes</TableCell><TableCell Class="font-mono text-xs">Dictionary&lt;string, object&gt;?</TableCell><TableCell Class="font-mono text-xs">null</TableCell><TableCell>Additional HTML attributes. SidebarTrigger toggles collapsed state. SidebarGroupLabel hides text when collapsed. SidebarSeparator has no ChildContent.</TableCell></TableRow>
             </TableBody>

--- a/docs/Lumeo.Docs/Pages/Components/SidebarPage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/SidebarPage.razor
@@ -199,6 +199,53 @@
             </SidebarProvider>
         </Stack>
     </ComponentDemo>
+
+    <ComponentDemo Title="Seamless header &amp; footer" Code="@_borderedCode">
+        <Stack Gap="2">
+            <Lumeo.Text Size="sm" Color="muted">Pass <code class="font-mono">Bordered="false"</code> on <code class="font-mono">SidebarHeader</code> / <code class="font-mono">SidebarFooter</code> to drop the divider rule and let the section flow into the content — replaces the consumer-side <code class="font-mono">!border-b-0</code> / <code class="font-mono">!border-t-0</code> override.</Lumeo.Text>
+            <Stack Class="h-[360px] w-full rounded-lg border overflow-hidden">
+                <SidebarProvider @bind-IsCollapsed="_borderedCollapsed">
+                    <SidebarComponent>
+                        <SidebarHeader Bordered="false">
+                            <Flex Gap="2" Align="center" Class="px-2">
+                                <Stack Class="h-6 w-6 rounded bg-primary"></Stack>
+                                <Lumeo.Text As="span" Size="sm" Class="font-semibold text-foreground">Acme Inc</Lumeo.Text>
+                            </Flex>
+                        </SidebarHeader>
+                        <SidebarContent>
+                            <SidebarGroup>
+                                <SidebarGroupLabel>Platform</SidebarGroupLabel>
+                                <SidebarMenu>
+                                    <SidebarMenuItem>
+                                        <SidebarMenuButton Href="#" IsActive="true">
+                                            <IconContent><DynamicIcon Name="House" Class="h-4 w-4" /></IconContent>
+                                            <LabelContent><Lumeo.Text As="span">Dashboard</Lumeo.Text></LabelContent>
+                                        </SidebarMenuButton>
+                                    </SidebarMenuItem>
+                                    <SidebarMenuItem>
+                                        <SidebarMenuButton Href="#">
+                                            <IconContent><DynamicIcon Name="Settings" Class="h-4 w-4" /></IconContent>
+                                            <LabelContent><Lumeo.Text As="span">Settings</Lumeo.Text></LabelContent>
+                                        </SidebarMenuButton>
+                                    </SidebarMenuItem>
+                                </SidebarMenu>
+                            </SidebarGroup>
+                        </SidebarContent>
+                        <SidebarFooter Bordered="false">
+                            <Flex Gap="2" Align="center" Class="px-2">
+                                <Avatar Src="" Fallback="CN" />
+                                <Lumeo.Text As="span" Size="sm" Class="text-foreground">User</Lumeo.Text>
+                            </Flex>
+                        </SidebarFooter>
+                    </SidebarComponent>
+                    <main class="flex-1 p-6">
+                        <SidebarTrigger />
+                        <Lumeo.Text Size="sm" Color="muted" Class="mt-4">Header and footer flow into the content with no divider rule.</Lumeo.Text>
+                    </main>
+                </SidebarProvider>
+            </Stack>
+        </Stack>
+    </ComponentDemo>
 </Stack>
 
 <Alert Variant="Alert.AlertVariant.Info" ShowIcon="true" Class="mt-6">
@@ -307,6 +354,34 @@
     private bool _pushCollapsed;
     private bool _overlayCollapsed = true;
     private bool _iconCollapsed = true;
+    private bool _borderedCollapsed;
+
+    private string _borderedCode = @"<SidebarProvider @bind-IsCollapsed=""_isCollapsed"">
+    <SidebarComponent>
+        <SidebarHeader Bordered=""false"">
+            <Lumeo.Text As=""span"" Size=""sm"" Weight=""semibold"">Acme Inc</Lumeo.Text>
+        </SidebarHeader>
+        <SidebarContent>
+            <SidebarGroup>
+                <SidebarGroupLabel>Platform</SidebarGroupLabel>
+                <SidebarMenu>
+                    <SidebarMenuItem>
+                        <SidebarMenuButton Href=""#"" IsActive=""true"">
+                            <IconContent><Blazicon Svg=""Lucide.House"" class=""h-4 w-4"" /></IconContent>
+                            <LabelContent><span>Dashboard</span></LabelContent>
+                        </SidebarMenuButton>
+                    </SidebarMenuItem>
+                </SidebarMenu>
+            </SidebarGroup>
+        </SidebarContent>
+        <SidebarFooter Bordered=""false"">
+            <Avatar Src="""" Fallback=""CN"" />
+        </SidebarFooter>
+    </SidebarComponent>
+    <main class=""flex-1 p-6"">
+        <SidebarTrigger />
+    </main>
+</SidebarProvider>";
 
     // Interactive: Side
     private string _sidebarSideSel = "Left";

--- a/docs/Lumeo.Docs/Pages/Components/SidebarPage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/SidebarPage.razor
@@ -52,7 +52,7 @@
                     </SidebarContent>
                     <SidebarFooter>
                         <Flex Gap="2" Align="center" Class="px-2">
-                            <Avatar Src="" Fallback="CN" />
+                            <Avatar><AvatarFallback>CN</AvatarFallback></Avatar>
                             <Lumeo.Text As="span" Size="sm" Class="text-foreground">User</Lumeo.Text>
                         </Flex>
                     </SidebarFooter>
@@ -233,7 +233,7 @@
                         </SidebarContent>
                         <SidebarFooter Bordered="false">
                             <Flex Gap="2" Align="center" Class="px-2">
-                                <Avatar Src="" Fallback="CN" />
+                                <Avatar><AvatarFallback>CN</AvatarFallback></Avatar>
                                 <Lumeo.Text As="span" Size="sm" Class="text-foreground">User</Lumeo.Text>
                             </Flex>
                         </SidebarFooter>
@@ -375,7 +375,7 @@
             </SidebarGroup>
         </SidebarContent>
         <SidebarFooter Bordered=""false"">
-            <Avatar Src="""" Fallback=""CN"" />
+            <Avatar><AvatarFallback>CN</AvatarFallback></Avatar>
         </SidebarFooter>
     </SidebarComponent>
     <main class=""flex-1 p-6"">
@@ -432,7 +432,7 @@
             </SidebarGroup>
         </SidebarContent>
         <SidebarFooter>
-            <Avatar Src="""" Fallback=""CN"" />
+            <Avatar><AvatarFallback>CN</AvatarFallback></Avatar>
         </SidebarFooter>
     </SidebarComponent>
     <main class=""flex-1 p-6"">

--- a/docs/Lumeo.Docs/Pages/Docs/ThemeOverrides.razor
+++ b/docs/Lumeo.Docs/Pages/Docs/ThemeOverrides.razor
@@ -137,9 +137,9 @@
     <Stack Gap="4">
         <Heading Level="2">Per-component class overrides</Heading>
         <Lumeo.Text Size="base" Color="muted" Leading="relaxed">
-            Every Lumeo component accepts <code class="rounded bg-muted px-1.5 py-0.5 text-xs font-mono">Class</code>,
-            merged with the component's base classes through the tailwind-merge resolver
-            (<code class="rounded bg-muted px-1.5 py-0.5 text-xs font-mono">Cx.Merge</code>) so a utility you pass
+            Every Lumeo component accepts <code class="rounded bg-muted px-1.5 py-0.5 text-xs font-mono">Class</code>.
+            On the components migrated to the tailwind-merge resolver
+            (<code class="rounded bg-muted px-1.5 py-0.5 text-xs font-mono">Cx.Merge</code>) — the core set — a utility you pass
             wins any conflict with a base utility (see <em>Overriding component classes</em> below).
             Use it to add utilities (margins, hover states, sizing). For colors, prefer pointing at theme
             variables — <code class="rounded bg-muted px-1.5 py-0.5 text-xs font-mono">bg-primary</code>,
@@ -159,9 +159,15 @@
     <Stack Gap="4">
         <Heading Level="2">Overriding component classes</Heading>
         <Lumeo.Text Size="base" Color="muted" Leading="relaxed">
-            Lumeo composes a component's final class list through a tailwind-merge resolver
+            Most Lumeo components compose their final class list through a tailwind-merge resolver
             (<code class="rounded bg-muted px-1.5 py-0.5 text-xs font-mono">Cx.Merge</code>), not a naive
-            string concat. When a utility you pass via
+            string concat. (A few primitives — e.g. <code class="rounded bg-muted px-1.5 py-0.5 text-xs font-mono">Heading</code>,
+            <code class="rounded bg-muted px-1.5 py-0.5 text-xs font-mono">Text</code>,
+            <code class="rounded bg-muted px-1.5 py-0.5 text-xs font-mono">Link</code>,
+            <code class="rounded bg-muted px-1.5 py-0.5 text-xs font-mono">AppBar</code> — are still being migrated and
+            append <code class="rounded bg-muted px-1.5 py-0.5 text-xs font-mono">Class</code> by concatenation; there a
+            conflicting utility may still need <code class="rounded bg-muted px-1.5 py-0.5 text-xs font-mono">!important</code>
+            until they move over.) When a utility you pass via
             <code class="rounded bg-muted px-1.5 py-0.5 text-xs font-mono">Class</code> conflicts with one of
             the component's base utilities, <em>your class wins</em> — and you no longer need
             <code class="rounded bg-muted px-1.5 py-0.5 text-xs font-mono">!important</code> to make it stick.
@@ -177,8 +183,10 @@
             Conflicts are resolved per utility group — padding, margin, sizing, colors, border-radius, and so
             on — so overriding <code class="rounded bg-muted px-1.5 py-0.5 text-xs font-mono">h-12</code> replaces
             only the height and leaves the component's other base utilities intact. Unknown or custom classes
-            (your own non-Tailwind class names, arbitrary values) are never dropped — they're always kept in
-            their original source position.
+            (your own non-Tailwind class names) are never dropped — they're always kept in their original
+            source position. Arbitrary Tailwind values such as <code class="rounded bg-muted px-1.5 py-0.5 text-xs font-mono">h-[42px]</code>
+            or <code class="rounded bg-muted px-1.5 py-0.5 text-xs font-mono">bg-[#fff]</code> are <em>not</em> unknown —
+            they're classified into their utility group and follow the same last-wins rule.
         </Lumeo.Text>
         <pre class="code-block rounded-lg border border-border/40 bg-muted px-4 py-3 font-mono text-xs text-foreground whitespace-pre overflow-x-auto">@_classMergeCode</pre>
     </Stack>

--- a/docs/Lumeo.Docs/Pages/Docs/ThemeOverrides.razor
+++ b/docs/Lumeo.Docs/Pages/Docs/ThemeOverrides.razor
@@ -164,15 +164,18 @@
             <code class="rounded bg-muted px-1.5 py-0.5 text-xs font-mono">Class</code> conflicts with one of
             the component's base utilities, <em>your class wins</em> — and you no longer need
             <code class="rounded bg-muted px-1.5 py-0.5 text-xs font-mono">!important</code> to make it stick.
-            So <code class="rounded bg-muted px-1.5 py-0.5 text-xs font-mono">&lt;Card Class="p-0"&gt;</code> or
-            <code class="rounded bg-muted px-1.5 py-0.5 text-xs font-mono">&lt;Button Class="h-12"&gt;</code>
-            just work; the old <code class="rounded bg-muted px-1.5 py-0.5 text-xs font-mono">!p-0</code> /
-            <code class="rounded bg-muted px-1.5 py-0.5 text-xs font-mono">!h-12</code> workarounds are obsolete.
+            So <code class="rounded bg-muted px-1.5 py-0.5 text-xs font-mono">&lt;Button Class="h-12"&gt;</code> or
+            <code class="rounded bg-muted px-1.5 py-0.5 text-xs font-mono">&lt;Badge Class="px-4"&gt;</code>
+            just work; the old <code class="rounded bg-muted px-1.5 py-0.5 text-xs font-mono">!h-12</code> /
+            <code class="rounded bg-muted px-1.5 py-0.5 text-xs font-mono">!px-4</code> workarounds are obsolete.
+            (Override the utility on the element that actually carries it — e.g. a Card's padding lives on
+            <code class="rounded bg-muted px-1.5 py-0.5 text-xs font-mono">CardContent</code>/<code class="rounded bg-muted px-1.5 py-0.5 text-xs font-mono">CardHeader</code>,
+            so pass <code class="rounded bg-muted px-1.5 py-0.5 text-xs font-mono">Class="p-0"</code> there, not on the bare <code class="rounded bg-muted px-1.5 py-0.5 text-xs font-mono">Card</code> root.)
         </Lumeo.Text>
         <Lumeo.Text Size="base" Color="muted" Leading="relaxed">
             Conflicts are resolved per utility group — padding, margin, sizing, colors, border-radius, and so
-            on — so overriding <code class="rounded bg-muted px-1.5 py-0.5 text-xs font-mono">p-0</code> replaces
-            only the padding and leaves the component's other base utilities intact. Unknown or custom classes
+            on — so overriding <code class="rounded bg-muted px-1.5 py-0.5 text-xs font-mono">h-12</code> replaces
+            only the height and leaves the component's other base utilities intact. Unknown or custom classes
             (your own non-Tailwind class names, arbitrary values) are never dropped — they're always kept and
             appended after the merged set.
         </Lumeo.Text>
@@ -287,14 +290,20 @@
 </div>";
 
     private const string _classMergeCode = @"<!-- Class wins the Tailwind conflict — no ! needed -->
-<Card Class=""p-0"">...</Card>        <!-- removes the card's default padding -->
 <Button Class=""h-12"">Tall</Button>   <!-- replaces the button's default height -->
+<Badge Class=""px-4"">Wide</Badge>     <!-- replaces the badge's default padding -->
 
-<!-- per-group: only padding is replaced, sizing/colors stay -->
-<Badge Class=""px-4"">Wide</Badge>
+<!-- override the element that actually carries the utility:
+     a Card's padding lives on its sub-components, not the Card root -->
+<Card>
+    <CardContent Class=""p-0"">...</CardContent>
+</Card>
+
+<!-- per-group: only height is replaced, colors/radius stay -->
+<Button Class=""h-12"">Tall, still primary, still rounded</Button>
 
 <!-- custom / unknown classes are always kept -->
-<Card Class=""p-0 my-analytics-card"">...</Card>";
+<Button Class=""h-12 my-cta-button"">...</Button>";
 
     private const string _perComponentCode = @"<!-- good: theme-aware utilities -->
 <Button Class=""bg-success text-success-foreground hover:bg-success/90"">Mark complete</Button>

--- a/docs/Lumeo.Docs/Pages/Docs/ThemeOverrides.razor
+++ b/docs/Lumeo.Docs/Pages/Docs/ThemeOverrides.razor
@@ -138,8 +138,9 @@
         <Heading Level="2">Per-component class overrides</Heading>
         <Lumeo.Text Size="base" Color="muted" Leading="relaxed">
             Every Lumeo component accepts <code class="rounded bg-muted px-1.5 py-0.5 text-xs font-mono">Class</code>,
-            appended to the component's base classes via
-            <code class="rounded bg-muted px-1.5 py-0.5 text-xs font-mono">$"{BaseClasses} {Class}".Trim()</code>.
+            merged with the component's base classes through the tailwind-merge resolver
+            (<code class="rounded bg-muted px-1.5 py-0.5 text-xs font-mono">Cx.Merge</code>) so a utility you pass
+            wins any conflict with a base utility (see <em>Overriding component classes</em> below).
             Use it to add utilities (margins, hover states, sizing). For colors, prefer pointing at theme
             variables — <code class="rounded bg-muted px-1.5 py-0.5 text-xs font-mono">bg-primary</code>,
             <code class="rounded bg-muted px-1.5 py-0.5 text-xs font-mono">text-foreground</code> — so the
@@ -176,8 +177,8 @@
             Conflicts are resolved per utility group — padding, margin, sizing, colors, border-radius, and so
             on — so overriding <code class="rounded bg-muted px-1.5 py-0.5 text-xs font-mono">h-12</code> replaces
             only the height and leaves the component's other base utilities intact. Unknown or custom classes
-            (your own non-Tailwind class names, arbitrary values) are never dropped — they're always kept and
-            appended after the merged set.
+            (your own non-Tailwind class names, arbitrary values) are never dropped — they're always kept in
+            their original source position.
         </Lumeo.Text>
         <pre class="code-block rounded-lg border border-border/40 bg-muted px-4 py-3 font-mono text-xs text-foreground whitespace-pre overflow-x-auto">@_classMergeCode</pre>
     </Stack>

--- a/docs/Lumeo.Docs/Pages/Docs/ThemeOverrides.razor
+++ b/docs/Lumeo.Docs/Pages/Docs/ThemeOverrides.razor
@@ -156,6 +156,32 @@
     <Separator Class="my-4" />
 
     <Stack Gap="4">
+        <Heading Level="2">Overriding component classes</Heading>
+        <Lumeo.Text Size="base" Color="muted" Leading="relaxed">
+            Lumeo composes a component's final class list through a tailwind-merge resolver
+            (<code class="rounded bg-muted px-1.5 py-0.5 text-xs font-mono">Cx.Merge</code>), not a naive
+            string concat. When a utility you pass via
+            <code class="rounded bg-muted px-1.5 py-0.5 text-xs font-mono">Class</code> conflicts with one of
+            the component's base utilities, <em>your class wins</em> — and you no longer need
+            <code class="rounded bg-muted px-1.5 py-0.5 text-xs font-mono">!important</code> to make it stick.
+            So <code class="rounded bg-muted px-1.5 py-0.5 text-xs font-mono">&lt;Card Class="p-0"&gt;</code> or
+            <code class="rounded bg-muted px-1.5 py-0.5 text-xs font-mono">&lt;Button Class="h-12"&gt;</code>
+            just work; the old <code class="rounded bg-muted px-1.5 py-0.5 text-xs font-mono">!p-0</code> /
+            <code class="rounded bg-muted px-1.5 py-0.5 text-xs font-mono">!h-12</code> workarounds are obsolete.
+        </Lumeo.Text>
+        <Lumeo.Text Size="base" Color="muted" Leading="relaxed">
+            Conflicts are resolved per utility group — padding, margin, sizing, colors, border-radius, and so
+            on — so overriding <code class="rounded bg-muted px-1.5 py-0.5 text-xs font-mono">p-0</code> replaces
+            only the padding and leaves the component's other base utilities intact. Unknown or custom classes
+            (your own non-Tailwind class names, arbitrary values) are never dropped — they're always kept and
+            appended after the merged set.
+        </Lumeo.Text>
+        <pre class="code-block rounded-lg border border-border/40 bg-muted px-4 py-3 font-mono text-xs text-foreground whitespace-pre overflow-x-auto">@_classMergeCode</pre>
+    </Stack>
+
+    <Separator Class="my-4" />
+
+    <Stack Gap="4">
         <Heading Level="2">Picking the right layer</Heading>
         <div class="overflow-x-auto rounded-lg border border-border/40">
             <Table>
@@ -259,6 +285,16 @@
         </Stack>
     </Card>
 </div>";
+
+    private const string _classMergeCode = @"<!-- Class wins the Tailwind conflict — no ! needed -->
+<Card Class=""p-0"">...</Card>        <!-- removes the card's default padding -->
+<Button Class=""h-12"">Tall</Button>   <!-- replaces the button's default height -->
+
+<!-- per-group: only padding is replaced, sizing/colors stay -->
+<Badge Class=""px-4"">Wide</Badge>
+
+<!-- custom / unknown classes are always kept -->
+<Card Class=""p-0 my-analytics-card"">...</Card>";
 
     private const string _perComponentCode = @"<!-- good: theme-aware utilities -->
 <Button Class=""bg-success text-success-foreground hover:bg-success/90"">Mark complete</Button>


### PR DESCRIPTION
Docs-only (no tag — Cloudflare auto-deploys from master). Closes the doc gaps for the props shipped in 3.5.2 / 3.5.3 that weren't yet on their component pages.

- **BadgePage** — "Sizes & Pill" demo (`Size` Sm/Md/Lg + `Pill` chips).
- **CardPage** — "Flat variant" demo (clickable `Variant="Card.CardVariant.Flat"` list rows; notes it replaces the Ghost-button + `!p-0` pattern).
- **SidebarPage** — seamless `SidebarHeader`/`SidebarFooter` `Bordered="false"` demo.
- **ScrollAreaPage** — `FocusRingGutter` demo + rationale (net-zero `-mx-1 px-1` so focus rings don't clip).
- **ThemeOverrides** — new "Overriding component classes" section explaining the `Cx.Merge` tailwind-merge behavior: a consumer's `Class` wins Tailwind conflicts **without `!important`** (`<Card Class="p-0">` just works), resolved per utility group, unknown classes preserved.

All params verified against `src/Lumeo/UI/` source.

## Test plan
- [ ] CI green (docs build)
- [ ] New demo blocks render on each page

---
_Generated by [Claude Code](https://claude.ai/code/session_01LJmBFYeCdQj2G2epoZaRzQ)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added Badge "Sizes & Pill" demo and documented Size and Pill properties.
  * Added Card "Flat" variant demo, clarified keyboard activation (Enter/Space) and tab behavior, and updated Variant semantics.
  * Added ScrollArea "Focus Ring Gutter" demo and documented the FocusRingGutter option.
  * Enhanced Sidebar demos with seamless header/footer example and clarified Bordered behavior.
  * Added guidance on component class overrides and utility-class merging.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Brain2k-0005/Lumeo/pull/116?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->