### PR TITLE
feat(combobox): composition-mode grouping (closes #125)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
   <!-- Lockstep version shared by all Lumeo packages.
        Update this single property to version all packages in unison. -->
   <PropertyGroup>
-    <Version>3.7.1</Version>
+    <Version>3.8.0</Version>
   </PropertyGroup>
 
   <!-- Shared NuGet README packing lives in Directory.Build.targets, NOT here.

--- a/docs/Lumeo.Docs/Pages/Components/ComboboxPage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/ComboboxPage.razor
@@ -78,6 +78,49 @@
         </Stack>
     </ComponentDemo>
 
+    <ComponentDemo Title="Grouped Items" Code="@_groupedCode">
+        <Stack Gap="2" Class="w-full max-w-xs">
+            <Combobox @bind-Value="_selectedGroupedFramework" @bind-Open="_isOpenGrouped">
+                <ComboboxInput Placeholder="Select framework..." />
+                <ComboboxContent>
+                    <ComboboxGroup Label="Web Frameworks">
+                        <ComboboxItem Value="blazor">Blazor</ComboboxItem>
+                        <ComboboxItem Value="react">React</ComboboxItem>
+                        <ComboboxItem Value="angular">Angular</ComboboxItem>
+                        <ComboboxItem Value="vue">Vue</ComboboxItem>
+                    </ComboboxGroup>
+                    <ComboboxGroup Label="Mobile Frameworks">
+                        <ComboboxItem Value="maui">.NET MAUI</ComboboxItem>
+                        <ComboboxItem Value="flutter">Flutter</ComboboxItem>
+                        <ComboboxItem Value="rn">React Native</ComboboxItem>
+                    </ComboboxGroup>
+                    <ComboboxEmpty>No framework found.</ComboboxEmpty>
+                </ComboboxContent>
+            </Combobox>
+            <Lumeo.Text Size="sm" Color="muted">Selected: @(_selectedGroupedFramework ?? "none")</Lumeo.Text>
+        </Stack>
+    </ComponentDemo>
+
+    <ComponentDemo Title="Collapsible Groups + Group Select" Code="@_groupedAdvancedCode">
+        <Stack Gap="2" Class="w-full max-w-sm">
+            <Combobox Multiple="true" @bind-Values="_selectedTools" @bind-Open="_isOpenGroupedAdv">
+                <ComboboxInput Placeholder="Select tools..." />
+                <ComboboxContent>
+                    <ComboboxGroup Label="Editors" Collapsible="true" GroupSelect="true">
+                        <ComboboxItem Value="vscode">VS Code</ComboboxItem>
+                        <ComboboxItem Value="rider">Rider</ComboboxItem>
+                        <ComboboxItem Value="vs">Visual Studio</ComboboxItem>
+                    </ComboboxGroup>
+                    <ComboboxGroup Label="CI/CD" Collapsible="true" GroupSelect="true" DefaultExpanded="false">
+                        <ComboboxItem Value="gha">GitHub Actions</ComboboxItem>
+                        <ComboboxItem Value="azdo">Azure DevOps</ComboboxItem>
+                    </ComboboxGroup>
+                </ComboboxContent>
+            </Combobox>
+            <Lumeo.Text Size="sm" Color="muted">Selected: @(_selectedTools.Count == 0 ? "none" : string.Join(", ", _selectedTools))</Lumeo.Text>
+        </Stack>
+    </ComponentDemo>
+
     <ComponentDemo Title="Async Search" Code="@_asyncCode">
         <Container MaxWidth="sm" Center="false" Padding="">
             <Combobox @bind-Open="_isOpenAsync" OnSearchAsync="@HandleSearchAsync" IsSearchLoading="@_isSearching">
@@ -103,6 +146,10 @@
     private bool _isOpen3;
     private bool _isOpenMulti;
     private bool _isOpenAsync;
+    private string? _selectedGroupedFramework;
+    private bool _isOpenGrouped;
+    private HashSet<string> _selectedTools = new();
+    private bool _isOpenGroupedAdv;
     private string _searchText1 = "";
     private HashSet<string> _selectedFrameworks = new();
     private bool _isSearching;
@@ -180,6 +227,44 @@
     private HashSet<string> _selectedFrameworks = new();
     private bool _isOpen;
 }";
