### PR TITLE
perf(datagrid): split Excel/PDF export into lazy-loadable Lumeo.DataGrid.Export

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -49,6 +49,7 @@ jobs:
           dotnet restore src/Lumeo.Charts/Lumeo.Charts.csproj
           dotnet restore src/Lumeo.CodeEditor/Lumeo.CodeEditor.csproj
           dotnet restore src/Lumeo.DataGrid/Lumeo.DataGrid.csproj
+          dotnet restore src/Lumeo.DataGrid.Export/Lumeo.DataGrid.Export.csproj
           dotnet restore src/Lumeo.Editor/Lumeo.Editor.csproj
           dotnet restore src/Lumeo.FileViewer/Lumeo.FileViewer.csproj
           dotnet restore src/Lumeo.Scheduler/Lumeo.Scheduler.csproj
@@ -65,6 +66,7 @@ jobs:
           dotnet build src/Lumeo.Charts/Lumeo.Charts.csproj -c Release --no-restore -warnaserror
           dotnet build src/Lumeo.CodeEditor/Lumeo.CodeEditor.csproj -c Release --no-restore -warnaserror
           dotnet build src/Lumeo.DataGrid/Lumeo.DataGrid.csproj -c Release --no-restore -warnaserror
+          dotnet build src/Lumeo.DataGrid.Export/Lumeo.DataGrid.Export.csproj -c Release --no-restore -warnaserror
           dotnet build src/Lumeo.Editor/Lumeo.Editor.csproj -c Release --no-restore -warnaserror
           dotnet build src/Lumeo.FileViewer/Lumeo.FileViewer.csproj -c Release --no-restore -warnaserror
           dotnet build src/Lumeo.Scheduler/Lumeo.Scheduler.csproj -c Release --no-restore -warnaserror
@@ -86,6 +88,7 @@ jobs:
           dotnet pack src/Lumeo.Charts/Lumeo.Charts.csproj -c Release --no-build -o ./nupkg /p:Version=${{ steps.ver.outputs.version }}
           dotnet pack src/Lumeo.CodeEditor/Lumeo.CodeEditor.csproj -c Release --no-build -o ./nupkg /p:Version=${{ steps.ver.outputs.version }}
           dotnet pack src/Lumeo.DataGrid/Lumeo.DataGrid.csproj -c Release --no-build -o ./nupkg /p:Version=${{ steps.ver.outputs.version }}
+          dotnet pack src/Lumeo.DataGrid.Export/Lumeo.DataGrid.Export.csproj -c Release --no-build -o ./nupkg /p:Version=${{ steps.ver.outputs.version }}
           dotnet pack src/Lumeo.Editor/Lumeo.Editor.csproj -c Release --no-build -o ./nupkg /p:Version=${{ steps.ver.outputs.version }}
           dotnet pack src/Lumeo.FileViewer/Lumeo.FileViewer.csproj -c Release --no-build -o ./nupkg /p:Version=${{ steps.ver.outputs.version }}
           dotnet pack src/Lumeo.Scheduler/Lumeo.Scheduler.csproj -c Release --no-build -o ./nupkg /p:Version=${{ steps.ver.outputs.version }}

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
   <!-- Lockstep version shared by all Lumeo packages.
        Update this single property to version all packages in unison. -->
   <PropertyGroup>
-    <Version>3.6.1</Version>
+    <Version>3.7.0</Version>
   </PropertyGroup>
 
   <!-- Shared NuGet README packing lives in Directory.Build.targets, NOT here.

--- a/Lumeo.slnx
+++ b/Lumeo.slnx
@@ -4,6 +4,7 @@
     <Project Path="src/Lumeo.Charts/Lumeo.Charts.csproj" />
     <Project Path="src/Lumeo.CodeEditor/Lumeo.CodeEditor.csproj" />
     <Project Path="src/Lumeo.DataGrid/Lumeo.DataGrid.csproj" />
+    <Project Path="src/Lumeo.DataGrid.Export/Lumeo.DataGrid.Export.csproj" />
     <Project Path="src/Lumeo.Editor/Lumeo.Editor.csproj" />
     <Project Path="src/Lumeo.FileViewer/Lumeo.FileViewer.csproj" />
     <Project Path="src/Lumeo.Gantt/Lumeo.Gantt.csproj" />

--- a/docs/Lumeo.Docs/Lumeo.Docs.csproj
+++ b/docs/Lumeo.Docs/Lumeo.Docs.csproj
@@ -94,6 +94,22 @@
     <BlazorWebAssemblyLazyLoad Include="Lumeo.Gantt.dll" />
     <BlazorWebAssemblyLazyLoad Include="Lumeo.PdfViewer.dll" />
     <BlazorWebAssemblyLazyLoad Include="Lumeo.Scheduler.dll" />
