### PR TITLE
docs(3.7.0): document DataGrid export lazy loading

### DIFF
--- a/docs/Lumeo.Docs/Pages/Components/DataGridPage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/DataGridPage.razor
@@ -22,6 +22,11 @@
         </ul>
         If you don't use the PDF export feature, the QuestPDF dependency is still loaded as a transitive package
         but never invoked — only calling <code>ExportPdfAsync</code> triggers the licensing requirement.
+        <br /><br />
+        <strong>Since v3.7.0:</strong> the export backend (ClosedXML + QuestPDF, ~1.65&nbsp;MB brotli)
+        ships as a separate bundled DLL inside <code>Lumeo.DataGrid</code> and can be lazy-loaded on
+        Blazor WebAssembly — keep it out of the first paint and pull it in on the first export click.
+        See the <a href="/docs/services/datagrid-export#lazy-loading" class="font-medium underline-offset-4 hover:underline">lazy-loading setup guide</a>.
     </ChildContent>
 </Alert>
 

--- a/docs/Lumeo.Docs/Pages/Docs/BundleFacts.razor
+++ b/docs/Lumeo.Docs/Pages/Docs/BundleFacts.razor
@@ -265,8 +265,10 @@
                         <Heading Level="3" Class="text-base font-semibold">DataGrid</Heading>
                         <Lumeo.Text Size="xs" Weight="medium" Color="muted" Class="font-mono">Lumeo.DataGrid</Lumeo.Text>
                         <Lumeo.Text Size="sm" Color="muted" Leading="relaxed">
-                            ClosedXML + QuestPDF are pulled in only when the package is referenced.
-                            Full virtualization, group-by, and export — on demand.
+                            Full virtualization, group-by, and export. Since <strong>v3.7.0</strong>
+                            the export backend (ClosedXML + QuestPDF, ~1.65&nbsp;MB brotli) ships in
+                            a separate bundled DLL — opt-in lazy-load on WASM keeps it out of the
+                            first paint. <a href="/docs/services/datagrid-export#lazy-loading" class="text-primary underline-offset-4 hover:underline">Lazy setup →</a>
                         </Lumeo.Text>
                     </Stack>
                 </BlurFade>

--- a/docs/Lumeo.Docs/Pages/Docs/Changelog.razor
+++ b/docs/Lumeo.Docs/Pages/Docs/Changelog.razor
@@ -15,6 +15,40 @@
 
     <Separator Class="my-4" />
 
+    <!-- v3.7.0 -->
+    <Stack Gap="4">
+        <div class="flex items-center gap-3">
+            <Badge>v3.7.0</Badge>
+            <Lumeo.Text Size="sm" Color="muted">May 2026</Lumeo.Text>
+        </div>
+
+        <Lumeo.Text Size="base" Color="muted" Leading="relaxed">
+            Minor: the heavy Excel/PDF export backend (ClosedXML + QuestPDF, ~1.65&nbsp;MB brotli)
+            is now compiled into a separate <code class="rounded bg-muted px-1 text-xs">Lumeo.DataGrid.Export.dll</code>
+            that ships <em>inside</em> the existing <code class="rounded bg-muted px-1 text-xs">Lumeo.DataGrid</code>
+            NuGet package and can be lazy-loaded on Blazor WebAssembly. Same package surface, same
+            public API — opt-in, zero breaking changes.
+        </Lumeo.Text>
+
+        <Stack Gap="3">
+            <Heading Level="3" Size="sm" Class="font-semibold">Added</Heading>
+            <ul class="space-y-1.5 text-sm list-disc list-inside text-muted-foreground">
+                <li><strong>WebAssembly lazy loading for DataGrid export.</strong> New <code class="rounded bg-muted px-1 text-xs">DataGridExportLoader.LoadAssembliesAsync</code> hook in <code class="rounded bg-muted px-1 text-xs">Lumeo.Services</code>. Wire it once in <code class="rounded bg-muted px-1 text-xs">Program.cs</code> with <code class="rounded bg-muted px-1 text-xs">LazyAssemblyLoader</code> and mark the export assemblies <code class="rounded bg-muted px-1 text-xs">BlazorWebAssemblyLazyLoad</code> to defer them until the user actually clicks Export. <a href="/docs/services/datagrid-export#lazy-loading" class="text-primary underline-offset-4 hover:underline">Setup guide</a>.</li>
+                <li><strong>New public type</strong> <code class="rounded bg-muted px-1 text-xs">IDataGridExportBackend</code> (in <code class="rounded bg-muted px-1 text-xs">Lumeo.Services</code>) — implemented by the lazy-loaded assembly; the core <code class="rounded bg-muted px-1 text-xs">IDataGridExportService</code> facade delegates Excel/PDF calls to it.</li>
+            </ul>
+        </Stack>
+
+        <Stack Gap="3">
+            <Heading Level="3" Size="sm" Class="font-semibold">Improved</Heading>
+            <ul class="space-y-1.5 text-sm list-disc list-inside text-muted-foreground">
+                <li><strong>Docs first-load: ~6.71&nbsp;MB → ~5.06&nbsp;MB brotli (−1.65&nbsp;MB / ~25%).</strong> ClosedXML, QuestPDF and their 8 transitive dependencies are now in the lazy bundle. On Excel-only screens QuestPDF is never downloaded; on screens that never export, none of them are.</li>
+                <li><strong>Public API unchanged.</strong> <code class="rounded bg-muted px-1 text-xs">AddLumeo()</code>, <code class="rounded bg-muted px-1 text-xs">IDataGridExportService</code>, <code class="rounded bg-muted px-1 text-xs">ToCsv/ToExcel/ToPdf</code> all behave exactly as in 3.6.1 by default. Server scenarios and consumers who don't opt into lazy loading are bit-identical at runtime.</li>
+            </ul>
+        </Stack>
+    </Stack>
+
+    <Separator Class="my-4" />
+
     <!-- v3.6.0 -->
     <Stack Gap="4">
         <div class="flex items-center gap-3">

