### PR TITLE
feat(overlay): unified OverlayOptions.Size for Dialog and Sheet (3.6.0)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
   <!-- Lockstep version shared by all Lumeo packages.
        Update this single property to version all packages in unison. -->
   <PropertyGroup>
-    <Version>3.5.3</Version>
+    <Version>3.6.0</Version>
   </PropertyGroup>
 
   <!-- Shared NuGet README packing lives in Directory.Build.targets, NOT here.

--- a/docs/Lumeo.Docs/Pages/Components/OverlayServicePage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/OverlayServicePage.razor
@@ -263,10 +263,16 @@
                             <td class="p-3 text-muted-foreground">Which side the sheet slides in from.</td>
                         </tr>
                         <tr>
-                            <td class="p-3 font-mono text-xs text-primary">SheetSize</td>
+                            <td class="p-3 font-mono text-xs text-primary">Size</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">OverlaySize</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">Default</td>
+                            <td class="p-3 text-muted-foreground"><strong>Dialog &amp; Sheet</strong> (3.6.0). Unified size knob. For a <strong>Dialog</strong> it maps to a <code>max-w-*</code> preset (<code>Sm</code>→<code>max-w-sm</code>, <code>Default</code>→<code>max-w-lg</code>, <code>Lg</code>→<code>max-w-2xl</code>, <code>Xl</code>→<code>max-w-4xl</code>, <code>Full</code>→near-viewport) — so you can enlarge a service Dialog without a <code>Class</code> override. For a <strong>Sheet</strong> it controls width on <code>Left</code>/<code>Right</code> or height on <code>Top</code>/<code>Bottom</code>; <code>Full</code> on <code>Bottom</code> + <code>SwipeToClose=true</code> gives the mobile-fullscreen sheet.</td>
+                        </tr>
+                        <tr>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">SheetSize <span class="text-[10px] uppercase tracking-wide text-amber-600">deprecated</span></td>
                             <td class="p-3 font-mono text-xs text-muted-foreground">SheetSize</td>
                             <td class="p-3 font-mono text-xs text-muted-foreground">Default</td>
-                            <td class="p-3 text-muted-foreground">Sheet dimension. On <code>Left</code>/<code>Right</code> controls width; on <code>Top</code>/<code>Bottom</code> controls height (2.1.1). <code>Full</code> on <code>Bottom</code> + <code>SwipeToClose=true</code> gives the mobile-fullscreen sheet pattern.</td>
+                            <td class="p-3 text-muted-foreground">Legacy Sheet-only alias for <code>Size</code> (1:1 mapping). Kept for source compatibility — prefer <code>Size</code> in new code.</td>
                         </tr>
                         <tr>
                             <td class="p-3 font-mono text-xs text-primary">SwipeToClose</td>
@@ -287,10 +293,16 @@
                             <td class="p-3 text-muted-foreground">Sheet-only (2.1.3). Side override used when the viewport is below <code>MobileBreakpoint</code>. Typical pattern: <code>Lumeo.Side.Right</code> on desktop, <code>Lumeo.Side.Bottom</code> on mobile. <code>null</code> keeps <code>SheetSide</code> at every size.</td>
                         </tr>
                         <tr>
-                            <td class="p-3 font-mono text-xs text-primary">MobileSheetSize</td>
+                            <td class="p-3 font-mono text-xs text-primary">MobileSize</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">OverlaySize?</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">null</td>
+                            <td class="p-3 text-muted-foreground"><strong>Dialog &amp; Sheet</strong> (3.6.0). Size override used below <code>MobileBreakpoint</code>. Pair with <code>MobileSheetSide=Bottom</code> + <code>MobileSize=Full</code> for the mobile-fullscreen bottom-sheet pattern. <code>null</code> keeps <code>Size</code> at every viewport.</td>
+                        </tr>
+                        <tr>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">MobileSheetSize <span class="text-[10px] uppercase tracking-wide text-amber-600">deprecated</span></td>
                             <td class="p-3 font-mono text-xs text-muted-foreground">SheetSize?</td>
                             <td class="p-3 font-mono text-xs text-muted-foreground">null</td>
-                            <td class="p-3 text-muted-foreground">Sheet-only (2.1.3). Size override used below <code>MobileBreakpoint</code>. Pair with <code>MobileSheetSide=Bottom</code> + <code>MobileSheetSize=Full</code> for the mobile-fullscreen bottom-sheet pattern.</td>
+                            <td class="p-3 text-muted-foreground">Legacy alias for <code>MobileSize</code> (1:1 mapping, null round-trips). Prefer <code>MobileSize</code>.</td>
                         </tr>
                         <tr>
                             <td class="p-3 font-mono text-xs text-primary">MobileSwipeToClose</td>