+
+    <!-- DataGrid Excel/PDF export backend + its heavy deps (~1.6 MB brotli). The DataGrid
+         itself is eager (Home hero), but export is an on-click action, so these load only
+         when a user actually exports — wired via DataGridExportLoader in Program.cs.
+         QuestPDF (PDF) throws on browser-wasm and is fetched only on a PDF click, so an
+         Excel-only WASM user never downloads it. -->
+    <BlazorWebAssemblyLazyLoad Include="Lumeo.DataGrid.Export.dll" />
+    <BlazorWebAssemblyLazyLoad Include="ClosedXML.dll" />
+    <BlazorWebAssemblyLazyLoad Include="ClosedXML.Parser.dll" />
+    <BlazorWebAssemblyLazyLoad Include="DocumentFormat.OpenXml.dll" />
+    <BlazorWebAssemblyLazyLoad Include="DocumentFormat.OpenXml.Framework.dll" />
+    <BlazorWebAssemblyLazyLoad Include="ExcelNumberFormat.dll" />
+    <BlazorWebAssemblyLazyLoad Include="RBush.dll" />
+    <BlazorWebAssemblyLazyLoad Include="SixLabors.Fonts.dll" />
+    <BlazorWebAssemblyLazyLoad Include="System.IO.Packaging.dll" />
+    <BlazorWebAssemblyLazyLoad Include="QuestPDF.dll" />
   </ItemGroup>
 
 </Project>

--- a/docs/Lumeo.Docs/Program.cs
+++ b/docs/Lumeo.Docs/Program.cs
@@ -1,8 +1,11 @@
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
+using Microsoft.AspNetCore.Components.WebAssembly.Services;
+using Microsoft.Extensions.DependencyInjection;
 using Lumeo;
 using Lumeo.Docs;
 using Lumeo.Docs.Services;
+using Lumeo.Services;
 
 var builder = WebAssemblyHostBuilder.CreateDefault(args);
 builder.RootComponents.Add<App>("#app");
@@ -18,4 +21,12 @@ builder.Services.AddSingleton<PatternFilterService>();
 builder.Services.AddScoped<NavConfigService>();
 builder.Services.AddScoped<RegistryService>();
 
-await builder.Build().RunAsync();
+var host = builder.Build();
+
+// Lazy-load the DataGrid Excel/PDF export backend on first export instead of at first paint.
+// The DataGrid calls this hook before exporting; the assemblies are marked
+// BlazorWebAssemblyLazyLoad in this project's .csproj.
+var lazyLoader = host.Services.GetRequiredService<LazyAssemblyLoader>();
+DataGridExportLoader.LoadAssembliesAsync = names => lazyLoader.LoadAssembliesAsync(names);
+
+await host.RunAsync();

