### PR TITLE
fix(datagrid): make export-bundling target compatible with no-build pack

### DIFF
--- a/src/Lumeo.DataGrid/Lumeo.DataGrid.csproj
+++ b/src/Lumeo.DataGrid/Lumeo.DataGrid.csproj
@@ -69,7 +69,13 @@
                       PrivateAssets="All" />
   </ItemGroup>
 
-  <Target Name="BundleExportAssembly" DependsOnTargets="ResolveProjectReferences">
+  <!-- Deliberately NO DependsOnTargets="ResolveProjectReferences" here: that resolves
+       project references by building them, which conflicts with a no-build pack
+       (NoBuild=true, as the publish workflow uses) and fails with NETSDK1085. The Export
+       DLL is already in $(OutputPath) from the preceding build step, so reference it by
+       literal path. The target is invoked at pack time via TargetsForTfmSpecificBuildOutput,
+       after build outputs exist. -->
+  <Target Name="BundleExportAssembly">
     <ItemGroup>
       <BuildOutputInPackage Include="$(OutputPath)Lumeo.DataGrid.Export.dll" />
       <BuildOutputInPackage Include="$(OutputPath)Lumeo.DataGrid.Export.pdb"


### PR DESCRIPTION
## Summary

Hotfix for the `v3.7.0` publish failure. The publish workflow's **Pack satellites** step failed with **NETSDK1085** (`The 'NoBuild' property was set to true but the 'Build' target was invoked`) on `Lumeo.DataGrid` and `Lumeo`, so no core/satellite packages were pushed to NuGet.

### Cause
The `BundleExportAssembly` target (which bundles `Lumeo.DataGrid.Export.dll` into `Lumeo.DataGrid.nupkg`) declared `DependsOnTargets="ResolveProjectReferences"`. That target builds project references — incompatible with the workflow's `dotnet pack --no-build` (`NoBuild=true`). It slipped through earlier CI because the build-and-test job packs nothing; only the publish workflow uses `--no-build`.

### Fix
Drop the `DependsOnTargets`. The Export DLL is already in `$(OutputPath)` after the workflow's build step, so the target references it by literal path — no project-reference resolution, no build, no NETSDK1085.

### Verified locally (CI-exact sequence)
```
dotnet build src/Lumeo.DataGrid -c Release
dotnet pack  src/Lumeo.DataGrid -c Release --no-build /p:Version=3.7.0
→ Successfully created Lumeo.DataGrid.3.7.0.nupkg
   lib/net10.0/Lumeo.DataGrid.dll
   lib/net10.0/Lumeo.DataGrid.Export.dll
   deps: Lumeo, Blazicons.Lucide, ClosedXML, Microsoft.AspNetCore.Components.Web, QuestPDF
```

After merge, the `v3.7.0` tag/release will be recreated at the fixed master HEAD to re-trigger publish (nothing reached NuGet yet, so 3.7.0 is still clean).

## Test plan
- [x] Local `build` + `pack --no-build` succeeds, nupkg correct
- [ ] CI build-and-test + e2e
- [ ] Publish workflow green end-to-end