--- a/docs/Lumeo.Docs/Pages/Docs/Introduction.razor
+++ b/docs/Lumeo.Docs/Pages/Docs/Introduction.razor
@@ -209,6 +209,15 @@
                     Or reference them directly in your <code class="rounded bg-muted px-1.5 py-0.5 text-xs font-mono text-foreground">.csproj</code>.
                     All packages share one version (lockstep) — always upgrade them together:
                 </Lumeo.Text>
+                <Alert Variant="Alert.AlertVariant.Info">
+                    <Lumeo.Text Size="sm">
+                        <strong>Since v3.7.0:</strong> the DataGrid's Excel/PDF export backend (ClosedXML + QuestPDF,
+                        ~1.65&nbsp;MB brotli) lives in a separate assembly bundled inside <code class="rounded bg-muted px-1 text-xs">Lumeo.DataGrid</code>.
+                        On Blazor WebAssembly you can opt-in to lazy-load it — see the
+                        <a href="/docs/services/datagrid-export#lazy-loading" class="text-primary underline-offset-4 hover:underline">setup guide</a>.
+                        No extra package, same install command.
+                    </Lumeo.Text>
+                </Alert>
                 <div class="rounded-lg overflow-hidden ring-1 ring-border/40" style="background-color: #0a0a0a;">
                     <div class="flex items-center justify-between px-3 py-2 border-b" style="border-color: rgba(255,255,255,0.08);">
                         <div class="flex items-center gap-1.5">