@@ -301,6 +313,20 @@
                     </tbody>
                 </table>
             </Stack>
+        </Stack>
+
+        <Stack>
+            <Heading Id="sizing-overlays" Level="3" Class="mb-3">Sizing overlays (3.6.0)</Heading>
+            <Lumeo.Text Size="sm" Color="muted" Class="mb-3">
+                <code>OverlayOptions.Size</code> is a single, unified knob that sizes both Dialogs and Sheets — no <code>Class</code> override needed. To make a service-opened Dialog larger, just pass a <code>Size</code>:
+            </Lumeo.Text>
+            <pre class="rounded-md border border-border/40 bg-muted/30 p-3 text-xs overflow-x-auto"><code>// A wide dialog — Lg → max-w-2xl, Xl → max-w-4xl, Full → near-viewport
+await Overlay.ShowDialogAsync&lt;MyForm&gt;(
+    title: "Edit user",
+    options: new OverlayOptions { Size = OverlaySize.Lg });</code></pre>
+            <Lumeo.Text Size="sm" Color="muted" Class="mt-3 mb-3">
+                The same <code>Size</code> drives Sheets (width on Left/Right, height on Top/Bottom). The old Sheet-only <code>SheetSize</code> property still works as a 1:1 alias but is deprecated — prefer <code>Size</code>.
+            </Lumeo.Text>
         </Stack>
 
         <Stack>
@@ -321,7 +347,7 @@ private async Task ShowResponsive()
         {
             // Below 768px, switch to a fullscreen bottom sheet with swipe-down dismiss
             MobileSheetSide    = Lumeo.Side.Bottom,
-            MobileSheetSize    = SheetSize.Full,
+            MobileSize         = OverlaySize.Full,   // unified Size — drives Dialog &amp; Sheet
             MobileSwipeToClose = true,
             // MobileBreakpoint defaults to 768 (md) — set to null to disable
         });

--- a/docs/Lumeo.Docs/Pages/Docs/Changelog.razor
+++ b/docs/Lumeo.Docs/Pages/Docs/Changelog.razor
@@ -15,6 +15,36 @@
 
     <Separator Class="my-4" />
 
+    <!-- v3.6.0 -->
+    <Stack Gap="4">
+        <div class="flex items-center gap-3">
+            <Badge>v3.6.0</Badge>
+            <Lumeo.Text Size="sm" Color="muted">May 2026</Lumeo.Text>
+        </div>
+
+        <Lumeo.Text Size="base" Color="muted" Leading="relaxed">
+            Minor: a unified <code class="rounded bg-muted px-1 text-xs">OverlayOptions.Size</code> that sizes both Dialogs and Sheets from one knob — so you can enlarge a service-opened Dialog without a <code class="rounded bg-muted px-1 text-xs">Class</code> override.
+        </Lumeo.Text>
+
+        <Stack Gap="3">
+            <Heading Level="3" Size="sm" Class="font-semibold">Added</Heading>
+            <ul class="space-y-1.5 text-sm list-disc list-inside text-muted-foreground">
+                <li><strong><code class="rounded bg-muted px-1 text-xs">OverlayOptions.Size</code></strong> (new <code class="rounded bg-muted px-1 text-xs">OverlaySize</code> enum: Sm/Default/Lg/Xl/Full) — one size property now drives <strong>both Dialog and Sheet</strong>. <code class="rounded bg-muted px-1 text-xs">OverlayProvider</code> maps it to <code class="rounded bg-muted px-1 text-xs">DialogContent.Size</code> (<code class="rounded bg-muted px-1 text-xs">max-w-*</code> presets) and <code class="rounded bg-muted px-1 text-xs">SheetContent.Size</code>. Example: <code class="rounded bg-muted px-1 text-xs">ShowDialogAsync&lt;T&gt;(options: new() { Size = OverlaySize.Lg })</code>.</li>
+                <li><strong><code class="rounded bg-muted px-1 text-xs">OverlayOptions.MobileSize</code></strong> — responsive size override below <code class="rounded bg-muted px-1 text-xs">MobileBreakpoint</code>, applies to Dialog &amp; Sheet (was Sheet-only).</li>
+                <li>Each <code class="rounded bg-muted px-1 text-xs">OverlayOptions</code> property now documents an <strong>“Applies to:”</strong> note (Dialog / Sheet / Drawer) in its XML doc and on the API reference page.</li>
+            </ul>
+        </Stack>
+
+        <Stack Gap="3">
+            <Heading Level="3" Size="sm" Class="font-semibold">Deprecated</Heading>
+            <ul class="space-y-1.5 text-sm list-disc list-inside text-muted-foreground">
+                <li><code class="rounded bg-muted px-1 text-xs">OverlayOptions.SheetSize</code> / <code class="rounded bg-muted px-1 text-xs">MobileSheetSize</code> — kept as 1:1 aliases onto <code class="rounded bg-muted px-1 text-xs">Size</code> / <code class="rounded bg-muted px-1 text-xs">MobileSize</code> for source compatibility; prefer the unified properties. No runtime behaviour change.</li>
+            </ul>
+        </Stack>
+    </Stack>
+
+    <Separator Class="my-4" />
+
     <!-- v3.5.3 -->
     <Stack Gap="4">
         <div class="flex items-center gap-3">

