### PR TITLE
perf(docs): defer DataGrid and Kanban below-the-fold via LazyRender

### DIFF
--- a/docs/Lumeo.Docs/Pages/Home.razor
+++ b/docs/Lumeo.Docs/Pages/Home.razor
@@ -163,12 +163,14 @@
                         </Lumeo.Link>
                     </Flex>
                     <div class="px-3 pb-3">
-                        <DataGrid TItem="Employee" Items="@_employees" PageSize="10" ShowPagination="false"
-                                  GroupBy="Department" GroupsExpandedByDefault="true">
-                            <DataGridColumnDef TItem="Employee" Title="Name"   Field="Name"   Sortable="true" />
-                            <DataGridColumnDef TItem="Employee" Title="Role"   Field="Role" />
-                            <DataGridColumnDef TItem="Employee" Title="Salary" Field="Salary" Format="C0" Sortable="true" Aggregate="AggregateType.Sum" />
-                        </DataGrid>
+                        <LazyRender Height="420px">
+                            <DataGrid TItem="Employee" Items="@_employees" PageSize="10" ShowPagination="false"
+                                      GroupBy="Department" GroupsExpandedByDefault="true">
+                                <DataGridColumnDef TItem="Employee" Title="Name"   Field="Name"   Sortable="true" />
+                                <DataGridColumnDef TItem="Employee" Title="Role"   Field="Role" />
+                                <DataGridColumnDef TItem="Employee" Title="Salary" Field="Salary" Format="C0" Sortable="true" Aggregate="AggregateType.Sum" />
+                            </DataGrid>
+                        </LazyRender>
                     </div>
                 </div>
 
@@ -183,7 +185,8 @@
                         </Lumeo.Link>
                     </Flex>
                     <div class="px-3 pb-3 overflow-x-auto">
-                        <Kanban Class="!p-0 !gap-2 min-w-[360px]">
+                        <LazyRender Height="420px">
+                            <Kanban Class="!p-0 !gap-2 min-w-[360px]">
                             <KanbanColumn Title="To do" Badge="@_kanbanTodo.Count"
                                           Class="flex flex-col flex-1 min-w-0 rounded-lg border border-border/40 bg-background min-h-[130px]"
                                           OnDrop="@(_ => MoveDraggingCard(_kanbanTodo))">
@@ -218,6 +221,7 @@
                                 }
                             </KanbanColumn>
                         </Kanban>
+                        </LazyRender>
                     </div>
                 </div>
             </div>

--- a/docs/Lumeo.Docs/Pages/Home.razor
+++ b/docs/Lumeo.Docs/Pages/Home.razor
@@ -163,7 +163,10 @@
                         </Lumeo.Link>
                     </Flex>
                     <div class="px-3 pb-3">
-                        <LazyRender Height="420px">
+                        @* RootMarginPx=0 so we only mount when the placeholder actually enters the viewport.
+                           The default 200px margin would mount during prerender (1280x800) because this block
+                           sits ~100px below the fold on the home layout — defeating the TBT deferral. *@
+                        <LazyRender Height="420px" RootMarginPx="0">
                             <DataGrid TItem="Employee" Items="@_employees" PageSize="10" ShowPagination="false"
                                       GroupBy="Department" GroupsExpandedByDefault="true">
                                 <DataGridColumnDef TItem="Employee" Title="Name"   Field="Name"   Sortable="true" />
@@ -185,7 +188,11 @@
                         </Lumeo.Link>
                     </Flex>
                     <div class="px-3 pb-3 overflow-x-auto">
-                        <LazyRender Height="420px">
+                        @* 200px matches the actual rendered Kanban: 3 columns (min-h-[130px]) + the row header
+                           with a few compact cards. On lg the row height is driven by the taller DataGrid cell
+                           in the same grid row, so the lower placeholder doesn't shorten the row.
+                           RootMarginPx=0 keeps it deferred during prerender — see DataGrid note above. *@
+                        <LazyRender Height="200px" RootMarginPx="0">
                             <Kanban Class="!p-0 !gap-2 min-w-[360px]">
                             <KanbanColumn Title="To do" Badge="@_kanbanTodo.Count"
                                           Class="flex flex-col flex-1 min-w-0 rounded-lg border border-border/40 bg-background min-h-[130px]"


### PR DESCRIPTION
## Summary

Targets the landing-page TBT (currently ~2.2 s on the new design, well over the 300 ms budget) by deferring the DataGrid + Kanban hero row.

### What changed
- The "Team roster" `DataGrid` and "Sprint board" `Kanban` are now wrapped in `<LazyRender Height="420px">`. They mount only once their placeholder scrolls within 200 px of the viewport. Both blocks live below the fold on every form factor.
- Above-the-fold (headline, KPI strip, BarChart + Map row) is **unchanged**. The Map was already lazy from before.
- 420 px placeholders approximate each block's rendered height so the page geometry stays stable while loading.

### Why these
- DataGrid: grouping + aggregation work per render — measurable TBT contribution even though the data is static.
- Kanban: builds three column lists with per-card draggable wrappers on every render.

Above-the-fold work isn't touched, so first-paint visuals are identical. This is the smallest defensible TBT change before we look at runtime/WASM-init costs.

### Versioning
Docs-only, no library code. Per Rule #2 this goes to master without a new tag — Cloudflare deploys from master.

## Test plan
- [x] `dotnet build docs/Lumeo.Docs -c Release` succeeds
- [ ] CI build-and-test + e2e
- [ ] Lighthouse on the preview deploy vs. master (expecting TBT drop; FCP/LCP unchanged)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LJmBFYeCdQj2G2epoZaRzQ)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved dashboard responsiveness with deferred component rendering for the team roster and sprint board.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Brain2k-0005/Lumeo/pull/132?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->