--- a/src/Lumeo.DataGrid.Export/DataGridExportBackendImpl.cs
+++ b/src/Lumeo.DataGrid.Export/DataGridExportBackendImpl.cs
@@ -1,0 +1,242 @@
+using System.Globalization;
+using System.Runtime.CompilerServices;
+using ClosedXML.Excel;
+using Lumeo.Services;
+using QuestPDF.Fluent;
+using QuestPDF.Helpers;
+using QuestPDF.Infrastructure;
+
+namespace Lumeo.DataGrid.Export;
+
+/// <summary>
+/// Registers <see cref="DataGridExportBackendImpl"/> with the core
+/// <see cref="DataGridExportBackend"/> registry as soon as this assembly is loaded — whether
+/// eagerly (server / tests / default consumers) or via lazy loading on WebAssembly.
+/// </summary>
+internal static class ModuleInit
+{
+    [ModuleInitializer]
+    internal static void Init() => DataGridExportBackend.Register(new DataGridExportBackendImpl());
+}
+
+/// <summary>
+/// Excel (ClosedXML) and PDF (QuestPDF) implementation behind the core
+/// <see cref="IDataGridExportService"/> facade.
+/// </summary>
+internal sealed class DataGridExportBackendImpl : IDataGridExportBackend
+{
+    // QuestPDF requires a license to be set exactly once per process. We pick Community here
+    // which is free for individuals and companies below the revenue threshold defined at
+    // https://www.questpdf.com/license — commercial users should replace this with their own
+    // paid license before shipping, e.g. `QuestPDF.Settings.License = LicenseType.Professional;`
+    // in their app's startup. We guard with a flag so changing this on the consumer side wins.
+    private static readonly object _licenseLock = new();
+    private static bool _licenseInitialized;
+
+    private static void EnsureQuestPdfLicense()
+    {
+        if (_licenseInitialized) return;
+        lock (_licenseLock)
+        {
+            if (_licenseInitialized) return;
+            QuestPDF.Settings.License = LicenseType.Community;
+            _licenseInitialized = true;
+        }
+    }
+
+    // ---------------------------------------------------------------- Excel
+
+    public byte[] ToExcel<TItem>(
+        IEnumerable<TItem> items,
+        IEnumerable<DataGridExportColumn<TItem>> columns,
+        string sheetName,
+        CultureInfo culture)
+    {
+        var cols = columns.ToList();
+
+        using var workbook = new XLWorkbook();
+        var sheet = workbook.Worksheets.Add(string.IsNullOrWhiteSpace(sheetName) ? "Sheet1" : sheetName);
+
+        // Header row: bold, muted background.
+        for (var c = 0; c < cols.Count; c++)
+        {
+            var cell = sheet.Cell(1, c + 1);
+            cell.Value = cols[c].Header;
+            cell.Style.Font.Bold = true;
+            cell.Style.Fill.BackgroundColor = XLColor.FromHtml("#E5E7EB");
+            cell.Style.Alignment.Horizontal = XLAlignmentHorizontalValues.Left;
+        }
+
+        // Data rows.
+        var row = 2;
+        foreach (var item in items)
+        {
+            for (var c = 0; c < cols.Count; c++)
+            {
+                var cell = sheet.Cell(row, c + 1);
+                var raw = cols[c].Accessor(item);
+                SetExcelCellValue(cell, raw, cols[c].Format, culture);
+            }
+            row++;
+        }
+
+        sheet.Columns().AdjustToContents();
+        sheet.SheetView.FreezeRows(1);
+
+        using var ms = new MemoryStream();
+        workbook.SaveAs(ms);
+        return ms.ToArray();
+    }
+
+    private static void SetExcelCellValue(IXLCell cell, object? value, string? format, CultureInfo culture)
+    {
+        if (value is null)
+        {
+            cell.Value = string.Empty;
+            return;
+        }
+
+        // ClosedXML picks up the workbook/host locale for date and number formats. We pass the
+        // native typed value (DateTime, decimal, …) plus a format string — Excel renders those
+        // using the user's locale when opening the file. For text cells we format with the
+        // supplied culture so strings mirror the exported CSV.
+        switch (value)
+        {
+            case DateTime dt:
+                cell.Value = dt;
+                cell.Style.DateFormat.Format = format ?? DefaultDateFormat(culture);
+                break;
+            case DateTimeOffset dto:
+                cell.Value = dto.DateTime;
+                cell.Style.DateFormat.Format = format ?? DefaultDateFormat(culture);
+                break;
+            case DateOnly dOnly:
+                cell.Value = dOnly.ToDateTime(TimeOnly.MinValue);
+                cell.Style.DateFormat.Format = format ?? DefaultDateOnlyFormat(culture);
+                break;
+            case bool b:
+                cell.Value = b;
+                break;
+            case decimal dec:
+                cell.Value = dec;
+                if (format is not null) cell.Style.NumberFormat.Format = format;
+                break;
+            case double d:
+                cell.Value = d;
+                if (format is not null) cell.Style.NumberFormat.Format = format;
+                break;
+            case float f:
+                cell.Value = f;
+                if (format is not null) cell.Style.NumberFormat.Format = format;
+                break;
+            case int or long or short or byte or uint or ulong or ushort or sbyte:
+                cell.Value = Convert.ToDouble(value, CultureInfo.InvariantCulture);
+                if (format is not null) cell.Style.NumberFormat.Format = format;
+                break;
+            default:
+                cell.Value = FormatValue(value, format, culture);
+                break;
+        }
+    }
+
+    private static string DefaultDateFormat(CultureInfo culture)
+    {
+        // Normalise .NET date format patterns (uppercase M for month) to the Excel variant
+        // (lowercase m for month) — Excel treats lowercase m as minutes inside a time context
+        // but as months outside it, which matches what .NET produces.
+        var shortDate = culture.DateTimeFormat.ShortDatePattern;
+        var shortTime = culture.DateTimeFormat.ShortTimePattern;
+        return ConvertToExcelPattern(shortDate) + " " + shortTime.Replace("tt", "AM/PM");
+    }
+
+    private static string DefaultDateOnlyFormat(CultureInfo culture)
+        => ConvertToExcelPattern(culture.DateTimeFormat.ShortDatePattern);
+
+    private static string ConvertToExcelPattern(string netPattern)
+        => netPattern.Replace("MMMM", "mmmm").Replace("MMM", "mmm").Replace("MM", "mm").Replace("M", "m");
+
+    // ------------------------------------------------------------------ PDF
+
+    public byte[] ToPdf<TItem>(
+        IEnumerable<TItem> items,
+        IEnumerable<DataGridExportColumn<TItem>> columns,
+        string title,
+        CultureInfo culture)
+    {
+        if (OperatingSystem.IsBrowser())
+        {
+            throw new PlatformNotSupportedException(
+                "QuestPDF-backed PDF export requires a server-side runtime — browser-wasm is not supported. " +
+                "Use ToCsv / ToExcel on WASM, or perform PDF generation in a Blazor Server / API host.");
+        }
+        EnsureQuestPdfLicense();
+        var cols = columns.ToList();
+        var data = items.ToList();
+        var timestamp = DateTime.Now.ToString("g", culture);
+
+        var document = Document.Create(container =>
+        {
+            container.Page(page =>
+            {
+                page.Size(PageSizes.A4);
+                page.Margin(28);
+                page.DefaultTextStyle(x => x.FontSize(9).FontColor(Colors.Grey.Darken4));
+
+                page.Header().Column(col =>
+                {
+                    col.Item().Text(title).FontSize(16).SemiBold();
+                    col.Item().Text(timestamp).FontSize(9).FontColor(Colors.Grey.Medium);
+                });
+
+                page.Content().PaddingVertical(10).Table(table =>
+                {
+                    table.ColumnsDefinition(cd =>
+                    {
+                        foreach (var _ in cols) cd.RelativeColumn();
+                    });
+
+                    // Header row
+                    table.Header(header =>
+                    {
+                        foreach (var col in cols)
+                        {
+                            header.Cell().Background(Colors.Grey.Lighten3).Padding(5).Text(col.Header).SemiBold();
+                        }
+                    });
+
+                    // Data rows
+                    foreach (var item in data)
+                    {
+                        foreach (var col in cols)
+                        {
+                            var text = FormatValue(col.Accessor(item), col.Format, culture);
+                            table.Cell().BorderBottom(0.5f).BorderColor(Colors.Grey.Lighten2).Padding(5).Text(text);
+                        }
+                    }
+                });
+
+                page.Footer().AlignRight().Text(x =>
+                {
+                    x.Span("Page ").FontSize(8).FontColor(Colors.Grey.Medium);
+                    x.CurrentPageNumber().FontSize(8).FontColor(Colors.Grey.Medium);
+                    x.Span(" / ").FontSize(8).FontColor(Colors.Grey.Medium);
+                    x.TotalPages().FontSize(8).FontColor(Colors.Grey.Medium);
+                });
+            });
+        });
+
+        return document.GeneratePdf();
+    }
+
+    // ---------------------------------------------------------- Formatting
+
+    private static string FormatValue(object? raw, string? format, CultureInfo culture)
+    {
+        if (raw is null) return string.Empty;
+        if (!string.IsNullOrEmpty(format) && raw is IFormattable f)
+            return f.ToString(format, culture);
+        if (raw is IFormattable plainFormattable)
+            return plainFormattable.ToString(null, culture);
+        return raw.ToString() ?? string.Empty;
+    }
+}