--- a/src/Lumeo/Services/OverlayService.cs
+++ b/src/Lumeo/Services/OverlayService.cs
@@ -36,7 +36,12 @@ public sealed class OverlayService : IOverlayService
         OverlayOptions? options = null) where TComponent : IComponent
     {
         options ??= new OverlayOptions();
-        options = options with { SheetSide = side, Size = OverlaySizeConvert.FromSheet(size) };
+        // Precedence: the legacy `size` parameter wins only when explicitly set
+        // to a non-default value; otherwise defer to the unified options.Size so
+        // ShowSheetAsync(options: new() { Size = OverlaySize.Xl }) takes effect
+        // instead of being overwritten back to Default by the omitted parameter.
+        var effectiveSize = size != SheetSize.Default ? OverlaySizeConvert.FromSheet(size) : options.Size;
+        options = options with { SheetSide = side, Size = effectiveSize };
         return ShowAsync(OverlayType.Sheet, typeof(TComponent), title, parameters, options);
     }
 

--- a/src/Lumeo/Services/OverlayService.cs
+++ b/src/Lumeo/Services/OverlayService.cs
@@ -36,7 +36,7 @@ public sealed class OverlayService : IOverlayService
         OverlayOptions? options = null) where TComponent : IComponent
     {
         options ??= new OverlayOptions();
-        options = options with { SheetSide = side, SheetSize = size };
+        options = options with { SheetSide = side, Size = OverlaySizeConvert.FromSheet(size) };
         return ShowAsync(OverlayType.Sheet, typeof(TComponent), title, parameters, options);
     }
 
@@ -119,11 +119,50 @@ public sealed class OverlayService : IOverlayService
 
 public enum OverlayType { Dialog, Sheet, Drawer, AlertDialog }
 
+/// <summary>Unified overlay content size as exposed through
+/// <see cref="OverlayService"/>. Drives both <c>DialogContent.DialogSize</c>
+/// and <c>SheetContent.SheetSize</c> from a single <see cref="OverlayOptions.Size"/>
+/// value, so the same options record can size a Dialog or a Sheet. Kept in the
+/// service layer (not the UI namespace) so consumers don't take a hard UI
+/// dependency. <c>Full</c> is layout-intent (entire viewport).</summary>
+public enum OverlaySize { Sm, Default, Lg, Xl, Full }
+
 /// <summary>Sheet size as exposed through <see cref="OverlayService"/>. Mirrors
 /// <c>SheetContent.SheetSize</c> — kept distinct so the service layer doesn't
 /// take a hard dependency on the UI namespace. <c>Full</c> is layout-intent
-/// (entire viewport) and intentionally NOT folded into <see cref="Lumeo.Size"/>.</summary>
+/// (entire viewport) and intentionally NOT folded into <see cref="Lumeo.Size"/>.
+/// <para>Retained as the parameter type of
+/// <see cref="OverlayService.ShowSheetAsync{T}"/> and as the backing type of the
+/// obsolete <see cref="OverlayOptions.SheetSize"/> alias; new code should prefer
+/// <see cref="OverlaySize"/>.</para></summary>
 public enum SheetSize { Sm, Default, Lg, Xl, Full }
