### PR TITLE
fix(consent-banner): stack layout on mobile instead of squeezing text

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
   <!-- Lockstep version shared by all Lumeo packages.
        Update this single property to version all packages in unison. -->
   <PropertyGroup>
-    <Version>3.6.0</Version>
+    <Version>3.6.1</Version>
   </PropertyGroup>
 
   <!-- Shared NuGet README packing lives in Directory.Build.targets, NOT here.

--- a/src/Lumeo/UI/ConsentBanner/ConsentBanner.razor
+++ b/src/Lumeo/UI/ConsentBanner/ConsentBanner.razor
@@ -8,7 +8,7 @@
          class="@(Cx.Merge("lumeo-consent-banner fixed bottom-4 left-1/2 -translate-x-1/2 w-[calc(100%-2rem)] max-w-2xl z-50", AnimationClass, Class))"
          @attributes="AdditionalAttributes">
         <div class="rounded-lg border border-border/60 bg-popover text-popover-foreground shadow-xl p-5">
-            <div class="flex items-start gap-4 flex-wrap md:flex-nowrap">
+            <div class="flex flex-col gap-4 md:flex-row md:items-start">
                 <div class="flex-1 min-w-0">
                     <div class="flex items-center gap-2 mb-1">
                         <Blazicon Svg="Lucide.Cookie" class="h-4 w-4 text-primary" />
@@ -24,22 +24,22 @@
                         }
                     </p>
                 </div>
-                <div class="flex flex-wrap items-center gap-2 shrink-0">
+                <div class="flex w-full flex-col gap-2 sm:w-auto sm:flex-row sm:flex-wrap sm:items-center sm:shrink-0">
                     @if (Categories.Any(c => !c.Required))
                     {
                         <button type="button"
-                                class="inline-flex items-center justify-center rounded-md text-xs font-medium h-8 px-3 text-muted-foreground hover:text-foreground transition-colors focus-visible:outline-none focus-visible:ring-[1.5px] focus-visible:ring-ring focus-visible:ring-offset-2"
+                                class="inline-flex items-center justify-center rounded-md text-xs font-medium w-full sm:w-auto h-10 sm:h-8 px-3 text-muted-foreground hover:text-foreground transition-colors focus-visible:outline-none focus-visible:ring-[1.5px] focus-visible:ring-ring focus-visible:ring-offset-2"
                                 @onclick="OpenPreferences">
                             @CustomizeLabel
                         </button>
                     }
                     <button type="button"
-                            class="inline-flex items-center justify-center rounded-md text-xs font-medium h-8 px-3 border border-border/60 bg-background hover:bg-accent transition-colors focus-visible:outline-none focus-visible:ring-[1.5px] focus-visible:ring-ring focus-visible:ring-offset-2"
+                            class="inline-flex items-center justify-center rounded-md text-xs font-medium w-full sm:w-auto h-10 sm:h-8 px-3 border border-border/60 bg-background hover:bg-accent transition-colors focus-visible:outline-none focus-visible:ring-[1.5px] focus-visible:ring-ring focus-visible:ring-offset-2"
                             @onclick="RejectAll">
                         @RejectLabel
                     </button>
                     <button type="button"
-                            class="inline-flex items-center justify-center rounded-md text-xs font-medium h-8 px-3 bg-primary text-primary-foreground hover:bg-primary/90 transition-colors focus-visible:outline-none focus-visible:ring-[1.5px] focus-visible:ring-ring focus-visible:ring-offset-2"
+                            class="inline-flex items-center justify-center rounded-md text-xs font-medium w-full sm:w-auto h-10 sm:h-8 px-3 bg-primary text-primary-foreground hover:bg-primary/90 transition-colors focus-visible:outline-none focus-visible:ring-[1.5px] focus-visible:ring-ring focus-visible:ring-offset-2"
                             @onclick="AcceptAll">
                         @AcceptLabel
                     </button>

