### PR TITLE
docs: skip Usage block on service/family pages, refresh install version

### DIFF
--- a/docs/Lumeo.Docs/Pages/Components/AiPage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/AiPage.razor
@@ -6,7 +6,7 @@
 <PageHeader Title="AI Chat Primitives"
             Description="Streaming-ready building blocks for LLM-powered chat interfaces. Render tokens as they arrive, show tool calls, surface reasoning, and let users send prompts — all over Blazor Server's SignalR pipe." />
 
-<InstallUsage Component="Ai" />
+<InstallUsage Component="Ai" ShowUsage="false" />
 
 <div class="mt-10 space-y-3">
     <Heading Id="when-to-use" Level="2" Class="scroll-mt-20">When to Use</Heading>

--- a/docs/Lumeo.Docs/Pages/Components/MotionPage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/MotionPage.razor
@@ -4,7 +4,7 @@
 
 <PageHeader Title="Motion" Description="A set of motion primitives — Marquee, NumberTicker, TextReveal, BlurFade, BorderBeam, ShimmerButton, Sparkles — for building high-energy, Aceternity / Magic UI style interfaces." />
 
-<InstallUsage Component="Motion" />
+<InstallUsage Component="Motion" Package="Lumeo.Motion" ShowUsage="false" />
 
 <div class="mt-10 space-y-3">
     <Heading Id="when-to-use" Level="2" Class="scroll-mt-20">When to Use</Heading>

--- a/docs/Lumeo.Docs/Pages/Components/OverlayServicePage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/OverlayServicePage.razor
@@ -7,7 +7,7 @@
 
 <PageHeader Title="Overlay Service" Description="A programmatic service for opening dialogs, sheets, drawers, and alert dialogs imperatively from code." />
 
-<InstallUsage Component="OverlayService" />
+<InstallUsage Component="OverlayService" ShowUsage="false" />
 
 <Stack Gap="8">
 

--- a/docs/Lumeo.Docs/Shared/InstallUsage.razor
+++ b/docs/Lumeo.Docs/Shared/InstallUsage.razor
@@ -31,10 +31,13 @@
         </Lumeo.Text>
     </div>
 
-    <div class="space-y-3">
-        <Heading Id="usage" Level="2" Size="xl" Class="scroll-mt-20">Usage</Heading>
-        <pre class="rounded-[var(--radius-lg)] border border-border bg-muted/30 px-4 py-3 text-sm font-mono overflow-x-auto whitespace-pre m-0">@_usage</pre>
-    </div>
+    @if (ShowUsage)
+    {
+        <div class="space-y-3">
+            <Heading Id="usage" Level="2" Size="xl" Class="scroll-mt-20">Usage</Heading>
+            <pre class="rounded-[var(--radius-lg)] border border-border bg-muted/30 px-4 py-3 text-sm font-mono overflow-x-auto whitespace-pre m-0">@_usage</pre>
+        </div>
+    }
 </div>
 
 @code {
@@ -47,12 +50,21 @@
     /// <summary>Optional custom usage snippet; defaults to the import plus the tag.</summary>
     [Parameter] public string? Usage { get; set; }
 
+    /// <summary>
+    /// Whether to render the Usage block. Set <c>false</c> on pages that document a service
+    /// or a family of primitives (e.g. Ai, Motion, OverlayService) where <c>&lt;{Component} /&gt;</c>
+    /// is not a real renderable tag — the Installation block still applies, but a single
+    /// auto-generated tag would be misleading.
+    /// </summary>
+    [Parameter] public bool ShowUsage { get; set; } = true;
+
     /// <summary>Registry slug for the Lumeo CLI (<c>lumeo add &lt;slug&gt;</c>).
     /// Defaults to the kebab-cased component name, which matches the registry
     /// for all but a couple of acronym names — override when it differs.</summary>
     [Parameter] public string? Slug { get; set; }
 
-    private const string _version = "3.6.1";
+    // Keep in lockstep with /Directory.Build.props <Version> on each release.
+    private const string _version = "3.7.1";
     private string _cli => $"dotnet add package {Package}";
     private string _pkg => $"<PackageReference Include=\"{Package}\" Version=\"{_version}\" />";
     private string _lumeoCli => $"lumeo add {Slug ?? Kebab(Component)}";


### PR DESCRIPTION
## Summary

Docs-only follow-up addressing the two Codex findings on PR #123. No library code; **no new tag** — Cloudflare deploys from master.

### Fixed
- **InstallUsage on service / family pages** *(Codex P2)*: `Ai`, `Motion`, `OverlayService` documented a service or a family of primitives, so the auto-generated `<{Component} />` usage tag wasn't a real renderable element and produced a misleading copy/paste snippet. Added a `ShowUsage` parameter (default `true`) and set `ShowUsage="false"` on those three pages. The Installation block still applies.
- **Stale install version**: the hardcoded `_version = "3.6.1"` in `InstallUsage` (shown on every component page's install snippet) is bumped to `3.7.1`, with a note that it tracks `Directory.Build.props`.

### Investigated, not a bug
The Codex P1 *"Load icon packs for every DynamicIcon route"* is **not a real issue**: `CustomizerSidebar` (mounted by `MainLayout` on every docs page) preloads all 8 non-Lucide Blazicons packs on first render. `IconService.ActiveLibrary` is a singleton, so a non-Lucide selection always has its assembly already loaded before any route renders `DynamicIcon`. No App.razor change needed.

## Test plan
- [x] `dotnet build docs/Lumeo.Docs -c Release` — succeeds
- [ ] CI docs check