### PR TITLE
fix(datagrid): bundle Lumeo.DataGrid.Export.dll into Lumeo.DataGrid.nupkg (no extra NuGet)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -49,7 +49,6 @@ jobs:
           dotnet restore src/Lumeo.Charts/Lumeo.Charts.csproj
           dotnet restore src/Lumeo.CodeEditor/Lumeo.CodeEditor.csproj
           dotnet restore src/Lumeo.DataGrid/Lumeo.DataGrid.csproj
-          dotnet restore src/Lumeo.DataGrid.Export/Lumeo.DataGrid.Export.csproj
           dotnet restore src/Lumeo.Editor/Lumeo.Editor.csproj
           dotnet restore src/Lumeo.FileViewer/Lumeo.FileViewer.csproj
           dotnet restore src/Lumeo.Scheduler/Lumeo.Scheduler.csproj
@@ -66,7 +65,6 @@ jobs:
           dotnet build src/Lumeo.Charts/Lumeo.Charts.csproj -c Release --no-restore -warnaserror
           dotnet build src/Lumeo.CodeEditor/Lumeo.CodeEditor.csproj -c Release --no-restore -warnaserror
           dotnet build src/Lumeo.DataGrid/Lumeo.DataGrid.csproj -c Release --no-restore -warnaserror
-          dotnet build src/Lumeo.DataGrid.Export/Lumeo.DataGrid.Export.csproj -c Release --no-restore -warnaserror
           dotnet build src/Lumeo.Editor/Lumeo.Editor.csproj -c Release --no-restore -warnaserror
           dotnet build src/Lumeo.FileViewer/Lumeo.FileViewer.csproj -c Release --no-restore -warnaserror
           dotnet build src/Lumeo.Scheduler/Lumeo.Scheduler.csproj -c Release --no-restore -warnaserror
@@ -88,7 +86,6 @@ jobs:
           dotnet pack src/Lumeo.Charts/Lumeo.Charts.csproj -c Release --no-build -o ./nupkg /p:Version=${{ steps.ver.outputs.version }}
           dotnet pack src/Lumeo.CodeEditor/Lumeo.CodeEditor.csproj -c Release --no-build -o ./nupkg /p:Version=${{ steps.ver.outputs.version }}
           dotnet pack src/Lumeo.DataGrid/Lumeo.DataGrid.csproj -c Release --no-build -o ./nupkg /p:Version=${{ steps.ver.outputs.version }}
-          dotnet pack src/Lumeo.DataGrid.Export/Lumeo.DataGrid.Export.csproj -c Release --no-build -o ./nupkg /p:Version=${{ steps.ver.outputs.version }}
           dotnet pack src/Lumeo.Editor/Lumeo.Editor.csproj -c Release --no-build -o ./nupkg /p:Version=${{ steps.ver.outputs.version }}
           dotnet pack src/Lumeo.FileViewer/Lumeo.FileViewer.csproj -c Release --no-build -o ./nupkg /p:Version=${{ steps.ver.outputs.version }}
           dotnet pack src/Lumeo.Scheduler/Lumeo.Scheduler.csproj -c Release --no-build -o ./nupkg /p:Version=${{ steps.ver.outputs.version }}

--- a/docs/Lumeo.Docs/Lumeo.Docs.csproj
+++ b/docs/Lumeo.Docs/Lumeo.Docs.csproj
@@ -48,6 +48,11 @@
     <!-- Satellite packages — needed so docs pages can render Chart, DataGrid, Scheduler, etc. -->
     <ProjectReference Include="..\..\src\Lumeo.Charts\Lumeo.Charts.csproj" />
     <ProjectReference Include="..\..\src\Lumeo.DataGrid\Lumeo.DataGrid.csproj" />
+    <!-- DataGrid's Excel/PDF export backend. DataGrid references it with PrivateAssets="All"
+         (so it bundles into the NuGet package without a phantom dependency), which means the
+         assembly does NOT flow here transitively. Reference it directly so the WASM publish
+         includes Lumeo.DataGrid.Export.dll and can lazy-load it (listed below). -->
+    <ProjectReference Include="..\..\src\Lumeo.DataGrid.Export\Lumeo.DataGrid.Export.csproj" />
     <ProjectReference Include="..\..\src\Lumeo.Editor\Lumeo.Editor.csproj" />
     <ProjectReference Include="..\..\src\Lumeo.FileViewer\Lumeo.FileViewer.csproj" />
     <ProjectReference Include="..\..\src\Lumeo.Scheduler\Lumeo.Scheduler.csproj" />