+
+/// <summary>1:1 conversions between the legacy <see cref="SheetSize"/> and the
+/// unified <see cref="OverlaySize"/>. The member sets are identical, so the maps
+/// are total and lossless — they exist only to bridge the obsolete
+/// <see cref="OverlayOptions.SheetSize"/> alias and the
+/// <see cref="OverlayService.ShowSheetAsync{T}"/> parameter onto the canonical
+/// <see cref="OverlayOptions.Size"/>.</summary>
+internal static class OverlaySizeConvert
+{
+    public static OverlaySize FromSheet(SheetSize s) => s switch
+    {
+        SheetSize.Sm => OverlaySize.Sm,
+        SheetSize.Lg => OverlaySize.Lg,
+        SheetSize.Xl => OverlaySize.Xl,
+        SheetSize.Full => OverlaySize.Full,
+        _ => OverlaySize.Default,
+    };
+
+    public static SheetSize ToSheet(OverlaySize s) => s switch
+    {
+        OverlaySize.Sm => SheetSize.Sm,
+        OverlaySize.Lg => SheetSize.Lg,
+        OverlaySize.Xl => SheetSize.Xl,
+        OverlaySize.Full => SheetSize.Full,
+        _ => SheetSize.Default,
+    };
+}
 
 public sealed record OverlayResult
 {
@@ -152,18 +191,50 @@ public sealed class OverlayParameters
     public Dictionary<string, object> ToDictionary() => new(_parameters);
 }
 
