### PR TITLE
fix(datagrid): make lazy export work for direct service calls (3.7.1)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
   <!-- Lockstep version shared by all Lumeo packages.
        Update this single property to version all packages in unison. -->
   <PropertyGroup>
-    <Version>3.7.0</Version>
+    <Version>3.7.1</Version>
   </PropertyGroup>
 
   <!-- Shared NuGet README packing lives in Directory.Build.targets, NOT here.

--- a/docs/Lumeo.Docs/Pages/Docs/Changelog.razor
+++ b/docs/Lumeo.Docs/Pages/Docs/Changelog.razor
@@ -15,6 +15,37 @@
 
     <Separator Class="my-4" />
 
+    <!-- v3.7.1 -->
+    <Stack Gap="4">
+        <div class="flex items-center gap-3">
+            <Badge>v3.7.1</Badge>
+            <Lumeo.Text Size="sm" Color="muted">May 2026</Lumeo.Text>
+        </div>
+
+        <Lumeo.Text Size="base" Color="muted" Leading="relaxed">
+            Patch: hardens the v3.7.0 lazy export so direct <code class="rounded bg-muted px-1 text-xs">IDataGridExportService</code>
+            calls work on WebAssembly, and clarifies the core-only export path.
+        </Lumeo.Text>
+
+        <Stack Gap="3">
+            <Heading Level="3" Size="sm" Class="font-semibold">Added</Heading>
+            <ul class="space-y-1.5 text-sm list-disc list-inside text-muted-foreground">
+                <li><strong><code class="rounded bg-muted px-1 text-xs">DataGridExportLoader.EnsureExcelAssembliesAsync()</code> / <code class="rounded bg-muted px-1 text-xs">EnsurePdfAssembliesAsync()</code></strong> — await these before a <em>direct</em> <code class="rounded bg-muted px-1 text-xs">ToExcel</code>/<code class="rounded bg-muted px-1 text-xs">ToPdf</code> call on a lazy-loading WASM app. The DataGrid component already calls them for toolbar exports. No-op on server / eager apps.</li>
+            </ul>
+        </Stack>
+
+        <Stack Gap="3">
+            <Heading Level="3" Size="sm" Class="font-semibold">Fixed</Heading>
+            <ul class="space-y-1.5 text-sm list-disc list-inside text-muted-foreground">
+                <li>Direct <code class="rounded bg-muted px-1 text-xs">IDataGridExportService</code> calls (e.g. the docs export demo) no longer fail on the lazy-loaded WASM docs site — the backend is preloaded first.</li>
+                <li>QuestPDF license is now set to Community <strong>only if the app hasn't configured one</strong>, so a consumer's <code class="rounded bg-muted px-1 text-xs">Professional</code> license is never overwritten.</li>
+                <li>Clearer error when Excel/PDF export is attempted from a core-only <code class="rounded bg-muted px-1 text-xs">Lumeo</code> install — the message now points at the <code class="rounded bg-muted px-1 text-xs">Lumeo.DataGrid</code> package.</li>
+            </ul>
+        </Stack>
+    </Stack>
+
+    <Separator Class="my-4" />
+
     <!-- v3.7.0 -->
     <Stack Gap="4">
         <div class="flex items-center gap-3">

