### PR TITLE
ci(docs): docs build check + Lighthouse baseline pipeline

### DIFF
--- a/.github/lighthouserc.json
+++ b/.github/lighthouserc.json
@@ -1,0 +1,23 @@
+{
+  "ci": {
+    "collect": {
+      "numberOfRuns": 3,
+      "settings": {
+        "preset": "desktop"
+      }
+    },
+    "assert": {
+      "assertions": {
+        "categories:performance": ["warn", { "minScore": 0.9 }],
+        "categories:accessibility": ["warn", { "minScore": 0.9 }],
+        "categories:best-practices": ["warn", { "minScore": 0.9 }],
+        "categories:seo": ["warn", { "minScore": 0.9 }],
+        "first-contentful-paint": ["warn", { "maxNumericValue": 1800 }],
+        "largest-contentful-paint": ["warn", { "maxNumericValue": 2500 }],
+        "cumulative-layout-shift": ["warn", { "maxNumericValue": 0.1 }],
+        "total-blocking-time": ["warn", { "maxNumericValue": 300 }],
+        "interactive": ["warn", { "maxNumericValue": 3800 }]
+      }
+    }
+  }
+}

--- a/.github/workflows/docs-ci.yml
+++ b/.github/workflows/docs-ci.yml
@@ -31,6 +31,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v4

--- a/.github/workflows/docs-ci.yml
+++ b/.github/workflows/docs-ci.yml
@@ -1,0 +1,56 @@
+name: Docs build check
+
+# The docs site (docs/Lumeo.Docs) is NOT in Lumeo.slnx, so the main `ci.yml`
+# build only compiles it transitively via Lumeo.Docs.Tests' ProjectReference.
+# That catches type errors but not the full WASM publish path (static-web-asset
+# pipeline, the GenerateLocalSearchIndex node target, lazy-load manifest, etc.).
+# This workflow runs the real `dotnet publish` so a docs-only change that breaks
+# the published output is caught in the PR instead of only at deploy time.
+#
+# Mirrors the proven setup steps from deploy-cloudflare.yml (dotnet 10 +
+# wasm-tools, node 22, npm installs) but stops at publish — no Puppeteer
+# prerender / OG cards (those belong to the deploy job, not a build gate).
+
+on:
+  pull_request:
+    paths:
+      - 'docs/Lumeo.Docs/**'
+      - 'src/Lumeo/**'
+      - '.github/workflows/docs-ci.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: docs-ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Install wasm-tools workload
+        run: dotnet workload install wasm-tools
+
+      - name: Install npm deps
+        # Root deps power the Tailwind build; docs deps power the
+        # GenerateLocalSearchIndex MSBuild target that runs during publish.
+        run: |
+          npm install --no-audit --no-fund
+          (cd docs/Lumeo.Docs && npm install --no-audit --no-fund)
+
+      - name: Publish Blazor WASM (build verification)
+        run: dotnet publish docs/Lumeo.Docs/Lumeo.Docs.csproj -c Release -o release

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -22,6 +22,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Setup Node
         uses: actions/setup-node@v4

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -1,0 +1,40 @@
+name: Lighthouse
+
+# Measurable Web-Vitals baseline for the docs site. Runs against the LIVE
+# Cloudflare-deployed site (PRs don't get an automatic CF preview — the deploy
+# workflow only triggers on master push), so this is a baseline + ongoing
+# regression signal rather than a per-PR gate. After a perf change lands on
+# master and redeploys, dispatch this (or wait for the weekly run) to see the
+# delta. Assertions are "warn"-level so a run never fails the actions tab — the
+# value is the uploaded HTML report and the budget deltas, not a red X.
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Weekly, Monday 06:00 UTC.
+    - cron: '0 6 * * 1'
+
+permissions:
+  contents: read
+
+jobs:
+  lighthouse:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Run Lighthouse CI
+        uses: treosh/lighthouse-ci-action@v12
+        with:
+          urls: |
+            https://lumeo.nativ.sh/
+            https://lumeo.nativ.sh/components
+            https://lumeo.nativ.sh/docs/introduction
+          configPath: ./.github/lighthouserc.json
+          uploadArtifacts: true
+          temporaryPublicStorage: true


### PR DESCRIPTION
## Summary

First step of the docs-site overhaul: **establish build safety + a measurable performance baseline** before the perf/IA/landing work lands. Pure CI/tooling — no app code changes.

- **`docs-ci.yml`** — PR-triggered `dotnet publish docs/Lumeo.Docs`. Today the docs project is *not* in `Lumeo.slnx`; `ci.yml` only compiles it transitively via `Lumeo.Docs.Tests`' ProjectReference, which misses full publish-path breakage (static-web-asset pipeline, the `GenerateLocalSearchIndex` node target, lazy-load manifest). This catches it in the PR. Mirrors the proven setup steps from `deploy-cloudflare.yml` (dotnet 10 + wasm-tools, node 22, npm installs) and stops at publish.
- **`lighthouse.yml` + `lighthouserc.json`** — weekly + manual Lighthouse run against the **live** site (`/`, `/components`, `/docs/introduction`) with warn-level budgets: perf/a11y/best-practices/seo ≥ 0.9, LCP ≤ 2.5s, CLS ≤ 0.1, TBT ≤ 300ms. PRs don't get an automatic Cloudflare preview (the deploy workflow only triggers on master push), so this is a baseline + ongoing regression signal, not a per-PR gate. HTML reports are uploaded as artifacts.

## Why this first
The upcoming overhaul (landing-page demos lazy/static, PNG→WebP, theme-CSS on-demand, IA/template consolidation) needs a way to *prove* "not laggy" instead of guessing. This PR is that measurement + a safety net for the docs build.

## Verification note
I could not run any of this locally (no dotnet / Chromium / image tooling in my environment) — JSON + YAML were syntax-validated, and the workflow steps mirror the already-working `deploy-cloudflare.yml`. `docs-ci.yml` self-validates on this PR (it matches its own path filter). `lighthouse.yml` is dispatch/schedule-only — trigger it from the Actions tab to capture the first baseline.

## Test plan
- [ ] `docs-ci.yml` runs and goes green on this PR (publishes docs successfully)
- [ ] After merge, dispatch `lighthouse.yml` to capture the baseline report
- [ ] Confirm budget thresholds are sensible against the real numbers (tune later)


---
_Generated by [Claude Code](https://claude.ai/code/session_01LJmBFYeCdQj2G2epoZaRzQ)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated Lighthouse performance and accessibility testing scheduled weekly.
  * Implemented documentation build verification in continuous integration pipeline.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Brain2k-0005/Lumeo/pull/118?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->