+// CS0618 is disabled across this record because the synthesized record members
+// (Equals / GetHashCode / PrintMembers) enumerate every public property,
+// including the obsolete SheetSize / MobileSheetSize aliases below — that
+// generated reference would otherwise trip -warnaserror. The aliases stay fully
+// usable by consumers; only the in-record generated access is suppressed.
+#pragma warning disable CS0618
 public record OverlayOptions
 {
+    /// <summary>Extra CSS classes merged onto the overlay's content element.
+    /// <b>Applies to:</b> Dialog, Sheet, Drawer.</summary>
     public string? Class { get; init; }
+
+    /// <summary>Suppress dismissal via backdrop click / Escape.
+    /// <b>Applies to:</b> Dialog, Sheet, Drawer.</summary>
     public bool PreventClose { get; init; }
+
+    /// <summary>Edge the sheet slides in from. <b>Applies to:</b> Sheet.</summary>
     public Lumeo.Side SheetSide { get; init; } = Lumeo.Side.Right;
-    public SheetSize SheetSize { get; init; } = SheetSize.Default;
+
+    /// <summary>Overlay content size. <b>Applies to:</b> Dialog, Sheet.
+    /// (Drawer sizes to its content and ignores this.) For a Dialog it maps to
+    /// the <c>max-w-*</c> preset (<c>Sm</c>→<c>max-w-sm</c> … <c>Xl</c>→<c>max-w-4xl</c>,
+    /// <c>Full</c>→near-viewport); for a Sheet it maps to the side-appropriate
+    /// width (Left/Right) or height (Top/Bottom). Replaces the Sheet-only
+    /// <see cref="SheetSize"/> as the single size knob for service overlays.</summary>
+    public OverlaySize Size { get; init; } = OverlaySize.Default;
+
+    /// <summary>Legacy Sheet-only size alias. <b>Applies to:</b> Sheet.
+    /// Reads/writes <see cref="Size"/> via a 1:1 mapping; setting either sets the
+    /// same backing value. Kept for source compatibility with pre-3.6 callers.</summary>
+    [Obsolete("Use Size instead — the unified size property now drives both Dialog and Sheet. SheetSize remains as a 1:1 mapping alias onto Size and may be removed in a future major version.")]
+    public SheetSize SheetSize
+    {
+        get => OverlaySizeConvert.ToSheet(Size);
+        init => Size = OverlaySizeConvert.FromSheet(value);
+    }
+
     /// <summary>
     /// When true, a Sheet opened via <see cref="OverlayService.ShowSheetAsync{T}"/>
     /// can be dismissed by swiping in the direction opposite to its
     /// <see cref="SheetSide"/> (e.g. swipe-down on a Bottom sheet). Ignored for
     /// non-Sheet overlay types. Drawers already enable swipe by default.
     /// Default false to preserve the existing programmatic-open behaviour.
+    /// <b>Applies to:</b> Sheet.
     /// </summary>
     public bool SwipeToClose { get; init; }
 
@@ -178,24 +249,39 @@ public record OverlayOptions
     /// <summary>Viewport width threshold (CSS pixels) below which the
     /// <c>Mobile*</c> overrides apply. Default 768 (Tailwind <c>md</c>).
     /// Set to null to disable responsive switching even if the
-    /// <c>Mobile*</c> fields are populated.</summary>
+    /// <c>Mobile*</c> fields are populated.
+    /// <b>Applies to:</b> Dialog, Sheet, Drawer (gates every <c>Mobile*</c> override).</summary>
     public int? MobileBreakpoint { get; init; } = 768;
 
     /// <summary>Sheet side to use when the viewport is below
     /// <see cref="MobileBreakpoint"/>. Null = use <see cref="SheetSide"/> at all
     /// sizes. Typical pattern: <c>Lumeo.Side.Right</c> on desktop,
-    /// <c>Lumeo.Side.Bottom</c> on mobile.</summary>
+    /// <c>Lumeo.Side.Bottom</c> on mobile.
+    /// <b>Applies to:</b> Sheet.</summary>
     public Lumeo.Side? MobileSheetSide { get; init; }
 
-    /// <summary>Sheet size to use when the viewport is below
-    /// <see cref="MobileBreakpoint"/>. Null = use <see cref="SheetSize"/> at all
-    /// sizes. Typical pattern: <c>SheetSize.Default</c> on desktop,
-    /// <c>SheetSize.Full</c> on mobile.</summary>
-    public SheetSize? MobileSheetSize { get; init; }
+    /// <summary>Overlay size to use when the viewport is below
+    /// <see cref="MobileBreakpoint"/>. Null = use <see cref="Size"/> at all
+    /// sizes. Typical pattern: <c>OverlaySize.Default</c> on desktop,
+    /// <c>OverlaySize.Full</c> on mobile.
+    /// <b>Applies to:</b> Dialog, Sheet.</summary>
+    public OverlaySize? MobileSize { get; init; }
+
+    /// <summary>Legacy Sheet-only alias for <see cref="MobileSize"/>.
+    /// <b>Applies to:</b> Sheet. Reads/writes <see cref="MobileSize"/> via a 1:1
+    /// mapping (null round-trips to null). Kept for source compatibility with
+    /// pre-3.6 callers.</summary>
+    [Obsolete("Use MobileSize instead — it drives both Dialog and Sheet below MobileBreakpoint. MobileSheetSize remains as a 1:1 mapping alias onto MobileSize and may be removed in a future major version.")]
+    public SheetSize? MobileSheetSize
+    {
+        get => MobileSize is { } s ? OverlaySizeConvert.ToSheet(s) : null;
+        init => MobileSize = value is { } v ? OverlaySizeConvert.FromSheet(v) : null;
+    }
 
     /// <summary>SwipeToClose override below <see cref="MobileBreakpoint"/>.
     /// Null = use <see cref="SwipeToClose"/> at all sizes. Typical pattern:
-    /// off on desktop, on for mobile bottom-sheet pull-down.</summary>
+    /// off on desktop, on for mobile bottom-sheet pull-down.
+    /// <b>Applies to:</b> Sheet.</summary>
     public bool? MobileSwipeToClose { get; init; }
 
     /// <summary>When true and the viewport width is below
@@ -205,8 +291,9 @@ public record OverlayOptions
     /// <c>max-md:!h-full max-md:!w-full max-md:!max-w-full</c> Tailwind
     /// override chain that was previously the only way to get a
     /// full-screen Dialog on mobile. For Sheets, this is equivalent to
-    /// setting <see cref="MobileSheetSize"/> to <see cref="SheetSize.Full"/>
-    /// but composes more naturally for the Sheet+Dialog mixed case.</summary>
+    /// setting <see cref="MobileSize"/> to <see cref="OverlaySize.Full"/>
+    /// but composes more naturally for the Sheet+Dialog mixed case.
+    /// <b>Applies to:</b> Dialog, Sheet, Drawer.</summary>
     public bool MobileFullscreen { get; init; }
 
     /// <summary>
@@ -223,9 +310,11 @@ public record OverlayOptions
     /// <c>false</c> for sheets whose content sets its own scrolling strategy
     /// (e.g. an embedded <c>PdfViewer</c> that already paints inside a fixed
     /// canvas).
+    /// <b>Applies to:</b> Sheet.
     /// </summary>
     public bool ScrollableBody { get; init; } = true;
 }
+#pragma warning restore CS0618
 
 /// <summary>
 /// Sheet-shaped overlay options. <b>Semantic</b> marker — at the call site