+
+    private string _groupedCode = @"<Combobox @bind-Value=""_selected"" @bind-Open=""_isOpen"">
+    <ComboboxInput Placeholder=""Select framework..."" />
+    <ComboboxContent>
+        <ComboboxGroup Label=""Web Frameworks"">
+            <ComboboxItem Value=""blazor"">Blazor</ComboboxItem>
+            <ComboboxItem Value=""react"">React</ComboboxItem>
+            <ComboboxItem Value=""angular"">Angular</ComboboxItem>
+            <ComboboxItem Value=""vue"">Vue</ComboboxItem>
+        </ComboboxGroup>
+        <ComboboxGroup Label=""Mobile Frameworks"">
+            <ComboboxItem Value=""maui"">.NET MAUI</ComboboxItem>
+            <ComboboxItem Value=""flutter"">Flutter</ComboboxItem>
+            <ComboboxItem Value=""rn"">React Native</ComboboxItem>
+        </ComboboxGroup>
+        <ComboboxEmpty>No framework found.</ComboboxEmpty>
+    </ComboboxContent>
+</Combobox>";
+
+    private string _groupedAdvancedCode = @"@* Collapsible groups + a tri-state group-select checkbox (Multiple mode).
+   Set DefaultExpanded=false to start a group collapsed; an active search
+   auto-expands groups and hides ones with no matching items. *@
+<Combobox Multiple=""true"" @bind-Values=""_selectedTools"" @bind-Open=""_isOpen"">
+    <ComboboxInput Placeholder=""Select tools..."" />
+    <ComboboxContent>
+        <ComboboxGroup Label=""Editors"" Collapsible=""true"" GroupSelect=""true"">
+            <ComboboxItem Value=""vscode"">VS Code</ComboboxItem>
+            <ComboboxItem Value=""rider"">Rider</ComboboxItem>
+            <ComboboxItem Value=""vs"">Visual Studio</ComboboxItem>
+        </ComboboxGroup>
+        <ComboboxGroup Label=""CI/CD"" Collapsible=""true"" GroupSelect=""true"" DefaultExpanded=""false"">
+            <ComboboxItem Value=""gha"">GitHub Actions</ComboboxItem>
+            <ComboboxItem Value=""azdo"">Azure DevOps</ComboboxItem>
+        </ComboboxGroup>
+    </ComboboxContent>
+</Combobox>
+
+@* Multi-level grouping: nest a ComboboxGroup inside another for Category -> Subcategory. *@";
 
     private string _asyncCode = @"<Combobox @bind-Open=""_isOpen"" OnSearchAsync=""@HandleSearchAsync"" IsSearchLoading=""@_isSearching"">
     <ComboboxInput Placeholder=""Search users..."" />

--- a/docs/Lumeo.Docs/Pages/Docs/Changelog.razor
+++ b/docs/Lumeo.Docs/Pages/Docs/Changelog.razor
@@ -15,6 +15,32 @@
 
     <Separator Class="my-4" />
 
+    <!-- v3.8.0 -->
+    <Stack Gap="4">
+        <div class="flex items-center gap-3">
+            <Badge>v3.8.0</Badge>
+            <Lumeo.Text Size="sm" Color="muted">May 2026</Lumeo.Text>
+        </div>
+
+        <Lumeo.Text Size="base" Color="muted" Leading="relaxed">
+            Minor: composition-mode grouping for <code class="rounded bg-muted px-1 text-xs">Combobox</code> —
+            labelled headers, multi-level nesting, collapsible groups, and group-level select.
+        </Lumeo.Text>
+
+        <Stack Gap="3">
+            <Heading Level="3" Size="sm" Class="font-semibold">Added</Heading>
+            <ul class="space-y-1.5 text-sm list-disc list-inside text-muted-foreground">
+                <li><strong><code class="rounded bg-muted px-1 text-xs">&lt;ComboboxGroup&gt;</code></strong> — wrap <code class="rounded bg-muted px-1 text-xs">ComboboxItem</code>s under a labelled header. Headers are non-selectable and skipped by keyboard navigation.</li>
+                <li><strong>Multi-level grouping</strong> — nest <code class="rounded bg-muted px-1 text-xs">ComboboxGroup</code> inside another for Category → Subcategory, with automatic indentation.</li>
+                <li><strong>Collapsible groups</strong> — <code class="rounded bg-muted px-1 text-xs">Collapsible</code> + <code class="rounded bg-muted px-1 text-xs">DefaultExpanded</code>. An active search auto-expands groups so matches stay reachable.</li>
+                <li><strong>Group-level select</strong> — <code class="rounded bg-muted px-1 text-xs">GroupSelect</code> (Multiple mode) renders a tri-state header checkbox that selects / clears every descendant item.</li>
+                <li><strong>Filter-aware</strong> — groups whose descendants are all filtered out hide automatically; <code class="rounded bg-muted px-1 text-xs">LabelClass</code> is a theming hook for the header.</li>
+            </ul>
+        </Stack>
+    </Stack>
+
+    <Separator Class="my-4" />
+
     <!-- v3.7.1 -->
     <Stack Gap="4">
         <div class="flex items-center gap-3">