--- a/docs/Lumeo.Docs/Pages/Docs/Services/DataGridExport.razor
+++ b/docs/Lumeo.Docs/Pages/Docs/Services/DataGridExport.razor
@@ -187,6 +187,56 @@ await Export.DownloadAsync(bytes, "orders.xlsx",
                     </table>
                 </Stack>
             </Stack>
+
+            <Stack>
+                <Heading Level="3" Class="mb-3">Lazy loading (Blazor WebAssembly) — since v3.7.0</Heading>
+                <Lumeo.Text Size="base" Color="muted" Leading="relaxed">
+                    The Excel (ClosedXML) and PDF (QuestPDF) backends compile into a separate
+                    <code class="rounded bg-muted px-1.5 py-0.5 text-xs font-mono text-foreground">Lumeo.DataGrid.Export.dll</code>
+                    that ships inside the <code class="rounded bg-muted px-1.5 py-0.5 text-xs font-mono text-foreground">Lumeo.DataGrid</code>
+                    NuGet package. On Blazor WebAssembly you can lazy-load it on demand, keeping
+                    ~1.65&nbsp;MB (brotli) of dependencies out of the initial download. Server
+                    scenarios are unaffected — the backend always loads eagerly there.
+                </Lumeo.Text>
+
+                <Stack Gap="2">
+                    <Heading Level="4" Size="sm" Class="font-semibold">1. Mark the assemblies lazy</Heading>
+                    <Lumeo.Text Size="sm" Color="muted">In your WASM app's <code class="rounded bg-muted px-1.5 py-0.5 text-xs font-mono text-foreground">.csproj</code>:</Lumeo.Text>
+                    <Stack Class="code-block rounded-lg border border-border/40 bg-muted px-4 py-3 font-mono text-xs text-foreground whitespace-pre">&lt;ItemGroup&gt;
+  &lt;BlazorWebAssemblyLazyLoad Include="Lumeo.DataGrid.Export.dll" /&gt;
+  &lt;BlazorWebAssemblyLazyLoad Include="ClosedXML.dll" /&gt;
+  &lt;BlazorWebAssemblyLazyLoad Include="ClosedXML.Parser.dll" /&gt;
+  &lt;BlazorWebAssemblyLazyLoad Include="DocumentFormat.OpenXml.dll" /&gt;
+  &lt;BlazorWebAssemblyLazyLoad Include="DocumentFormat.OpenXml.Framework.dll" /&gt;
+  &lt;BlazorWebAssemblyLazyLoad Include="ExcelNumberFormat.dll" /&gt;
+  &lt;BlazorWebAssemblyLazyLoad Include="RBush.dll" /&gt;
+  &lt;BlazorWebAssemblyLazyLoad Include="SixLabors.Fonts.dll" /&gt;
+  &lt;BlazorWebAssemblyLazyLoad Include="System.IO.Packaging.dll" /&gt;
+  &lt;BlazorWebAssemblyLazyLoad Include="QuestPDF.dll" /&gt;
+&lt;/ItemGroup&gt;</Stack>
+                </Stack>
+
+                <Stack Gap="2">
+                    <Heading Level="4" Size="sm" Class="font-semibold">2. Wire the loader hook</Heading>
+                    <Lumeo.Text Size="sm" Color="muted">In <code class="rounded bg-muted px-1.5 py-0.5 text-xs font-mono text-foreground">Program.cs</code>:</Lumeo.Text>
+                    <Stack Class="code-block rounded-lg border border-border/40 bg-muted px-4 py-3 font-mono text-xs text-foreground whitespace-pre">@@using Lumeo.Services;
+@@using Microsoft.AspNetCore.Components.WebAssembly.Services;
+
+var host = builder.Build();
+var lazy = host.Services.GetRequiredService&lt;LazyAssemblyLoader&gt;();
+DataGridExportLoader.LoadAssembliesAsync = names =&gt; lazy.LoadAssembliesAsync(names);
+await host.RunAsync();</Stack>
+                </Stack>
+
+                <Alert Variant="Alert.AlertVariant.Info">
+                    <Lumeo.Text Size="sm">
+                        DataGrid loads the right assemblies on the first export click — Excel pulls
+                        the ClosedXML closure, PDF pulls QuestPDF. An Excel-only WASM user never
+                        downloads QuestPDF. Without this opt-in nothing breaks: the backend just
+                        loads eagerly at startup like before.
+                    </Lumeo.Text>
+                </Alert>
+            </Stack>
         </Stack>
     </Stack>
 </Stack>

--- a/docs/Lumeo.Docs/Pages/Home.razor
+++ b/docs/Lumeo.Docs/Pages/Home.razor
@@ -20,8 +20,8 @@
                 <Flex Align="center" Gap="3">
                     <Lumeo.Link Href="docs/changelog" Class="no-underline group">
                         <Flex Inline="true" Align="center" Gap="2" Class="rounded-full border border-border/60 bg-background/80 px-3 py-1 text-xs font-medium text-muted-foreground backdrop-blur-sm hover:border-primary/40 hover:text-foreground transition-colors">
-                            <Badge Variant="Badge.BadgeVariant.Default" Class="h-4 px-1.5 text-[10px] leading-none">v3.5</Badge>
-                            <Lumeo.Text As="span" Class="hidden sm:inline">Density scale &middot; Splash Kit &middot; Theme.Customize &middot; OverlayForm</Lumeo.Text>
+                            <Badge Variant="Badge.BadgeVariant.Default" Class="h-4 px-1.5 text-[10px] leading-none">v3.7</Badge>
+                            <Lumeo.Text As="span" Class="hidden sm:inline">DataGrid export lazy-loads &middot; &minus;1.65 MB first paint &middot; same one-package install</Lumeo.Text>
                             <DynamicIcon Name="ArrowRight" Class="h-3 w-3 transition-transform group-hover:translate-x-0.5" />
                         </Flex>
                     </Lumeo.Link>


### PR DESCRIPTION
## Summary

Docs-only PR documenting the 3.7.0 changes. No library code touched; per repo rules **no new tag/release** — Cloudflare Pages picks this up from master.

### Files
- `Pages/Docs/Changelog.razor` — v3.7.0 entry at the top (Added: DataGridExportLoader + IDataGridExportBackend; Improved: -1.65 MB first-load, public API unchanged).
- `Pages/Docs/Services/DataGridExport.razor` — new "Lazy loading (Blazor WebAssembly) — since v3.7.0" section with the BlazorWebAssemblyLazyLoad csproj snippet, the Program.cs DataGridExportLoader wiring, and an explanation that QuestPDF never downloads in Excel-only WASM use.
- `Pages/Docs/Introduction.razor` — info callout under the install step that points to the lazy-load guide and reassures readers it's the same package, no extra install.
- `Pages/Docs/BundleFacts.razor` — DataGrid tile mentions the bundled-but-lazy 1.65 MB export DLL with a link to the setup guide.
- `Pages/Components/DataGridPage.razor` — export alert links to the lazy-load setup guide.
- `Pages/Home.razor` — version pill bumped to v3.7 with the export-lazy / one-package-install headline.

## Test plan
- [x] `dotnet build docs/Lumeo.Docs -c Release` succeeds (0 errors)
- [ ] CI docs check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated DataGrid documentation for v3.7.0, covering the separate export backend assembly (ClosedXML + QuestPDF) now available for lazy-loading in Blazor WebAssembly.
  * Added setup guide for enabling lazy-loading and clarified bundle size improvements.
  * Confirmed no breaking changes and that public API remains unchanged by default.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Brain2k-0005/Lumeo/pull/128?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->