--- a/src/Lumeo/UI/Overlay/OverlayProvider.razor
+++ b/src/Lumeo/UI/Overlay/OverlayProvider.razor
@@ -8,7 +8,7 @@
     {
         case OverlayType.Dialog:
             <Dialog @key="overlay.Id" Open="true" OpenChanged="(bool val) => OnOverlayClosed(val, overlay.Id)">
-                <DialogContent ZIndex="@overlay.ZIndex" PreventClose="@overlay.Options.PreventClose" Class="@EffectiveClass(overlay.Options)">
+                <DialogContent ZIndex="@overlay.ZIndex" Size="@EffectiveDialogSize(overlay.Options)" PreventClose="@overlay.Options.PreventClose" Class="@EffectiveClass(overlay.Options)">
                     @if (overlay.Title is not null)
                     {
                         <DialogHeader>
@@ -155,7 +155,7 @@
     private static bool HasMobileOverrides(OverlayOptions opts) =>
         opts.MobileBreakpoint is not null
         && (opts.MobileSheetSide is not null
-            || opts.MobileSheetSize is not null
+            || opts.MobileSize is not null
             || opts.MobileSwipeToClose is not null
             || opts.MobileFullscreen);
 
@@ -170,11 +170,14 @@
     private Lumeo.Side EffectiveSheetSide(OverlayOptions opts) =>
         IsMobile(opts) && opts.MobileSheetSide is { } ms ? ms : opts.SheetSide;
 
-    private SheetContent.SheetSize EffectiveSheetSize(OverlayOptions opts)
-    {
-        var size = IsMobile(opts) && opts.MobileSheetSize is { } ms ? ms : opts.SheetSize;
-        return MapSheetSize(size);
-    }
+    private OverlaySize EffectiveSize(OverlayOptions opts) =>
+        IsMobile(opts) && opts.MobileSize is { } ms ? ms : opts.Size;
+
+    private SheetContent.SheetSize EffectiveSheetSize(OverlayOptions opts) =>
+        MapSheetSize(EffectiveSize(opts));
+
+    private DialogContent.DialogSize EffectiveDialogSize(OverlayOptions opts) =>
+        MapDialogSize(EffectiveSize(opts));
 
     private bool EffectiveSwipeToClose(OverlayOptions opts) =>
         IsMobile(opts) && opts.MobileSwipeToClose is bool m ? m : opts.SwipeToClose;
@@ -276,13 +279,22 @@
         return reference;
     }
 
-    private static SheetContent.SheetSize MapSheetSize(SheetSize size) => size switch
+    private static SheetContent.SheetSize MapSheetSize(OverlaySize size) => size switch
     {
-        SheetSize.Sm => SheetContent.SheetSize.Sm,
-        SheetSize.Lg => SheetContent.SheetSize.Lg,
-        SheetSize.Xl => SheetContent.SheetSize.Xl,
-        SheetSize.Full => SheetContent.SheetSize.Full,
+        OverlaySize.Sm => SheetContent.SheetSize.Sm,
+        OverlaySize.Lg => SheetContent.SheetSize.Lg,
+        OverlaySize.Xl => SheetContent.SheetSize.Xl,
+        OverlaySize.Full => SheetContent.SheetSize.Full,
         _ => SheetContent.SheetSize.Default
+    };
+
+    private static DialogContent.DialogSize MapDialogSize(OverlaySize size) => size switch
+    {
+        OverlaySize.Sm => DialogContent.DialogSize.Sm,
+        OverlaySize.Lg => DialogContent.DialogSize.Lg,
+        OverlaySize.Xl => DialogContent.DialogSize.Xl,
+        OverlaySize.Full => DialogContent.DialogSize.Full,
+        _ => DialogContent.DialogSize.Default
     };
 
     public async ValueTask DisposeAsync()

--- a/tests/Lumeo.Tests/Components/Overlay/OverlayProviderTests.cs
+++ b/tests/Lumeo.Tests/Components/Overlay/OverlayProviderTests.cs
@@ -269,4 +269,25 @@ public class OverlayProviderTests : IAsyncLifetime
         // Right side + Lg maps to sm:max-w-lg (see SheetContent size switch).
         Assert.Contains("sm:max-w-lg", cls);
     }