--- a/src/Lumeo.DataGrid.Export/Lumeo.DataGrid.Export.csproj
+++ b/src/Lumeo.DataGrid.Export/Lumeo.DataGrid.Export.csproj
@@ -10,34 +10,17 @@
          self-registers its export backend with the core registry the moment it loads
          (eagerly or via lazy loading), with no app-side wiring required. -->
     <NoWarn>$(NoWarn);CA2255</NoWarn>
-    <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
-    <CompilerGeneratedFilesOutputPath>$(BaseIntermediateOutputPath)GeneratedFiles</CompilerGeneratedFilesOutputPath>
 
-    <!-- NuGet Package Metadata -->
-    <PackageId>Lumeo.DataGrid.Export</PackageId>
-    <!-- Version is inherited from /Directory.Build.props (lockstep with all Lumeo packages) -->
-    <Title>Lumeo.DataGrid.Export</Title>
-    <Authors>nativ.sh</Authors>
-    <Description>Excel (ClosedXML) and PDF (QuestPDF) export backend for Lumeo.DataGrid. Ships transitively with Lumeo.DataGrid and can be lazy-loaded on demand in Blazor WebAssembly so its dependencies stay out of the initial download.</Description>
-    <PackageTags>blazor;datagrid;export;excel;pdf;closedxml;questpdf;lumeo</PackageTags>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <PackageReadmeFile>README.md</PackageReadmeFile>
-    <PackageProjectUrl>https://github.com/Brain2k-0005/Lumeo</PackageProjectUrl>
-    <RepositoryUrl>https://github.com/Brain2k-0005/Lumeo</RepositoryUrl>
-    <RepositoryType>git</RepositoryType>
-
-    <!-- NuGet health -->
-    <PublishRepositoryUrl>true</PublishRepositoryUrl>
-    <EmbedUntrackedSources>true</EmbedUntrackedSources>
-    <IncludeSymbols>true</IncludeSymbols>
-    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <Deterministic>true</Deterministic>
-    <ContinuousIntegrationBuild Condition="'$(GITHUB_ACTIONS)' == 'true'">true</ContinuousIntegrationBuild>
+    <!-- Internal helper project: NOT a NuGet package. Its compiled DLL is bundled
+         into Lumeo.DataGrid.nupkg (see Lumeo.DataGrid.csproj's BuildOutputInPackage
+         target) so consumers install only Lumeo.DataGrid as before. Splitting the
+         Excel/PDF code into its own DLL is what allows Blazor WebAssembly to lazy-
+         load it on demand — Lumeo.DataGrid.dll itself stays eager. -->
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="ClosedXML" Version="0.104.2" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
     <PackageReference Include="QuestPDF" Version="2024.12.3" />
   </ItemGroup>
 

--- a/src/Lumeo.DataGrid.Export/README.md
+++ b/src/Lumeo.DataGrid.Export/README.md
@@ -1,16 +1,19 @@
 # Lumeo.DataGrid.Export
 