--- a/docs/Lumeo.Docs/Shared/InstallUsage.razor
+++ b/docs/Lumeo.Docs/Shared/InstallUsage.razor
@@ -64,7 +64,7 @@
     [Parameter] public string? Slug { get; set; }
 
     // Keep in lockstep with /Directory.Build.props <Version> on each release.
-    private const string _version = "3.7.1";
+    private const string _version = "3.8.0";
     private string _cli => $"dotnet add package {Package}";
     private string _pkg => $"<PackageReference Include=\"{Package}\" Version=\"{_version}\" />";
     private string _lumeoCli => $"lumeo add {Slug ?? Kebab(Component)}";

--- a/src/Lumeo/UI/Combobox/ComboboxGroup.razor
+++ b/src/Lumeo/UI/Combobox/ComboboxGroup.razor
@@ -1,0 +1,221 @@
+@namespace Lumeo
+@implements IDisposable
+
+@* Composition-mode grouping for Combobox. Wrap ComboboxItems (or nested ComboboxGroups
+   for multi-level grouping) under a labelled, optionally collapsible header. The group
+   hides itself when a search filters out all of its descendants, and — in Multiple mode —
+   can offer a group-level select-all checkbox. *@
+
+<CascadingValue Value="_groupContext" IsFixed="true">
+    <div role="group" aria-labelledby="@_labelId"
+         class="@Cx.Join(Cx.When(_isHidden, "hidden"))" @attributes="AdditionalAttributes">
+
+        @if (!string.IsNullOrEmpty(Label))
+        {
+            <div id="@_labelId"
+                 class="@HeaderCss"
+                 style="@IndentStyle"
+                 role="@(Collapsible ? "button" : null)"
+                 aria-expanded="@(Collapsible ? _expanded.ToString().ToLowerInvariant() : null)"
+                 @onclick="OnHeaderClick">
+
+                @if (Collapsible)
+                {
+                    <Blazicon Svg="Lucide.ChevronRight"
+                              class="@Cx.Join("h-3.5 w-3.5 shrink-0 transition-transform", Cx.When(_expanded, "rotate-90"))" />
+                }
+
+                @if (Context.Multiple && GroupSelect)
+                {
+                    <span class="flex h-3.5 w-3.5 items-center justify-center shrink-0"
+                          role="checkbox" aria-checked="@GroupCheckedState"
+                          @onclick="ToggleGroupSelection" @onclick:stopPropagation="true">
+                        @if (_allSelected)
+                        {
+                            <Blazicon Svg="Lucide.Check" class="h-3.5 w-3.5" />
+                        }
+                        else if (_anySelected)
+                        {
+                            <Blazicon Svg="Lucide.Minus" class="h-3.5 w-3.5" />
+                        }
+                    </span>
+                }
+
+                <span class="@Cx.Merge("truncate", LabelClass)">@Label</span>
+            </div>
+        }
+
+        @if (_expanded)
+        {
+            @ChildContent
+        }
+    </div>
+</CascadingValue>
+
+@code {
+    [CascadingParameter] public Combobox.ComboboxContext Context { get; set; } = default!;
+    // A parent group, present only for nested (multi-level) grouping.
+    [CascadingParameter] public ComboboxGroupContext? ParentGroup { get; set; }
+
+    [Parameter] public RenderFragment? ChildContent { get; set; }
+
+    /// <summary>Group header text. When null/empty the group renders no header (still nests its items).</summary>
+    [Parameter] public string? Label { get; set; }
+
+    /// <summary>Extra classes for the group label — theming hook for the header appearance.</summary>
+    [Parameter] public string? LabelClass { get; set; }
+
+    /// <summary>When true the header toggles the group open/closed. Collapsed groups hide their items.</summary>
+    [Parameter] public bool Collapsible { get; set; }
+
+    /// <summary>Initial expanded state for a <see cref="Collapsible"/> group. Default expanded.</summary>
+    [Parameter] public bool DefaultExpanded { get; set; } = true;
+
+    /// <summary>
+    /// In <c>Multiple</c> mode, render a tri-state checkbox on the header that selects /
+    /// deselects every descendant item in one click.
+    /// </summary>
+    [Parameter] public bool GroupSelect { get; set; }
+
+    [Parameter] public string? Class { get; set; }
+    [Parameter(CaptureUnmatchedValues = true)] public Dictionary<string, object>? AdditionalAttributes { get; set; }
+
+    private readonly string _labelId = LumeoIds.New("combobox-group-label");
+    private ComboboxGroupContext _groupContext = default!;
+    // The user's explicit expand state (header toggle). Effective expansion also force-opens
+    // while a search is active so matches inside a collapsed group stay reachable.
+    private bool _userExpanded = true;
+    private bool _expanded => !Collapsible || HasActiveSearch || _userExpanded;
+
+    // Depth drives the left-indent for multi-level grouping (Category → Subcategory).
+    private int Depth => (ParentGroup?.Depth ?? -1) + 1;
+
+    // A group is hidden when an active search filtered out every descendant item.
+    private bool _isHidden;
+
+    private string IndentStyle => Depth > 0 ? $"padding-left:{0.5 + Depth * 0.75:0.###}rem" : "";
+
+    private string HeaderCss => Cx.Merge(
+        "flex items-center gap-1.5 px-2 py-1.5 text-xs font-semibold text-muted-foreground",
+        Cx.When(Collapsible, "cursor-pointer select-none hover:text-foreground"),
+        Class);
+
+    protected override void OnInitialized()
+    {
+        _userExpanded = DefaultExpanded;
+        _groupContext = new ComboboxGroupContext(Depth, OnChildrenChanged);
+        // Register ourselves with a parent group so multi-level empty-hiding bubbles up.
+        ParentGroup?.RegisterChild(_groupContext);
+    }
+
+    protected override void OnParametersSet() => RecomputeVisibility();
+
+    // When a search is active, collapsible groups auto-expand so matches stay reachable.
+    private bool HasActiveSearch => !string.IsNullOrEmpty(Context.SearchText);
+
+    private void OnChildrenChanged()
+    {
+        RecomputeVisibility();
+        InvokeAsync(StateHasChanged);
+    }
+
+    // Hide the whole group only while filtering AND nothing inside it matches.
+    private void RecomputeVisibility()
+        => _isHidden = HasActiveSearch && _groupContext.VisibleDescendantCount == 0;
+
+    private void OnHeaderClick()
+    {
+        if (!Collapsible || HasActiveSearch) return;
+        _userExpanded = !_userExpanded;
+    }
+
+    // --- Group-level selection (Multiple mode) ---
+
+    private bool _allSelected;
+    private bool _anySelected;
+
+    private string GroupCheckedState => _allSelected ? "true" : _anySelected ? "mixed" : "false";
+
+    private async Task ToggleGroupSelection()
+    {
+        var values = _groupContext.AllDescendantValues.ToList();
+        if (values.Count == 0) return;
+        // If everything is already selected, clear the group; otherwise select all.
+        var selectAll = !_allSelected;
+        foreach (var v in values)
+        {
+            var isSelected = Context.Values?.Contains(v) == true;
+            if (selectAll != isSelected)
+                await Context.OnSelect.InvokeAsync(v);
+        }
+    }
+
+    protected override void OnAfterRender(bool firstRender)
+    {
+        // Refresh the tri-state after selection changes flow back through the cascade.
+        if (!Context.Multiple || !GroupSelect) return;
+        var values = _groupContext.AllDescendantValues.ToList();
+        var all = values.Count > 0 && values.All(v => Context.Values?.Contains(v) == true);
+        var any = values.Any(v => Context.Values?.Contains(v) == true);
+        if (all != _allSelected || any != _anySelected)
+        {
+            _allSelected = all;
+            _anySelected = any;
+            InvokeAsync(StateHasChanged);
+        }
+    }
+
+    public void Dispose() => ParentGroup?.UnregisterChild(_groupContext);
+
+    /// <summary>
+    /// Mutable context cascaded to a group's descendants. ComboboxItems report their value and
+    /// current visibility here; nested groups register themselves so empty-hiding and group
+    /// selection aggregate across multiple levels.
+    /// </summary>
+    public sealed class ComboboxGroupContext
+    {
+        private readonly Action _onChanged;
+        private readonly Dictionary<string, (string Value, bool Visible)> _items = new();
+        private readonly List<ComboboxGroupContext> _childGroups = new();
+
+        public ComboboxGroupContext(int depth, Action onChanged)
+        {
+            Depth = depth;
+            _onChanged = onChanged;
+        }
+
+        public int Depth { get; }
+
+        public void RegisterItem(string id, string value, bool visible)
+        {
+            // Only notify when something actually changed — ComboboxItem calls this on every
+            // parameter set, so an unconditional notify would spin the group's render loop.
+            if (_items.TryGetValue(id, out var existing) && existing.Value == value && existing.Visible == visible)
+                return;
+            _items[id] = (value, visible);
+            _onChanged();
+        }
+
+        public void UnregisterItem(string id)
+        {
+            if (_items.Remove(id)) _onChanged();
+        }
+
+        public void RegisterChild(ComboboxGroupContext child)
+        {
+            if (!_childGroups.Contains(child)) _childGroups.Add(child);
+            _onChanged();
+        }
+
+        public void UnregisterChild(ComboboxGroupContext child)
+        {
+            if (_childGroups.Remove(child)) _onChanged();
+        }
+
+        public int VisibleDescendantCount
+            => _items.Values.Count(i => i.Visible) + _childGroups.Sum(g => g.VisibleDescendantCount);
+
+        public IEnumerable<string> AllDescendantValues
+            => _items.Values.Select(i => i.Value).Concat(_childGroups.SelectMany(g => g.AllDescendantValues));
+    }
+}

