### PR TITLE
test(toast): de-flake MaxVisible eviction test

### DIFF
--- a/tests/Lumeo.Tests/Components/Toast/ToastPositioningTests.cs
+++ b/tests/Lumeo.Tests/Components/Toast/ToastPositioningTests.cs
@@ -48,9 +48,14 @@ public class ToastPositioningTests : IAsyncLifetime
         var cut = _ctx.Render<L.ToastProvider>(p => p
             .Add(b => b.MaxVisible, 2));
 
-        toastService!.Show("Toast One");
-        toastService!.Show("Toast Two");
-        toastService!.Show("Toast Three");
+        // Long Duration keeps the toasts evictable (eviction only targets
+        // Duration != 0 toasts) while preventing the DefaultDuration (5000 ms)
+        // auto-dismiss from firing inside the 5 s WaitForState window — that
+        // race was the source of intermittent "Actual: 1" failures: a surviving
+        // toast timed out mid-wait, dropping the count below 2.
+        toastService!.Show(new ToastOptions { Title = "Toast One", Duration = 60000 });
+        toastService!.Show(new ToastOptions { Title = "Toast Two", Duration = 60000 });
+        toastService!.Show(new ToastOptions { Title = "Toast Three", Duration = 60000 });
 
         // Wait until eviction settles to exactly 2 (exit animation is 220 ms).
         cut.WaitForState(


### PR DESCRIPTION
## Summary

Fixes the long-standing flaky test `ToastProvider_MaxVisible_2_With_3_Toasts_Shows_Only_2` that just failed the **master** CI run for #118 (`build-and-test` → 2746/2747 passed, this one test `Expected: 2, Actual: 1`). It is **not** a regression from #118 (which only added CI workflows) — it's an intermittent timing race.

## Root cause
The test shows 3 toasts with `MaxVisible=2` and waits up to 5 s for eviction to settle to 2. The toasts used the default `DefaultDuration = 5000 ms` auto-dismiss. On a slow runner, a surviving toast's 5 s auto-dismiss timer fires *inside* the `WaitForState` window, dropping the count to 1 before the assert → `Actual: 1`.

## Fix
Give the test's toasts a long `Duration = 60000`. Eviction only targets `Duration != 0` toasts (see `ToastProvider.razor:104`), so they stay evictable — but they no longer auto-dismiss during the ~5 s test window. The test now deterministically settles to exactly 2 (the MaxVisible eviction behavior it's actually asserting).

Note: setting `Duration = 0` would *not* work — that marks a toast as pinned/non-evictable, which would break the eviction the test verifies.

## Test plan
- [ ] `build-and-test` green (the de-flaked test passes deterministically)
- [ ] Test still asserts the MaxVisible=2 eviction (3 shown → 2 visible)


---
_Generated by [Claude Code](https://claude.ai/code/session_01LJmBFYeCdQj2G2epoZaRzQ)_