--- a/src/Lumeo.DataGrid.Export/Lumeo.DataGrid.Export.csproj
+++ b/src/Lumeo.DataGrid.Export/Lumeo.DataGrid.Export.csproj
@@ -1,25 +1,25 @@
-<Project Sdk="Microsoft.NET.Sdk.Razor">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <SupportedPlatform>browser</SupportedPlatform>
-    <!-- RootNamespace must be "Lumeo" (matching @namespace in .razor files), NOT "Lumeo.DataGrid"
-         (which would be the SDK default derived from the project name). If RootNamespace
-         differs from the @namespace directive, the Razor SDK source generator generates
-         duplicate type definitions causing CS0101. -->
     <RootNamespace>Lumeo</RootNamespace>
+    <!-- CA2255: a module initializer is exactly the right tool here — this assembly
+         self-registers its export backend with the core registry the moment it loads
+         (eagerly or via lazy loading), with no app-side wiring required. -->
+    <NoWarn>$(NoWarn);CA2255</NoWarn>
     <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
     <CompilerGeneratedFilesOutputPath>$(BaseIntermediateOutputPath)GeneratedFiles</CompilerGeneratedFilesOutputPath>
 
     <!-- NuGet Package Metadata -->
-    <PackageId>Lumeo.DataGrid</PackageId>
+    <PackageId>Lumeo.DataGrid.Export</PackageId>
     <!-- Version is inherited from /Directory.Build.props (lockstep with all Lumeo packages) -->
-    <Title>Lumeo.DataGrid</Title>
+    <Title>Lumeo.DataGrid.Export</Title>
     <Authors>nativ.sh</Authors>
-    <Description>DataGrid package for Lumeo — install alongside Lumeo. Provides enterprise DataGrid with Excel/PDF/CSV export, DataTable, and Filter components.</Description>
-    <PackageTags>blazor;components;ui;datagrid;datatable;filter;lumeo</PackageTags>
+    <Description>Excel (ClosedXML) and PDF (QuestPDF) export backend for Lumeo.DataGrid. Ships transitively with Lumeo.DataGrid and can be lazy-loaded on demand in Blazor WebAssembly so its dependencies stay out of the initial download.</Description>
+    <PackageTags>blazor;datagrid;export;excel;pdf;closedxml;questpdf;lumeo</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageProjectUrl>https://github.com/Brain2k-0005/Lumeo</PackageProjectUrl>
@@ -36,18 +36,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Blazicons.Lucide" Version="2.1.3" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="10.0.6" />
+    <PackageReference Include="ClosedXML" Version="0.104.2" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
+    <PackageReference Include="QuestPDF" Version="2024.12.3" />
   </ItemGroup>
 
   <ItemGroup>
-    <!-- Reference core for shared types: ComponentInteropService, theme primitives, etc. -->
+    <!-- Core supplies IDataGridExportBackend, IDataGridExportService, DataGridExportColumn. -->
     <ProjectReference Include="..\Lumeo\Lumeo.csproj" />