-Excel (ClosedXML) and PDF (QuestPDF) export backend for
-[`Lumeo.DataGrid`](https://www.nuget.org/packages/Lumeo.DataGrid).
+**Internal helper project — not a published NuGet package.**
 
-You normally don't reference this package directly — it ships transitively with
-`Lumeo.DataGrid`. It exists as a separate assembly so its ~1.6 MB of dependencies
-can be **lazy-loaded on demand** in Blazor WebAssembly, keeping them out of the
-initial download.
+The compiled `Lumeo.DataGrid.Export.dll` is bundled into `Lumeo.DataGrid.nupkg`
+(see `Lumeo.DataGrid.csproj` → `BundleExportAssembly` target). Consumers install
+the single `Lumeo.DataGrid` package and receive two DLLs:
 
-## Lazy loading (optional, WebAssembly)
+- `Lumeo.DataGrid.dll` — components, eager.
+- `Lumeo.DataGrid.Export.dll` — Excel (ClosedXML) + PDF (QuestPDF) backend.
+  Lazy-loadable on Blazor WebAssembly so its ~1.6 MB of dependencies stay out
+  of the initial download.
 
-Mark the export assemblies as lazy in your WASM app's `.csproj`:
+## Enabling lazy loading (Blazor WebAssembly, optional)
+
+In your WASM app's `.csproj`:
 
 ```xml
 <ItemGroup>
@@ -27,7 +30,7 @@ Mark the export assemblies as lazy in your WASM app's `.csproj`:
 </ItemGroup>
 ```
 
-Then wire the loader hook in `Program.cs`:
+In `Program.cs`:
 
 ```csharp
 using Lumeo.Services;
@@ -39,5 +42,6 @@ DataGridExportLoader.LoadAssembliesAsync = names => lazy.LoadAssembliesAsync(nam
 await host.RunAsync();
 ```
 
-The DataGrid loads the required assemblies the first time a user exports. Without
-this setup everything still works — the assemblies just load eagerly at startup.
+The DataGrid loads the required assemblies the first time a user exports.
+Without this setup everything still works — the assemblies just load eagerly
+at startup, same behaviour as before.

--- a/src/Lumeo.DataGrid/Lumeo.DataGrid.csproj
+++ b/src/Lumeo.DataGrid/Lumeo.DataGrid.csproj
@@ -59,8 +59,12 @@
     <!-- Reference core for shared types: ComponentInteropService, theme primitives, etc. -->
     <ProjectReference Include="..\Lumeo\Lumeo.csproj" />
     <!-- Internal helper project — its compiled DLL is bundled into this nupkg by the
-         BundleExportAssembly target below. PrivateAssets="All" suppresses any flow of
-         its (non-existent) NuGet identity to consumers. -->
+         BundleExportAssembly target below. PrivateAssets="All" stops NuGet from adding a
+         (non-existent) package dependency on it. NuGet package consumers therefore get
+         Lumeo.DataGrid.Export.dll inside lib/<tfm>/ with no extra dependency to restore.
+         Repo-internal apps that consume DataGrid via ProjectReference (e.g. docs) must
+         reference this project directly so the WASM publish includes the assembly for
+         lazy loading — see docs/Lumeo.Docs/Lumeo.Docs.csproj. -->
     <ProjectReference Include="..\Lumeo.DataGrid.Export\Lumeo.DataGrid.Export.csproj"
                       PrivateAssets="All" />
   </ItemGroup>

--- a/src/Lumeo.DataGrid/Lumeo.DataGrid.csproj
+++ b/src/Lumeo.DataGrid/Lumeo.DataGrid.csproj
@@ -33,22 +33,45 @@
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <Deterministic>true</Deterministic>
     <ContinuousIntegrationBuild Condition="'$(GITHUB_ACTIONS)' == 'true'">true</ContinuousIntegrationBuild>
+
+    <!-- Bundle the internal Lumeo.DataGrid.Export.dll into this nupkg's lib/<tfm>/
+         folder via a custom MSBuild target appended to TargetsForTfmSpecificBuildOutput.
+         Consumers install one NuGet package (Lumeo.DataGrid) and receive two DLLs:
+         Lumeo.DataGrid.dll (eager) + Lumeo.DataGrid.Export.dll (lazy-loadable on WASM,
+         eager elsewhere). The Export project sets IsPackable=false so it never produces
+         its own NuGet package. -->
+    <TargetsForTfmSpecificBuildOutput>$(TargetsForTfmSpecificBuildOutput);BundleExportAssembly</TargetsForTfmSpecificBuildOutput>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Blazicons.Lucide" Version="2.1.3" />
+    <!-- ClosedXML + QuestPDF are runtime dependencies of the bundled Lumeo.DataGrid.Export.dll.
+         Declared here (not just in the Export project) so they appear as NuGet dependencies of
+         Lumeo.DataGrid — that way consumers' apps restore them, and the lazy-loaded Export.dll
+         can resolve its types at runtime. -->
+    <PackageReference Include="ClosedXML" Version="0.104.2" />
     <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="10.0.6" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
+    <PackageReference Include="QuestPDF" Version="2024.12.3" />
   </ItemGroup>
 
   <ItemGroup>
     <!-- Reference core for shared types: ComponentInteropService, theme primitives, etc. -->
     <ProjectReference Include="..\Lumeo\Lumeo.csproj" />
-    <!-- Excel/PDF export backend (ClosedXML + QuestPDF). Ships transitively so consumers
-         get export out of the box; its assemblies can be lazy-loaded on WASM (see the
-         Lumeo.DataGrid.Export README) so the ~1.6 MB of deps stay out of the initial load. -->
-    <ProjectReference Include="..\Lumeo.DataGrid.Export\Lumeo.DataGrid.Export.csproj" />
+    <!-- Internal helper project — its compiled DLL is bundled into this nupkg by the
+         BundleExportAssembly target below. PrivateAssets="All" suppresses any flow of
+         its (non-existent) NuGet identity to consumers. -->
+    <ProjectReference Include="..\Lumeo.DataGrid.Export\Lumeo.DataGrid.Export.csproj"
+                      PrivateAssets="All" />
   </ItemGroup>
+
+  <Target Name="BundleExportAssembly" DependsOnTargets="ResolveProjectReferences">
+    <ItemGroup>
+      <BuildOutputInPackage Include="$(OutputPath)Lumeo.DataGrid.Export.dll" />
+      <BuildOutputInPackage Include="$(OutputPath)Lumeo.DataGrid.Export.pdb"
+                            Condition="Exists('$(OutputPath)Lumeo.DataGrid.Export.pdb')" />
+    </ItemGroup>
+  </Target>
 
   <ItemGroup>
     <InternalsVisibleTo Include="Lumeo.Tests" />

--- a/tests/Lumeo.Tests/Lumeo.Tests.csproj
+++ b/tests/Lumeo.Tests/Lumeo.Tests.csproj
@@ -22,6 +22,10 @@
     <ProjectReference Include="..\..\src\Lumeo\Lumeo.csproj" />
     <ProjectReference Include="..\..\src\Lumeo.Charts\Lumeo.Charts.csproj" />
     <ProjectReference Include="..\..\src\Lumeo.DataGrid\Lumeo.DataGrid.csproj" />
+    <!-- DataGrid references the export backend with PrivateAssets="All" (bundles it into the
+         NuGet package without a phantom dependency), so the assembly does not flow here
+         transitively. Reference it directly so DataGridExportServiceTests can load it. -->
+    <ProjectReference Include="..\..\src\Lumeo.DataGrid.Export\Lumeo.DataGrid.Export.csproj" />
     <ProjectReference Include="..\..\src\Lumeo.Editor\Lumeo.Editor.csproj" />
     <ProjectReference Include="..\..\src\Lumeo.FileViewer\Lumeo.FileViewer.csproj" />
     <ProjectReference Include="..\..\src\Lumeo.Gantt\Lumeo.Gantt.csproj" />


### PR DESCRIPTION
## Summary

Course-correct on #124: keep the assembly split (still needed for Blazor WebAssembly lazy loading) but **don't ship `Lumeo.DataGrid.Export` as a separate NuGet package**. Bundle its DLL directly into `Lumeo.DataGrid.nupkg` so the consumer-facing package surface is unchanged from 3.6.1.

### What changed
- `Lumeo.DataGrid.Export.csproj` → `IsPackable=false`, all NuGet metadata removed. Internal helper project.
- `Lumeo.DataGrid.csproj` gains:
  - `ClosedXML` + `QuestPDF` as `PackageReference` (so the lazy DLL's runtime deps flow to consumers via the `Lumeo.DataGrid` package, like before).
  - A `BundleExportAssembly` target appended to `TargetsForTfmSpecificBuildOutput` that adds `Lumeo.DataGrid.Export.dll` (and `.pdb` if present) into the nupkg's `lib/<tfm>/` folder.
  - `PrivateAssets="All"` on the project reference so nothing leaks.
- `publish.yml` no longer restores / builds / packs `Lumeo.DataGrid.Export` standalone — the parent's build picks it up via `ProjectReference`.

### Verified pack output (`dotnet pack -c Release`)
```
lib/net10.0/Lumeo.DataGrid.dll          (411 KB)
lib/net10.0/Lumeo.DataGrid.Export.dll   ( 14 KB)

dependencies (net10.0):
  Lumeo 3.7.0
  Blazicons.Lucide 2.1.3
  ClosedXML 0.104.2
  Microsoft.AspNetCore.Components.Web 10.0.6
  QuestPDF 2024.12.3
```
No separate `Lumeo.DataGrid.Export.nupkg` is produced.

### Effect on consumers
- **Package list:** identical to 3.6.1 (no `Lumeo.DataGrid.Export` package to install).
- **Behaviour out of the box:** identical — `Lumeo.DataGrid.Export.dll` loads eagerly with `Lumeo.DataGrid.dll`.
- **Opt-in lazy loading (WASM):** unchanged — mark `Lumeo.DataGrid.Export.dll` + the ClosedXML/QuestPDF closure as `BlazorWebAssemblyLazyLoad`, wire `DataGridExportLoader.LoadAssembliesAsync`. Same −1.65 MB brotli first-load saving as measured in #124.

### Versioning
- Version stays at **3.7.0**. The intermediate master commit from #124 had the wrong (separate-package) design but was never tagged or published, so 3.7.0 is still free on NuGet.
- Per repo Rule #2, the tag + GitHub release + NuGet publish step for `v3.7.0` await owner confirmation.

## Test plan
- [x] `dotnet pack src/Lumeo.DataGrid -c Release` → produces `Lumeo.DataGrid.3.7.0.nupkg` containing both DLLs in `lib/net10.0/` and listing `ClosedXML` + `QuestPDF` as direct deps. No `Lumeo.DataGrid.Export.nupkg` is produced.
- [x] Build clean. (SourceLink env errors are local container only — real CI uses the github.com remote.)
- [ ] CI build-and-test + e2e on this PR
- [ ] Manual WASM check of the lazy-load path