+
+    [Fact]
+    public void ShowSheet_Honors_OverlayOptions_Size_When_Size_Param_Omitted()
+    {
+        // Regression: the unified options.Size must drive sheets too. With the
+        // legacy `size` parameter omitted (defaulting to SheetSize.Default), the
+        // caller's options.Size must NOT be overwritten back to Default.
+        var service = _ctx.Services.GetRequiredService<OverlayService>();
+        var cut = _ctx.Render<Lumeo.OverlayProvider>();
+
+        _ = service.ShowSheetAsync<DummyOverlayBody>(
+            title: "Unified-size sheet",
+            options: new OverlayOptions { Size = OverlaySize.Xl });
+
+        cut.WaitForState(() => cut.Markup.Contains("BODY"));
+
+        var dialog = cut.Find("[role='dialog']");
+        var cls = dialog.GetAttribute("class") ?? "";
+        // Right side + Xl maps to sm:max-w-xl (see SheetContent size switch).
+        Assert.Contains("sm:max-w-xl", cls);
+    }
 }

--- a/tests/Lumeo.Tests/Components/Overlay/OverlayProviderTests.cs
+++ b/tests/Lumeo.Tests/Components/Overlay/OverlayProviderTests.cs
@@ -124,7 +124,7 @@ public class OverlayProviderTests : IAsyncLifetime
         Assert.Equal(768, options.MobileBreakpoint);
         // Mobile* override fields default to null = "no responsive switch".
         Assert.Null(options.MobileSheetSide);
-        Assert.Null(options.MobileSheetSize);
+        Assert.Null(options.MobileSize);
         Assert.Null(options.MobileSwipeToClose);
     }
 
@@ -186,15 +186,87 @@ public class OverlayProviderTests : IAsyncLifetime
         var options = new OverlayOptions
         {
             MobileBreakpoint = null,
-            MobileSheetSize = SheetSize.Full
+            MobileSize = OverlaySize.Full
         };
 
         // MobileBreakpoint=null is the documented opt-out: even though
-        // MobileSheetSize is set, the provider must keep the desktop SheetSize
+        // MobileSize is set, the provider must keep the desktop Size
         // at every viewport. We can't drive the provider end-to-end here
         // without mocking IResponsiveService AND inspecting SheetContent
         // class output, so this test guards the record values only.
         Assert.Null(options.MobileBreakpoint);
-        Assert.Equal(SheetSize.Full, options.MobileSheetSize);
+        Assert.Equal(OverlaySize.Full, options.MobileSize);
+    }
+
+    // --- Unified Size (3.6.0) ----------------------------------------------
+    //
+    // OverlayOptions.Size now drives both Dialog and Sheet. The legacy
+    // SheetSize / MobileSheetSize properties are obsolete 1:1 aliases that
+    // read/write the same backing Size / MobileSize value.
+
+    [Fact]
+    public void OverlayOptions_Size_Default_Is_Default()
+    {
+        var options = new OverlayOptions();
+        Assert.Equal(OverlaySize.Default, options.Size);
+        Assert.Null(options.MobileSize);
+    }
+
+    [Fact]
+    public void OverlayOptions_SheetSize_Alias_RoundTrips_Through_Size()
+    {
+#pragma warning disable CS0618 // exercising the obsolete alias on purpose
+        // Writing the legacy alias sets the canonical Size.
+        var viaAlias = new OverlayOptions { SheetSize = SheetSize.Xl };
+        Assert.Equal(OverlaySize.Xl, viaAlias.Size);
+        Assert.Equal(SheetSize.Xl, viaAlias.SheetSize);
+
+        // Writing Size reflects back through the alias getter.
+        var viaSize = new OverlayOptions { Size = OverlaySize.Lg };
+        Assert.Equal(SheetSize.Lg, viaSize.SheetSize);
+
+        // Mobile alias round-trips too, including the null case.
+        var mobile = new OverlayOptions { MobileSheetSize = SheetSize.Full };
+        Assert.Equal(OverlaySize.Full, mobile.MobileSize);
+        Assert.Equal(SheetSize.Full, mobile.MobileSheetSize);
+        Assert.Null(new OverlayOptions().MobileSheetSize);
+#pragma warning restore CS0618
+    }
+
+    [Fact]
+    public void ShowDialog_With_Size_Lg_Emits_DialogSize_MaxWidth()
+    {
+        var service = _ctx.Services.GetRequiredService<OverlayService>();
+        var cut = _ctx.Render<Lumeo.OverlayProvider>();
+
+        _ = service.ShowDialogAsync<DummyOverlayBody>(
+            title: "Wide dialog",
+            options: new OverlayOptions { Size = OverlaySize.Lg });
+
+        cut.WaitForState(() => cut.Markup.Contains("BODY"));
+
+        var dialog = cut.Find("[role='dialog']");
+        var cls = dialog.GetAttribute("class") ?? "";
+        // DialogSize.Lg maps to max-w-2xl (see DialogContent.SizeClass).
+        Assert.Contains("max-w-2xl", cls);
+    }
+
+    [Fact]
+    public void ShowSheet_Size_Param_Routes_Through_To_SheetContent()
+    {
+        var service = _ctx.Services.GetRequiredService<OverlayService>();
+        var cut = _ctx.Render<Lumeo.OverlayProvider>();
+
+        _ = service.ShowSheetAsync<DummyOverlayBody>(
+            title: "Large sheet",
+            side: Lumeo.Side.Right,
+            size: SheetSize.Lg);
+
+        cut.WaitForState(() => cut.Markup.Contains("BODY"));
+
+        var dialog = cut.Find("[role='dialog']");
+        var cls = dialog.GetAttribute("class") ?? "";
+        // Right side + Lg maps to sm:max-w-lg (see SheetContent size switch).
+        Assert.Contains("sm:max-w-lg", cls);
     }
 }