--- a/src/Lumeo/UI/ConsentBanner/ConsentBanner.razor
+++ b/src/Lumeo/UI/ConsentBanner/ConsentBanner.razor
@@ -28,18 +28,18 @@
                     @if (Categories.Any(c => !c.Required))
                     {
                         <button type="button"
-                                class="inline-flex items-center justify-center rounded-md text-xs font-medium w-full sm:w-auto h-10 sm:h-8 px-3 text-muted-foreground hover:text-foreground transition-colors focus-visible:outline-none focus-visible:ring-[1.5px] focus-visible:ring-ring focus-visible:ring-offset-2"
+                                class="inline-flex items-center justify-center rounded-md text-xs font-medium w-full sm:w-auto h-8 px-3 text-muted-foreground hover:text-foreground transition-colors focus-visible:outline-none focus-visible:ring-[1.5px] focus-visible:ring-ring focus-visible:ring-offset-2"
                                 @onclick="OpenPreferences">
                             @CustomizeLabel
                         </button>
                     }
                     <button type="button"
-                            class="inline-flex items-center justify-center rounded-md text-xs font-medium w-full sm:w-auto h-10 sm:h-8 px-3 border border-border/60 bg-background hover:bg-accent transition-colors focus-visible:outline-none focus-visible:ring-[1.5px] focus-visible:ring-ring focus-visible:ring-offset-2"
+                            class="inline-flex items-center justify-center rounded-md text-xs font-medium w-full sm:w-auto h-8 px-3 border border-border/60 bg-background hover:bg-accent transition-colors focus-visible:outline-none focus-visible:ring-[1.5px] focus-visible:ring-ring focus-visible:ring-offset-2"
                             @onclick="RejectAll">
                         @RejectLabel
                     </button>
                     <button type="button"
-                            class="inline-flex items-center justify-center rounded-md text-xs font-medium w-full sm:w-auto h-10 sm:h-8 px-3 bg-primary text-primary-foreground hover:bg-primary/90 transition-colors focus-visible:outline-none focus-visible:ring-[1.5px] focus-visible:ring-ring focus-visible:ring-offset-2"
+                            class="inline-flex items-center justify-center rounded-md text-xs font-medium w-full sm:w-auto h-8 px-3 bg-primary text-primary-foreground hover:bg-primary/90 transition-colors focus-visible:outline-none focus-visible:ring-[1.5px] focus-visible:ring-ring focus-visible:ring-offset-2"
                             @onclick="AcceptAll">
                         @AcceptLabel
                     </button>


### PR DESCRIPTION
## Problem
On mobile the consent banner laid the text and action buttons out in a **single flex row**: the button group was `shrink-0` while the text column was `flex-1 min-w-0`, so the text collapsed to a **one-word-per-line** sliver and the buttons crammed into the top-right corner. `flex-wrap` never triggered because the shrinkable text absorbed all the squeeze.

## Fix (scoped to layout/stacking only)
- Outer layout is now `flex-col` on mobile (text block full width on top, actions below) and only switches to the side-by-side row at `md`.
- The action group is full width with **stacked, full-width buttons** below `sm`, reverting to the compact inline row from `sm` up.
- Button height is **unchanged** (`h-8`); desktop (`md`+) layout is unchanged.

Pure markup/class change. All utility variants used are already emitted by other library components, and `lumeo-utilities.src.css` scans `../UI/**/*.razor`, so the classes ship in the NuGet CSS bundle.

## Version (CLAUDE.md Rule #2)
`ConsentBanner` is shipped library code → `Directory.Build.props` bumped **3.6.0 → 3.6.1** (patch, layout bugfix). Mergeable to `master` now; the **tag + NuGet publish remain gated on owner confirmation** — not created in this PR.

## Verification
- Owner confirmed the banner renders correctly on a real phone via the preview deploy. ✅

## Test plan
- [x] Banner renders correctly on a narrow viewport (text full width, buttons stacked full-width below)
- [x] Desktop layout unchanged
- [ ] `build-and-test` green on the version-bump commit


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Consent banner layout now features improved responsiveness across mobile and desktop screens.

* **Chores**
  * Version updated to 3.6.1.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Brain2k-0005/Lumeo/pull/122?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->