--- a/src/Lumeo/UI/Combobox/ComboboxItem.razor
+++ b/src/Lumeo/UI/Combobox/ComboboxItem.razor
@@ -4,7 +4,7 @@
 @if (Visible)
 {
     <button type="button" id="@_itemId" role="option" aria-selected="@IsSelected.ToString().ToLower()"
-            class="@CssClass" @onclick="Select" @attributes="AdditionalAttributes">
+            class="@CssClass" style="@IndentStyle" @onclick="Select" @attributes="AdditionalAttributes">
         <span class="flex h-3.5 w-3.5 items-center justify-center">
             @if (IsSelected)
             {
@@ -17,6 +17,8 @@
 
 @code {
     [CascadingParameter] public Combobox.ComboboxContext Context { get; set; } = default!;
+    // Present when the item sits inside one or more ComboboxGroups (nearest group wins).
+    [CascadingParameter] public ComboboxGroup.ComboboxGroupContext? Group { get; set; }
     [Parameter] public RenderFragment? ChildContent { get; set; }
     [Parameter, EditorRequired] public string Value { get; set; } = "";
     [Parameter] public string? Class { get; set; }
@@ -26,6 +28,12 @@
 
     private readonly string _itemId = LumeoIds.New("combobox-item");
     private bool _registered;
+    private bool _groupRegistered;
+
+    // Indent items one extra step beyond their group's header for visual nesting.
+    private string IndentStyle => Group is { Depth: var d } && d >= 0
+        ? $"padding-left:{0.5 + (d + 1) * 0.75:0.###}rem"
+        : "";
 
     private bool IsSelected => Context.Multiple
         ? Context.Values?.Contains(Value) == true
@@ -60,11 +68,20 @@
             Context.UnregisterItem(_itemId);
             _registered = false;
         }
+
+        // Report value + visibility to the enclosing group so it can hide itself when all
+        // descendants are filtered out and drive its group-select tri-state checkbox.
+        if (Group is not null)
+        {
+            Group.RegisterItem(_itemId, Value, Visible);
+            _groupRegistered = true;
+        }
     }
 
     public void Dispose()
     {
         if (_registered) Context.UnregisterItem(_itemId);
+        if (_groupRegistered) Group?.UnregisterItem(_itemId);
     }
 
     private async Task Select() => await Context.OnSelect.InvokeAsync(Value);

--- a/tests/Lumeo.Tests/Components/Combobox/ComboboxGroupTests.cs
+++ b/tests/Lumeo.Tests/Components/Combobox/ComboboxGroupTests.cs
@@ -1,0 +1,238 @@
+using Bunit;
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Rendering;
+using Xunit;
+using Lumeo.Tests.Helpers;
+using L = Lumeo;
+
+namespace Lumeo.Tests.Components.Combobox;
+
+/// <summary>
+/// Tests for composition-mode grouping (<see cref="L.ComboboxGroup"/>): labelled headers,
+/// nested (multi-level) groups, collapsible behaviour, group-level selection in multi-select,
+/// and filtering that hides groups with no matching descendants.
+/// </summary>
+public class ComboboxGroupTests : IAsyncLifetime
+{
+    private readonly BunitContext _ctx = new();
+
+    public ComboboxGroupTests() => _ctx.AddLumeoServices();
+
+    public Task InitializeAsync() => Task.CompletedTask;
+    public async Task DisposeAsync() => await _ctx.DisposeAsync();
+
+    // Renders an open Combobox with two groups (Fruits: apple/banana, Vegetables: carrot)
+    // and lets the caller tweak the group/item options via the builder hooks.
+    private IRenderedComponent<IComponent> RenderGrouped(
+        string? search = null,
+        bool collapsible = false,
+        bool defaultExpanded = true,
+        bool multiple = false,
+        bool groupSelect = false,
+        HashSet<string>? values = null)
+    {
+        return _ctx.Render(builder =>
+        {
+            builder.OpenComponent<L.Combobox>(0);
+            builder.AddAttribute(1, "Open", true);
+            builder.AddAttribute(2, "Multiple", multiple);
+            if (values is not null) builder.AddAttribute(3, "Values", values);
+            builder.AddAttribute(4, "ChildContent", (RenderFragment)(b =>
+            {
+                b.OpenComponent<L.ComboboxInput>(0);
+                b.AddAttribute(1, "Placeholder", "Search...");
+                b.CloseComponent();
+
+                b.OpenComponent<L.ComboboxContent>(2);
+                b.AddAttribute(3, "ChildContent", (RenderFragment)(c =>
+                {
+                    Group(c, 0, "Fruits", grp =>
+                    {
+                        Item(grp, 0, "apple", "Apple");
+                        Item(grp, 1, "banana", "Banana");
+                    }, collapsible, defaultExpanded, groupSelect);
+
+                    Group(c, 10, "Vegetables", grp =>
+                    {
+                        Item(grp, 0, "carrot", "Carrot");
+                    }, collapsible, defaultExpanded, groupSelect);
+                }));
+                b.CloseComponent();
+            }));
+            builder.CloseComponent();
+        });
+
+        void Group(RenderTreeBuilder rb, int seq, string label, RenderFragment children,
+                   bool col, bool def, bool gs)
+        {
+            rb.OpenComponent<L.ComboboxGroup>(seq);
+            rb.AddAttribute(seq + 1, "Label", label);
+            rb.AddAttribute(seq + 2, "Collapsible", col);
+            rb.AddAttribute(seq + 3, "DefaultExpanded", def);
+            rb.AddAttribute(seq + 4, "GroupSelect", gs);
+            rb.AddAttribute(seq + 5, "ChildContent", children);
+            rb.CloseComponent();
+        }
+
+        void Item(RenderTreeBuilder rb, int seq, string value, string label)
+        {
+            rb.OpenComponent<L.ComboboxItem>(seq);
+            rb.AddAttribute(seq + 1, "Value", value);
+            rb.AddAttribute(seq + 2, "ChildContent", (RenderFragment)(i => i.AddContent(0, label)));
+            rb.CloseComponent();
+        }
+    }
+
+    // Helper to type into the search input (drives client-side filtering).
+    private static void Search(IRenderedComponent<IComponent> cut, string text)
+        => cut.Find("input[type='text']").Input(text);
+
+    [Fact]
+    public void Renders_Group_Headers_As_Non_Option_Roles()
+    {
+        var cut = RenderGrouped();
+        var groups = cut.FindAll("[role='group']");
+        Assert.Equal(2, groups.Count);
+        Assert.Contains(cut.Markup, m => true); // sanity
+        Assert.Contains("Fruits", cut.Markup);
+        Assert.Contains("Vegetables", cut.Markup);
+    }
+
+    [Fact]
+    public void Group_Header_Is_Not_An_Option()
+    {
+        var cut = RenderGrouped();
+        // Only the 3 items are options; headers are not role=option.
+        Assert.Equal(3, cut.FindAll("[role='option']").Count);
+    }
+
+    [Fact]
+    public void Filter_Hides_Group_With_No_Matching_Items()
+    {
+        var cut = RenderGrouped();
+        Search(cut, "carrot");
+
+        // Only the Vegetables group should remain visible; Fruits is hidden.
+        var groups = cut.FindAll("[role='group']");
+        var fruits = groups.First(g => g.TextContent.Contains("Fruits"));
+        var veg = groups.First(g => g.TextContent.Contains("Vegetables"));
+        Assert.Contains("hidden", fruits.GetAttribute("class"));
+        Assert.DoesNotContain("hidden", veg.GetAttribute("class") ?? "");
+        // Only the carrot option is rendered now.
+        Assert.Single(cut.FindAll("[role='option']"));
+    }
+
+    [Fact]
+    public void Collapsible_Group_Hides_Items_When_Collapsed()
+    {
+        var cut = RenderGrouped(collapsible: true, defaultExpanded: false);
+        // Collapsed by default → its items are not rendered.
+        Assert.Empty(cut.FindAll("[role='option']"));
+
+        // Click the Fruits header to expand it.
+        var fruitsHeader = cut.FindAll("[role='button']").First(h => h.TextContent.Contains("Fruits"));
+        fruitsHeader.Click();
+
+        Assert.Equal(2, cut.FindAll("[role='option']").Count);
+    }
+
+    [Fact]
+    public void Active_Search_Force_Expands_Collapsed_Group()
+    {
+        var cut = RenderGrouped(collapsible: true, defaultExpanded: false);
+        Assert.Empty(cut.FindAll("[role='option']"));
+
+        Search(cut, "apple");
+        // The matching item shows even though the group started collapsed.
+        var options = cut.FindAll("[role='option']");
+        Assert.Single(options);
+        Assert.Contains("Apple", options[0].TextContent);
+    }
+
+    [Fact]
+    public void GroupSelect_Checkbox_Selects_All_Descendants()
+    {
+        var selected = new HashSet<string>();
+        var cut = _ctx.Render(builder =>
+        {
+            builder.OpenComponent<L.Combobox>(0);
+            builder.AddAttribute(1, "Open", true);
+            builder.AddAttribute(2, "Multiple", true);
+            builder.AddAttribute(3, "Values", selected);
+            builder.AddAttribute(4, "ValuesChanged",
+                EventCallback.Factory.Create<HashSet<string>>(this, v => selected = v));
+            builder.AddAttribute(5, "ChildContent", (RenderFragment)(b =>
+            {
+                b.OpenComponent<L.ComboboxContent>(0);
+                b.AddAttribute(1, "ChildContent", (RenderFragment)(c =>
+                {
+                    c.OpenComponent<L.ComboboxGroup>(0);
+                    c.AddAttribute(1, "Label", "Fruits");
+                    c.AddAttribute(2, "GroupSelect", true);
+                    c.AddAttribute(3, "ChildContent", (RenderFragment)(g =>
+                    {
+                        g.OpenComponent<L.ComboboxItem>(0);
+                        g.AddAttribute(1, "Value", "apple");
+                        g.AddAttribute(2, "ChildContent", (RenderFragment)(i => i.AddContent(0, "Apple")));
+                        g.CloseComponent();
+                        g.OpenComponent<L.ComboboxItem>(3);
+                        g.AddAttribute(1, "Value", "banana");
+                        g.AddAttribute(2, "ChildContent", (RenderFragment)(i => i.AddContent(0, "Banana")));
+                        g.CloseComponent();
+                    }));
+                    c.CloseComponent();
+                }));
+                b.CloseComponent();
+            }));
+            builder.CloseComponent();
+        });
+
+        // The group header checkbox is the first role=checkbox in the markup.
+        var checkbox = cut.Find("[role='checkbox']");
+        checkbox.Click();
+
+        Assert.Contains("apple", selected);
+        Assert.Contains("banana", selected);
+    }
+
+    [Fact]
+    public void Nested_Groups_Render_Multi_Level()
+    {
+        var cut = _ctx.Render(builder =>
+        {
+            builder.OpenComponent<L.Combobox>(0);
+            builder.AddAttribute(1, "Open", true);
+            builder.AddAttribute(2, "ChildContent", (RenderFragment)(b =>
+            {
+                b.OpenComponent<L.ComboboxContent>(0);
+                b.AddAttribute(1, "ChildContent", (RenderFragment)(c =>
+                {
+                    c.OpenComponent<L.ComboboxGroup>(0);
+                    c.AddAttribute(1, "Label", "Food");
+                    c.AddAttribute(2, "ChildContent", (RenderFragment)(outer =>
+                    {
+                        outer.OpenComponent<L.ComboboxGroup>(0);
+                        outer.AddAttribute(1, "Label", "Fruits");
+                        outer.AddAttribute(2, "ChildContent", (RenderFragment)(inner =>
+                        {
+                            inner.OpenComponent<L.ComboboxItem>(0);
+                            inner.AddAttribute(1, "Value", "apple");
+                            inner.AddAttribute(2, "ChildContent", (RenderFragment)(i => i.AddContent(0, "Apple")));
+                            inner.CloseComponent();
+                        }));
+                        outer.CloseComponent();
+                    }));
+                    c.CloseComponent();
+                }));
+                b.CloseComponent();
+            }));
+            builder.CloseComponent();
+        });
+
+        // Two nested group containers + the apple option.
+        Assert.Equal(2, cut.FindAll("[role='group']").Count);
+        Assert.Single(cut.FindAll("[role='option']"));
+        Assert.Contains("Food", cut.Markup);
+        Assert.Contains("Fruits", cut.Markup);
+    }
+}


### PR DESCRIPTION
## Summary

Implements **Combobox grouping** (closes #125) for the composition API — the full feature set requested in the issue.

### New: `<ComboboxGroup>`
```razor
<Combobox @bind-Value="_value">
    <ComboboxInput Placeholder="Select framework..." />
    <ComboboxContent>
        <ComboboxGroup Label="Web Frameworks">
            <ComboboxItem Value="blazor">Blazor</ComboboxItem>
            <ComboboxItem Value="react">React</ComboboxItem>
        </ComboboxGroup>
        <ComboboxGroup Label="Mobile Frameworks">
            <ComboboxItem Value="maui">.NET MAUI</ComboboxItem>
        </ComboboxGroup>
    </ComboboxContent>
</Combobox>
```

### Features
- **Labelled, non-selectable headers** — keyboard nav already skips them (only `ComboboxItem`s register as navigable options).
- **Multi-level grouping** — nest `ComboboxGroup` inside another (Category → Subcategory) with depth-based indentation.
- **Collapsible groups** — `Collapsible` + `DefaultExpanded`. An active search force-expands collapsed groups so matches stay reachable; collapsed groups unmount their items so they drop out of keyboard nav.
- **Group-level select** (Multiple mode) — `GroupSelect` renders a tri-state header checkbox that selects/clears every descendant value, aggregated across nested levels.
- **Filter-aware** — a group whose descendants are all filtered out hides automatically. `LabelClass` is a theming hook.

### Implementation
`ComboboxItem` reports its value + current visibility to the enclosing group through a cascaded `ComboboxGroupContext` (registration guarded so it never spins the render loop). The data-bound `ItemGroup` grouping from before is unchanged; this adds the composition-mode equivalent.

### Versioning
`Directory.Build.props` 3.7.1 → **3.8.0** (new feature, SemVer minor). Per repo Rule #2, the tag + NuGet publish await owner confirmation — tell me if you'd prefer 3.7.2.

## Test plan
- [x] 7 new bUnit tests in `ComboboxGroupTests` (headers, nesting, collapse, force-expand on search, group-select, empty-group hiding) — pass
- [x] All 33 Combobox tests pass
- [x] `dotnet build docs/Lumeo.Docs -c Release` succeeds; two new demos (Grouped Items, Collapsible + Group Select)
- [ ] CI build-and-test + e2e