--- a/tools/Lumeo.RegistryGen/ComponentsApiEmitter.cs
+++ b/tools/Lumeo.RegistryGen/ComponentsApiEmitter.cs
@@ -212,7 +212,7 @@ public static class ComponentsApiEmitter
             {
                 "OverlayService", "OverlayOptions", "SheetOverlayOptions",
                 "DialogOverlayOptions", "DrawerOverlayOptions", "AlertDialogOptions",
-                "OverlayResult", "OverlayParameters", "OverlayInstance", "OverlayType", "SheetSize",
+                "OverlayResult", "OverlayParameters", "OverlayInstance", "OverlayType", "OverlaySize", "SheetSize",
             }),
             // IOverlayService lives in its own file, not OverlayService.cs.
             (Core("Services", "IOverlayService.cs"), new[]


### PR DESCRIPTION
## Summary

Adds a single, unified size knob to the overlay service so a **Dialog** can be enlarged without a `Class` override — the original motivation ("wie mache ich meinen Dialog größer, ohne Class?").

- **New `OverlaySize` enum** `{ Sm, Default, Lg, Xl, Full }` + **`OverlayOptions.Size`** (and **`MobileSize`**). One property now drives **both Dialog and Sheet**: `OverlayProvider` maps `Size` → `DialogContent.Size` (`max-w-*` presets) and → `SheetContent.Size`.
  ```csharp
  await Overlay.ShowDialogAsync<MyForm>(
      title: "Edit user",
      options: new OverlayOptions { Size = OverlaySize.Lg }); // max-w-2xl
  ```
- **Back-compat:** `SheetSize` / `MobileSheetSize` are kept as `[Obsolete]` **1:1 aliases** onto `Size` / `MobileSize` (no runtime behaviour change). `ShowSheetAsync(size: SheetSize.X)` still works.
- **`MobileSize`** extends the responsive override to Dialogs too (was Sheet-only).
- Every `OverlayOptions` property now documents an **"Applies to:"** note (Dialog / Sheet / Drawer) in XML docs and on the API reference page.
- `OverlaySize` added to the MCP components-api emitter type list.
- Docs: OverlayService page (API table + new "Sizing overlays" section) and changelog entry for v3.6.0.

### Notes
- A scoped `#pragma warning disable CS0618` wraps the `OverlayOptions` record so the compiler-synthesized `Equals`/`PrintMembers` (which enumerate the obsolete aliases) don't trip the CI `-warnaserror` gate. Consumer usage of the aliases still warns as intended.
- This is a **real library change** → version bumped to `3.6.0` in `Directory.Build.props`. Tag/NuGet publish awaits owner confirmation per project rules.

## Test plan
- [ ] CI green (`build-and-test`, `e2e`, `bom-check`)
- [ ] New unit tests: `Size` default, `SheetSize`/`MobileSheetSize` alias round-trip, `ShowDialogAsync(Size=Lg)` emits `max-w-2xl`, `ShowSheetAsync(size:Lg)` emits `sm:max-w-lg`
- [ ] Manually verify a large service Dialog renders without a `Class` override

---
_Generated by [Claude Code](https://claude.ai/code/session_01LJmBFYeCdQj2G2epoZaRzQ)_