-    <!-- Excel/PDF export backend (ClosedXML + QuestPDF). Ships transitively so consumers
-         get export out of the box; its assemblies can be lazy-loaded on WASM (see the
-         Lumeo.DataGrid.Export README) so the ~1.6 MB of deps stay out of the initial load. -->
-    <ProjectReference Include="..\Lumeo.DataGrid.Export\Lumeo.DataGrid.Export.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Lumeo.DataGrid.Export/README.md
+++ b/src/Lumeo.DataGrid.Export/README.md
@@ -1,0 +1,43 @@
+# Lumeo.DataGrid.Export
+
+Excel (ClosedXML) and PDF (QuestPDF) export backend for
+[`Lumeo.DataGrid`](https://www.nuget.org/packages/Lumeo.DataGrid).
+
+You normally don't reference this package directly — it ships transitively with
+`Lumeo.DataGrid`. It exists as a separate assembly so its ~1.6 MB of dependencies
+can be **lazy-loaded on demand** in Blazor WebAssembly, keeping them out of the
+initial download.
+
+## Lazy loading (optional, WebAssembly)
+
+Mark the export assemblies as lazy in your WASM app's `.csproj`:
+
+```xml
+<ItemGroup>
+  <BlazorWebAssemblyLazyLoad Include="Lumeo.DataGrid.Export.dll" />
+  <BlazorWebAssemblyLazyLoad Include="ClosedXML.dll" />
+  <BlazorWebAssemblyLazyLoad Include="ClosedXML.Parser.dll" />
+  <BlazorWebAssemblyLazyLoad Include="DocumentFormat.OpenXml.dll" />
+  <BlazorWebAssemblyLazyLoad Include="DocumentFormat.OpenXml.Framework.dll" />
+  <BlazorWebAssemblyLazyLoad Include="ExcelNumberFormat.dll" />
+  <BlazorWebAssemblyLazyLoad Include="RBush.dll" />
+  <BlazorWebAssemblyLazyLoad Include="SixLabors.Fonts.dll" />
+  <BlazorWebAssemblyLazyLoad Include="System.IO.Packaging.dll" />
+  <BlazorWebAssemblyLazyLoad Include="QuestPDF.dll" />
+</ItemGroup>
+```
+
+Then wire the loader hook in `Program.cs`:
+
+```csharp
+using Lumeo.Services;
+using Microsoft.AspNetCore.Components.WebAssembly.Services;
+
+var host = builder.Build();
+var lazy = host.Services.GetRequiredService<LazyAssemblyLoader>();
+DataGridExportLoader.LoadAssembliesAsync = names => lazy.LoadAssembliesAsync(names);
+await host.RunAsync();
+```
+
+The DataGrid loads the required assemblies the first time a user exports. Without
+this setup everything still works — the assemblies just load eagerly at startup.

--- a/src/Lumeo.DataGrid/UI/DataGrid/DataGrid.razor
+++ b/src/Lumeo.DataGrid/UI/DataGrid/DataGrid.razor
@@ -2731,6 +2731,7 @@
                     }
                 case "excel":
                     {
+                        await EnsureExportAssembliesAsync(ExcelExportAssemblies);
                         var bytes = Export.ToExcel(items, exportColumns, sheetName: "Data", culture: culture);
                         await Export.DownloadAsync(bytes, "export.xlsx",
                             "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
@@ -2740,6 +2741,7 @@
                     {
                         // QuestPDF isn't supported on browser-wasm — ToPdf throws PlatformNotSupportedException
                         // on that runtime. Consumers should restrict ExportFormats to exclude Pdf on WASM.
+                        await EnsureExportAssembliesAsync(PdfExportAssemblies);
                         var bytes = Export.ToPdf(items, exportColumns, title: FullscreenTitle ?? "Export", culture: culture);
                         await Export.DownloadAsync(bytes, "export.pdf", "application/pdf");
                         break;
@@ -2757,6 +2759,27 @@
             await OnError.InvokeAsync(ex);
         }
     }
+
+    // Excel needs ClosedXML + its transitive closure; PDF needs QuestPDF. These ship in the
+    // Lumeo.DataGrid.Export assembly and can be lazy-loaded on WASM. When the host wires
+    // DataGridExportLoader (see the Lumeo.DataGrid.Export README) we fetch them on first export;
+    // otherwise this is a no-op because the assemblies are already loaded eagerly.
+    private static readonly string[] ExcelExportAssemblies =
+    {
+        "Lumeo.DataGrid.Export.dll", "ClosedXML.dll", "ClosedXML.Parser.dll",
+        "DocumentFormat.OpenXml.dll", "DocumentFormat.OpenXml.Framework.dll",
+        "ExcelNumberFormat.dll", "RBush.dll", "SixLabors.Fonts.dll", "System.IO.Packaging.dll",
+    };
+
+    private static readonly string[] PdfExportAssemblies =
+    {
+        "Lumeo.DataGrid.Export.dll", "QuestPDF.dll",
+    };
+
+    private static Task EnsureExportAssembliesAsync(IReadOnlyList<string> assemblies)
+        => Lumeo.Services.DataGridExportLoader.LoadAssembliesAsync is { } load
+            ? load(assemblies)
+            : Task.CompletedTask;
 
     // --- Layout Persistence ---
 

--- a/src/Lumeo/Lumeo.csproj
+++ b/src/Lumeo/Lumeo.csproj
@@ -83,12 +83,13 @@
 
   <ItemGroup>
     <PackageReference Include="Blazicons.Lucide" Version="2.1.3" />
-    <PackageReference Include="ClosedXML" Version="0.104.2" />
     <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="10.0.6" />
     <!-- Source Link: embeds GitHub URLs in the PDB so debuggers can step into Lumeo source. -->
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
     <PackageReference Include="QRCoder" Version="1.8.0" />
-    <PackageReference Include="QuestPDF" Version="2024.12.3" />
+    <!-- ClosedXML (Excel) + QuestPDF (PDF) moved to the lazy-loaded Lumeo.DataGrid.Export
+         assembly so their ~1.6 MB of dependencies stay out of the core's eager first load.
+         The IDataGridExportService facade delegates Excel/PDF to that backend on demand. -->
   </ItemGroup>
 
   <!-- [LumeoForm] Roslyn source generator — builds a RenderFragment per annotated POCO. -->

--- a/src/Lumeo/Services/DataGridExportBackend.cs
+++ b/src/Lumeo/Services/DataGridExportBackend.cs
@@ -1,0 +1,79 @@
+using System.Globalization;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+
+namespace Lumeo.Services;
+
+/// <summary>
+/// Heavy export backend (Excel via ClosedXML, PDF via QuestPDF). Implemented in the
+/// separate <c>Lumeo.DataGrid.Export</c> assembly so the ~1.6 MB of ClosedXML/QuestPDF
+/// dependencies stay out of the core's eager load and can be lazy-loaded on demand.
+/// </summary>
+public interface IDataGridExportBackend
+{
+    byte[] ToExcel<TItem>(
+        IEnumerable<TItem> items,
+        IEnumerable<DataGridExportColumn<TItem>> columns,
+        string sheetName,
+        CultureInfo culture);
+
+    byte[] ToPdf<TItem>(
+        IEnumerable<TItem> items,
+        IEnumerable<DataGridExportColumn<TItem>> columns,
+        string title,
+        CultureInfo culture);
+}
+
+/// <summary>
+/// Registry that bridges the core <see cref="IDataGridExportService"/> facade to the
+/// lazy-loaded <see cref="IDataGridExportBackend"/> implementation. The
+/// <c>Lumeo.DataGrid.Export</c> assembly registers itself via a module initializer.
+/// </summary>
+public static class DataGridExportBackend
+{
+    private const string ExportAssemblyName = "Lumeo.DataGrid.Export";
+    private static IDataGridExportBackend? _instance;
+
+    /// <summary>Called by the export assembly's module initializer when it loads.</summary>
+    public static void Register(IDataGridExportBackend backend) => _instance = backend;
+
+    internal static IDataGridExportBackend Resolve()
+    {
+        if (_instance is not null) return _instance;
+
+        // In eager scenarios (server, tests, consumers without lazy loading) the export
+        // assembly is referenced but its module initializer hasn't run yet because no type
+        // from it has been touched. Force-load it and run its module constructor. On WASM
+        // with lazy loading the DataGrid pre-loads it via DataGridExportLoader first, so by
+        // the time we get here the assembly is already in the ALC.
+        try
+        {
+            var asm = Assembly.Load(ExportAssemblyName);
+            RuntimeHelpers.RunModuleConstructor(asm.ManifestModule.ModuleHandle);
+        }
+        catch (Exception ex)
+        {
+            throw new InvalidOperationException(
+                $"Excel/PDF export requires the '{ExportAssemblyName}' assembly, which ships " +
+                "transitively with the Lumeo.DataGrid package. On Blazor WebAssembly with lazy " +
+                "loading enabled, the assembly must be loaded before exporting — wire " +
+                $"{nameof(DataGridExportLoader)}.{nameof(DataGridExportLoader.LoadAssembliesAsync)} " +
+                "in your app startup.", ex);
+        }
+
+        return _instance ?? throw new InvalidOperationException(
+            $"'{ExportAssemblyName}' loaded but did not register an export backend.");
+    }
+}
+
+/// <summary>
+/// Optional hook for Blazor WebAssembly apps that lazy-load the export assemblies. Set this
+/// in <c>Program.cs</c> using the framework's <c>LazyAssemblyLoader</c>; the DataGrid calls
+/// it before an Excel/PDF export so the heavy assemblies are fetched on demand instead of at
+/// first paint. When unset (server, or WASM without lazy loading) export still works because
+/// the assemblies are loaded eagerly.
+/// </summary>
+public static class DataGridExportLoader
+{
+    public static Func<IReadOnlyList<string>, Task>? LoadAssembliesAsync { get; set; }
+}

--- a/src/Lumeo/Services/DataGridExportService.cs
+++ b/src/Lumeo/Services/DataGridExportService.cs
@@ -1,44 +1,22 @@
 using System.Globalization;
 using System.Text;
-using ClosedXML.Excel;
-using QuestPDF.Fluent;
-using QuestPDF.Helpers;
-using QuestPDF.Infrastructure;
 
 namespace Lumeo.Services;
 
 /// <summary>
 /// Default <see cref="IDataGridExportService"/> implementation. Registered by <c>AddLumeo()</c>
-/// as a scoped service.
+/// as a scoped service. CSV and the download trigger are dependency-free and live here; Excel
+/// (ClosedXML) and PDF (QuestPDF) are delegated to the <see cref="IDataGridExportBackend"/> in
+/// the separate <c>Lumeo.DataGrid.Export</c> assembly so their ~1.6 MB of dependencies stay out
+/// of the core's eager load and can be lazy-loaded on demand.
 /// </summary>
 public sealed class DataGridExportService : IDataGridExportService
 {
     private readonly IComponentInteropService _interop;
 
-    // QuestPDF requires a license to be set exactly once per process. We pick Community here
-    // which is free for individuals and companies below the revenue threshold defined at
-    // https://www.questpdf.com/license — commercial users should replace this with their own
-    // paid license before shipping, e.g. `QuestPDF.Settings.License = LicenseType.Professional;`
-    // in their app's startup. We guard with a flag so changing this on the consumer side wins.
-    private static readonly object _licenseLock = new();
-    private static bool _licenseInitialized;
-
     public DataGridExportService(IComponentInteropService interop)
     {
         _interop = interop;
-        // QuestPDF license init is deferred to ToPdf() — touching QuestPDF.Settings
-        // at construction triggers a native-library probe that throws on browser-wasm.
-    }
-
-    private static void EnsureQuestPdfLicense()
-    {
-        if (_licenseInitialized) return;
-        lock (_licenseLock)
-        {
-            if (_licenseInitialized) return;
-            QuestPDF.Settings.License = LicenseType.Community;
-            _licenseInitialized = true;
-        }
     }
 
     // ------------------------------------------------------------------ CSV
@@ -88,191 +66,25 @@ public sealed class DataGridExportService : IDataGridExportService
         return "\"" + value.Replace("\"", "\"\"") + "\"";
     }
 
-    // ---------------------------------------------------------------- Excel
+    // ---------------------------------------------------------- Excel / PDF
 
     public byte[] ToExcel<TItem>(
         IEnumerable<TItem> items,
         IEnumerable<DataGridExportColumn<TItem>> columns,
         string sheetName = "Sheet1",
         CultureInfo? culture = null)
-    {
-        var effectiveCulture = culture ?? CultureInfo.CurrentCulture;
-        var cols = columns.ToList();
-
-        using var workbook = new XLWorkbook();
-        var sheet = workbook.Worksheets.Add(string.IsNullOrWhiteSpace(sheetName) ? "Sheet1" : sheetName);
-
-        // Header row: bold, muted background.
-        for (var c = 0; c < cols.Count; c++)
-        {
-            var cell = sheet.Cell(1, c + 1);
-            cell.Value = cols[c].Header;
-            cell.Style.Font.Bold = true;
-            cell.Style.Fill.BackgroundColor = XLColor.FromHtml("#E5E7EB");
-            cell.Style.Alignment.Horizontal = XLAlignmentHorizontalValues.Left;
-        }
-
-        // Data rows.
-        var row = 2;
-        foreach (var item in items)
-        {
-            for (var c = 0; c < cols.Count; c++)
-            {
-                var cell = sheet.Cell(row, c + 1);
-                var raw = cols[c].Accessor(item);
-                SetExcelCellValue(cell, raw, cols[c].Format, effectiveCulture);
-            }
-            row++;
-        }
-
-        sheet.Columns().AdjustToContents();
-        sheet.SheetView.FreezeRows(1);
-
-        using var ms = new MemoryStream();
-        workbook.SaveAs(ms);
-        return ms.ToArray();
-    }
-
-    private static void SetExcelCellValue(IXLCell cell, object? value, string? format, CultureInfo culture)
-    {
-        if (value is null)
-        {
-            cell.Value = string.Empty;
-            return;
-        }
-
-        // ClosedXML picks up the workbook/host locale for date and number formats. We pass the
-        // native typed value (DateTime, decimal, …) plus a format string — Excel renders those
-        // using the user's locale when opening the file. For text cells we format with the
-        // supplied culture so strings mirror the exported CSV.
-        switch (value)
-        {
-            case DateTime dt:
-                cell.Value = dt;
-                cell.Style.DateFormat.Format = format ?? DefaultDateFormat(culture);
-                break;
-            case DateTimeOffset dto:
-                cell.Value = dto.DateTime;
-                cell.Style.DateFormat.Format = format ?? DefaultDateFormat(culture);
-                break;
-            case DateOnly dOnly:
-                cell.Value = dOnly.ToDateTime(TimeOnly.MinValue);
-                cell.Style.DateFormat.Format = format ?? DefaultDateOnlyFormat(culture);
-                break;
-            case bool b:
-                cell.Value = b;
-                break;
-            case decimal dec:
-                cell.Value = dec;
-                if (format is not null) cell.Style.NumberFormat.Format = format;
-                break;
-            case double d:
-                cell.Value = d;
-                if (format is not null) cell.Style.NumberFormat.Format = format;
-                break;
-            case float f:
-                cell.Value = f;
-                if (format is not null) cell.Style.NumberFormat.Format = format;
-                break;
-            case int or long or short or byte or uint or ulong or ushort or sbyte:
-                cell.Value = Convert.ToDouble(value, CultureInfo.InvariantCulture);
-                if (format is not null) cell.Style.NumberFormat.Format = format;
-                break;
-            default:
-                cell.Value = FormatValue(value, format, culture);
-                break;
-        }
-    }
-
-    private static string DefaultDateFormat(CultureInfo culture)
-    {
-        // Normalise .NET date format patterns (uppercase M for month) to the Excel variant
-        // (lowercase m for month) — Excel treats lowercase m as minutes inside a time context
-        // but as months outside it, which matches what .NET produces.
-        var shortDate = culture.DateTimeFormat.ShortDatePattern;
-        var shortTime = culture.DateTimeFormat.ShortTimePattern;
-        return ConvertToExcelPattern(shortDate) + " " + shortTime.Replace("tt", "AM/PM");
-    }
-
-    private static string DefaultDateOnlyFormat(CultureInfo culture)
-        => ConvertToExcelPattern(culture.DateTimeFormat.ShortDatePattern);
-
-    private static string ConvertToExcelPattern(string netPattern)
-        => netPattern.Replace("MMMM", "mmmm").Replace("MMM", "mmm").Replace("MM", "mm").Replace("M", "m");
-
-    // ------------------------------------------------------------------ PDF
+        => DataGridExportBackend.Resolve().ToExcel(
+            items, columns,
+            string.IsNullOrWhiteSpace(sheetName) ? "Sheet1" : sheetName,
+            culture ?? CultureInfo.CurrentCulture);
 
     public byte[] ToPdf<TItem>(
         IEnumerable<TItem> items,
         IEnumerable<DataGridExportColumn<TItem>> columns,
         string title = "Export",
         CultureInfo? culture = null)
-    {
-        if (OperatingSystem.IsBrowser())
-        {
-            throw new PlatformNotSupportedException(
-                "QuestPDF-backed PDF export requires a server-side runtime — browser-wasm is not supported. " +
-                "Use ToCsv / ToExcel on WASM, or perform PDF generation in a Blazor Server / API host.");
-        }
-        EnsureQuestPdfLicense();
-        var effectiveCulture = culture ?? CultureInfo.CurrentCulture;
-        var cols = columns.ToList();
-        var data = items.ToList();
-        var timestamp = DateTime.Now.ToString("g", effectiveCulture);
-
-        var document = Document.Create(container =>
-        {
-            container.Page(page =>
-            {
-                page.Size(PageSizes.A4);
-                page.Margin(28);
-                page.DefaultTextStyle(x => x.FontSize(9).FontColor(Colors.Grey.Darken4));
-
-                page.Header().Column(col =>
-                {
-                    col.Item().Text(title).FontSize(16).SemiBold();
-                    col.Item().Text(timestamp).FontSize(9).FontColor(Colors.Grey.Medium);
-                });
-
-                page.Content().PaddingVertical(10).Table(table =>
-                {
-                    table.ColumnsDefinition(cd =>
-                    {
-                        foreach (var _ in cols) cd.RelativeColumn();
-                    });
-
-                    // Header row
-                    table.Header(header =>
-                    {
-                        foreach (var col in cols)
-                        {
-                            header.Cell().Background(Colors.Grey.Lighten3).Padding(5).Text(col.Header).SemiBold();
-                        }
-                    });
-
-                    // Data rows
-                    foreach (var item in data)
-                    {
-                        foreach (var col in cols)
-                        {
-                            var text = FormatValue(col.Accessor(item), col.Format, effectiveCulture);
-                            table.Cell().BorderBottom(0.5f).BorderColor(Colors.Grey.Lighten2).Padding(5).Text(text);
-                        }
-                    }
-                });
-
-                page.Footer().AlignRight().Text(x =>
-                {
-                    x.Span("Page ").FontSize(8).FontColor(Colors.Grey.Medium);
-                    x.CurrentPageNumber().FontSize(8).FontColor(Colors.Grey.Medium);
-                    x.Span(" / ").FontSize(8).FontColor(Colors.Grey.Medium);
-                    x.TotalPages().FontSize(8).FontColor(Colors.Grey.Medium);
-                });
-            });
-        });
-
-        return document.GeneratePdf();
-    }
+        => DataGridExportBackend.Resolve().ToPdf(
+            items, columns, title, culture ?? CultureInfo.CurrentCulture);
 
     // ------------------------------------------------------------- Download
 


### PR DESCRIPTION
## Summary

Moves the heavy DataGrid export dependencies (ClosedXML for Excel, QuestPDF for PDF) out of the core/eager bundle into a **new `Lumeo.DataGrid.Export` assembly** that can be lazy-loaded on demand. End users notice nothing — `AddLumeo()` and `IDataGridExportService` are unchanged, CSV/JSON export and Excel/PDF all still work out of the box.

**Measured first-visit win (docs WASM publish, brotli):** eager payload **6.71 MB → 5.06 MB = −1.65 MB (~25%)**. All 10 export-related assemblies (ClosedXML + its 7 transitive deps, QuestPDF) move from eager to lazy.

### How it works
- **Core (`Lumeo`)** keeps `IDataGridExportService` + `DataGridExportColumn<T>`. CSV and the download trigger stay here (dependency-free); `ToExcel`/`ToPdf` delegate to an `IDataGridExportBackend` resolved from the export assembly. ClosedXML + QuestPDF package refs removed from core.
- **New `Lumeo.DataGrid.Export`** holds the ClosedXML/QuestPDF implementation and self-registers via a `[ModuleInitializer]` the moment it loads (eagerly or lazily).
- **Bridge** (`DataGridExportBackend.Resolve()`): in eager scenarios (server, tests, default consumers) it force-loads the assembly via `Assembly.Load` + `RunModuleConstructor`, so nothing changes for them. On WASM with lazy loading, the DataGrid pre-loads the assemblies first.
- **DataGrid** lazy-loads only what each format needs: Excel pulls the ClosedXML closure; PDF pulls QuestPDF. Since QuestPDF throws on `browser-wasm` (guard runs before any QuestPDF type is touched), an Excel-only WASM user never downloads it.
- **Opt-in lazy wiring** lives in the app layer via `DataGridExportLoader.LoadAssembliesAsync` (set in the docs `Program.cs` using `LazyAssemblyLoader`) + `BlazorWebAssemblyLazyLoad` entries — the library stays platform-agnostic (no WebAssembly dependency). Consumers who don't configure lazy loading get the previous eager behavior unchanged.

### Notes
- `Directory.Build.props` bumped to **3.7.0** (real library change). Per repo Rule #2, the tag + GitHub release / NuGet publish await owner confirmation.
- `Lumeo.DataGrid` now has a transitive NuGet dependency on `Lumeo.DataGrid.Export` (added to the publish workflow: restore/build/pack).

## Test plan
- [x] `dotnet build src/Lumeo.DataGrid` (Release, `-warnaserror`) — succeeds
- [x] `DataGridExportServiceTests` — 8/8 pass (CSV + Excel via the new lazy bridge, eager path)
- [x] Docs WASM publish: all 10 export assemblies confirmed in the lazy set; eager first-load −1.65 MB
- [ ] Manual browser check of on-click lazy load (LazyAssemblyLoader path) — not run, no browser in this environment

---
_Generated by [Claude Code](https://claude.ai/code/session_01LJmBFYeCdQj2G2epoZaRzQ)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Excel export functionality with formatted cells and styling for DataGrid.
  * Added PDF export functionality with tables and page footers for DataGrid.
  * Introduced optional lazy-loading support for export libraries in Blazor WebAssembly applications to reduce initial bundle size.

* **Chores**
  * Released version 3.7.0.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Brain2k-0005/Lumeo/pull/124?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->