--- a/docs/Lumeo.Docs/Pages/Docs/Services/DataGridExport.razor
+++ b/docs/Lumeo.Docs/Pages/Docs/Services/DataGridExport.razor
@@ -219,8 +219,8 @@ await Export.DownloadAsync(bytes, "orders.xlsx",
                 <Stack Gap="2">
                     <Heading Level="4" Size="sm" Class="font-semibold">2. Wire the loader hook</Heading>
                     <Lumeo.Text Size="sm" Color="muted">In <code class="rounded bg-muted px-1.5 py-0.5 text-xs font-mono text-foreground">Program.cs</code>:</Lumeo.Text>
-                    <Stack Class="code-block rounded-lg border border-border/40 bg-muted px-4 py-3 font-mono text-xs text-foreground whitespace-pre">@@using Lumeo.Services;
-@@using Microsoft.AspNetCore.Components.WebAssembly.Services;
+                    <Stack Class="code-block rounded-lg border border-border/40 bg-muted px-4 py-3 font-mono text-xs text-foreground whitespace-pre">using Lumeo.Services;
+using Microsoft.AspNetCore.Components.WebAssembly.Services;
 
 var host = builder.Build();
 var lazy = host.Services.GetRequiredService&lt;LazyAssemblyLoader&gt;();
@@ -230,12 +230,26 @@ await host.RunAsync();</Stack>
 
                 <Alert Variant="Alert.AlertVariant.Info">
                     <Lumeo.Text Size="sm">
-                        DataGrid loads the right assemblies on the first export click — Excel pulls
-                        the ClosedXML closure, PDF pulls QuestPDF. An Excel-only WASM user never
-                        downloads QuestPDF. Without this opt-in nothing breaks: the backend just
-                        loads eagerly at startup like before.
+                        The DataGrid component awaits the loader before its toolbar export, so
+                        Excel pulls the ClosedXML closure and PDF pulls QuestPDF on the first click —
+                        an Excel-only WASM user never downloads QuestPDF. If you call
+                        <code class="rounded bg-muted px-1 text-xs">IDataGridExportService.ToExcel/ToPdf</code>
+                        <strong>directly</strong> (not via the DataGrid toolbar), first await
+                        <code class="rounded bg-muted px-1 text-xs">DataGridExportLoader.EnsureExcelAssembliesAsync()</code>
+                        / <code class="rounded bg-muted px-1 text-xs">EnsurePdfAssembliesAsync()</code> —
+                        the synchronous service methods can't fetch a lazy assembly themselves.
+                        Without this opt-in nothing breaks: the backend loads eagerly at startup like before.
                     </Lumeo.Text>
                 </Alert>
+
+                <Stack Gap="2">
+                    <Heading Level="4" Size="sm" Class="font-semibold">3. Direct service calls (optional)</Heading>
+                    <Lumeo.Text Size="sm" Color="muted">When calling the service yourself on a lazy-loading WASM app, preload first:</Lumeo.Text>
+                    <Stack Class="code-block rounded-lg border border-border/40 bg-muted px-4 py-3 font-mono text-xs text-foreground whitespace-pre">await DataGridExportLoader.EnsureExcelAssembliesAsync();
+var bytes = Export.ToExcel(rows, columns, sheetName: "Data");
+await Export.DownloadAsync(bytes, "data.xlsx",
+    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");</Stack>
+                </Stack>
             </Stack>
         </Stack>
     </Stack>
@@ -272,6 +286,9 @@ await host.RunAsync();</Stack>
 
     private async Task ExportExcel()
     {
+        // This docs site lazy-loads the export assemblies, and we call the service directly
+        // (not through a DataGrid toolbar), so preload the Excel backend before ToExcel.
+        await Lumeo.Services.DataGridExportLoader.EnsureExcelAssembliesAsync();
         var bytes = Export.ToExcel(_products, GetColumns(), sheetName: "Products");
         await Export.DownloadAsync(bytes, "products.xlsx",
             "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
@@ -282,6 +299,7 @@ await host.RunAsync();</Stack>
     {
         try
         {
+            await Lumeo.Services.DataGridExportLoader.EnsurePdfAssembliesAsync();
             var bytes = Export.ToPdf(_products, GetColumns(), title: "Product Catalogue");
             await Export.DownloadAsync(bytes, "products.pdf", "application/pdf");
             Toast.Show("Exported products.pdf", variant: ToastVariant.Success);

--- a/src/Lumeo.DataGrid.Export/DataGridExportBackendImpl.cs
+++ b/src/Lumeo.DataGrid.Export/DataGridExportBackendImpl.cs
@@ -25,22 +25,19 @@ internal static class ModuleInit
 /// </summary>
 internal sealed class DataGridExportBackendImpl : IDataGridExportBackend
 {
-    // QuestPDF requires a license to be set exactly once per process. We pick Community here
-    // which is free for individuals and companies below the revenue threshold defined at
-    // https://www.questpdf.com/license — commercial users should replace this with their own
-    // paid license before shipping, e.g. `QuestPDF.Settings.License = LicenseType.Professional;`
-    // in their app's startup. We guard with a flag so changing this on the consumer side wins.
+    // QuestPDF needs a license set once per process before GeneratePdf(). We default to
+    // Community (free below the revenue threshold at https://www.questpdf.com/license) ONLY if
+    // the consuming app hasn't already configured one — so a consumer who set
+    // `QuestPDF.Settings.License = LicenseType.Professional;` in startup is never overwritten.
     private static readonly object _licenseLock = new();
-    private static bool _licenseInitialized;
 
     private static void EnsureQuestPdfLicense()
     {
-        if (_licenseInitialized) return;
+        if (QuestPDF.Settings.License is not null) return;
         lock (_licenseLock)
         {
-            if (_licenseInitialized) return;
-            QuestPDF.Settings.License = LicenseType.Community;
-            _licenseInitialized = true;
+            // Re-check under lock: the app (or a prior call) may have set it meanwhile.
+            QuestPDF.Settings.License ??= LicenseType.Community;
         }
     }
 

--- a/src/Lumeo.DataGrid/UI/DataGrid/DataGrid.razor
+++ b/src/Lumeo.DataGrid/UI/DataGrid/DataGrid.razor
@@ -2731,7 +2731,7 @@
                     }
                 case "excel":
                     {
-                        await EnsureExportAssembliesAsync(ExcelExportAssemblies);
+                        await Lumeo.Services.DataGridExportLoader.EnsureExcelAssembliesAsync();
                         var bytes = Export.ToExcel(items, exportColumns, sheetName: "Data", culture: culture);
                         await Export.DownloadAsync(bytes, "export.xlsx",
                             "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
@@ -2741,7 +2741,7 @@
                     {
                         // QuestPDF isn't supported on browser-wasm — ToPdf throws PlatformNotSupportedException
                         // on that runtime. Consumers should restrict ExportFormats to exclude Pdf on WASM.
-                        await EnsureExportAssembliesAsync(PdfExportAssemblies);
+                        await Lumeo.Services.DataGridExportLoader.EnsurePdfAssembliesAsync();
                         var bytes = Export.ToPdf(items, exportColumns, title: FullscreenTitle ?? "Export", culture: culture);
                         await Export.DownloadAsync(bytes, "export.pdf", "application/pdf");
                         break;
@@ -2759,27 +2759,6 @@
             await OnError.InvokeAsync(ex);
         }
     }
-
-    // Excel needs ClosedXML + its transitive closure; PDF needs QuestPDF. These ship in the
-    // Lumeo.DataGrid.Export assembly and can be lazy-loaded on WASM. When the host wires
-    // DataGridExportLoader (see the Lumeo.DataGrid.Export README) we fetch them on first export;
-    // otherwise this is a no-op because the assemblies are already loaded eagerly.
-    private static readonly string[] ExcelExportAssemblies =
-    {
-        "Lumeo.DataGrid.Export.dll", "ClosedXML.dll", "ClosedXML.Parser.dll",
-        "DocumentFormat.OpenXml.dll", "DocumentFormat.OpenXml.Framework.dll",
-        "ExcelNumberFormat.dll", "RBush.dll", "SixLabors.Fonts.dll", "System.IO.Packaging.dll",
-    };
-
-    private static readonly string[] PdfExportAssemblies =
-    {
-        "Lumeo.DataGrid.Export.dll", "QuestPDF.dll",
-    };
-
-    private static Task EnsureExportAssembliesAsync(IReadOnlyList<string> assemblies)
-        => Lumeo.Services.DataGridExportLoader.LoadAssembliesAsync is { } load
-            ? load(assemblies)
-            : Task.CompletedTask;
 
     // --- Layout Persistence ---
 

--- a/src/Lumeo/Services/DataGridExportBackend.cs
+++ b/src/Lumeo/Services/DataGridExportBackend.cs
@@ -54,11 +54,14 @@ public static class DataGridExportBackend
         catch (Exception ex)
         {
             throw new InvalidOperationException(
-                $"Excel/PDF export requires the '{ExportAssemblyName}' assembly, which ships " +
-                "transitively with the Lumeo.DataGrid package. On Blazor WebAssembly with lazy " +
-                "loading enabled, the assembly must be loaded before exporting — wire " +
-                $"{nameof(DataGridExportLoader)}.{nameof(DataGridExportLoader.LoadAssembliesAsync)} " +
-                "in your app startup.", ex);
+                $"Excel/PDF export requires the '{ExportAssemblyName}' assembly. " +
+                "It ships inside the 'Lumeo.DataGrid' NuGet package — if your app references only " +
+                "the core 'Lumeo' package, add 'Lumeo.DataGrid' to enable Excel/PDF (CSV needs no " +
+                "extra package). On Blazor WebAssembly that lazy-loads these assemblies, also " +
+                $"await {nameof(DataGridExportLoader)}.{nameof(DataGridExportLoader.EnsureExcelAssembliesAsync)}() / " +
+                $"{nameof(DataGridExportLoader.EnsurePdfAssembliesAsync)}() before a direct service call " +
+                $"(the DataGrid component does this for you), and wire " +
+                $"{nameof(DataGridExportLoader)}.{nameof(DataGridExportLoader.LoadAssembliesAsync)} in startup.", ex);
         }
 
         return _instance ?? throw new InvalidOperationException(
@@ -73,7 +76,49 @@ public static class DataGridExportBackend
 /// first paint. When unset (server, or WASM without lazy loading) export still works because
 /// the assemblies are loaded eagerly.
 /// </summary>
+/// <remarks>
+/// The DataGrid component awaits <see cref="EnsureExcelAssembliesAsync"/> /
+/// <see cref="EnsurePdfAssembliesAsync"/> automatically before a toolbar export. If you call
+/// <see cref="IDataGridExportService"/>.<c>ToExcel</c>/<c>ToPdf</c> <em>directly</em> from your
+/// own code on a WASM app that lazy-marks these assemblies, await the matching Ensure method
+/// first — the synchronous service methods cannot fetch a lazy assembly on their own.
+/// </remarks>
 public static class DataGridExportLoader
 {
+    /// <summary>
+    /// Set by the app (WASM only) to the framework's
+    /// <c>LazyAssemblyLoader.LoadAssembliesAsync</c>. Left <c>null</c> on server / eager apps,
+    /// where the Ensure methods become no-ops because the assemblies are already loaded.
+    /// </summary>
     public static Func<IReadOnlyList<string>, Task>? LoadAssembliesAsync { get; set; }
+
+    /// <summary>The export backend assembly plus the ClosedXML closure needed for Excel.</summary>
+    public static readonly IReadOnlyList<string> ExcelAssemblies = new[]
+    {
+        "Lumeo.DataGrid.Export.dll", "ClosedXML.dll", "ClosedXML.Parser.dll",
+        "DocumentFormat.OpenXml.dll", "DocumentFormat.OpenXml.Framework.dll",
+        "ExcelNumberFormat.dll", "RBush.dll", "SixLabors.Fonts.dll", "System.IO.Packaging.dll",
+    };
+
+    /// <summary>The export backend assembly plus QuestPDF, needed for PDF.</summary>
+    public static readonly IReadOnlyList<string> PdfAssemblies = new[]
+    {
+        "Lumeo.DataGrid.Export.dll", "QuestPDF.dll",
+    };
+
+    /// <summary>
+    /// Ensures the Excel backend assemblies are loaded before a direct
+    /// <c>IDataGridExportService.ToExcel</c> call on a lazy-loading WASM app. No-op when
+    /// <see cref="LoadAssembliesAsync"/> is unset (server / eager apps).
+    /// </summary>
+    public static Task EnsureExcelAssembliesAsync()
+        => LoadAssembliesAsync is { } load ? load(ExcelAssemblies) : Task.CompletedTask;
+
+    /// <summary>
+    /// Ensures the PDF backend assemblies are loaded before a direct
+    /// <c>IDataGridExportService.ToPdf</c> call on a lazy-loading WASM app. No-op when
+    /// <see cref="LoadAssembliesAsync"/> is unset (server / eager apps).
+    /// </summary>
+    public static Task EnsurePdfAssembliesAsync()
+        => LoadAssembliesAsync is { } load ? load(PdfAssemblies) : Task.CompletedTask;
 }


### PR DESCRIPTION
## Summary

Patch release **3.7.1** addressing the Codex / CodeRabbit review findings on the v3.7.0 lazy export split. The most important: **direct `IDataGridExportService` calls failed on the lazy-loaded WASM docs site** (the export demo's Excel button), because only the DataGrid component triggered the lazy load.

### Library fixes
- **New public API** `DataGridExportLoader.EnsureExcelAssembliesAsync()` / `EnsurePdfAssembliesAsync()` (+ the shared `ExcelAssemblies` / `PdfAssemblies` lists). Await before a *direct* `ToExcel`/`ToPdf` call on a lazy-loading WASM app. No-op on server / eager apps. The DataGrid component now uses these shared lists instead of its own copies. *(Codex P2 on #124 & #128)*
- **QuestPDF license** is set to `Community` only when `QuestPDF.Settings.License is null`, so a consumer's `Professional` license is never overwritten. *(CodeRabbit on #124)*
- **Clearer error** for core-only `Lumeo` installs attempting Excel/PDF — the `InvalidOperationException` now points at the `Lumeo.DataGrid` package and the Ensure* methods. *(Codex P1 on #124)*

### Docs fixes
- `Program.cs` snippet uses plain `using` (was Razor `@using`, which renders `@using` and won't compile). *(Codex P2 on #128)*
- New "Direct service calls" subsection + an Alert clarifying the hook only covers DataGrid toolbar exports. *(Codex P2 on #128)*
- The docs export demo now preloads the backend before calling the service directly — **fixes the broken Excel button on the live WASM docs**. *(Codex P2 on #124)*
- v3.7.1 changelog entry.

### Not in this PR
The two #123 docs-app findings (DynamicIcon icon-pack routes P1; InstallUsage on service pages P2) are docs-only issues in the just-merged design revamp, unrelated to the export work — they'll be handled in a focused follow-up.

## Test plan
- [x] `dotnet build src/Lumeo.DataGrid -c Release -warnaserror` — succeeds
- [x] `DataGridExportServiceTests` — 8/8 pass
- [x] `dotnet build docs/Lumeo.Docs -c Release` — succeeds
- [ ] CI build-and-test + e2e