### PR TITLE
perf(docs): defer hero BarChart's ECharts init off the critical path (IdleMount)

### DIFF
--- a/docs/Lumeo.Docs/Pages/Home.razor
+++ b/docs/Lumeo.Docs/Pages/Home.razor
@@ -116,7 +116,33 @@
                         </Badge>
                     </Flex>
                     <div class="h-56 sm:h-64 lg:h-80 px-2 pb-3">
-                        <BarChart Categories="_barCategories" Series="_barSeries" Stacked="true" Height="100%" ShowLoadingSkeleton="false" />
+                        @* IdleMount keeps ECharts' CDN fetch + init off the first-paint critical
+                           path: a cheap CSS stacked-bar placeholder (built from the same data, so
+                           it matches the real chart's shape) shows immediately, then the live
+                           BarChart swaps in once the browser is idle. *@
+                        <IdleMount>
+                            <Placeholder>
+                                <div class="flex h-full items-end gap-1.5 sm:gap-2" aria-hidden="true">
+                                    @for (var i = 0; i < _barCategories.Count; i++)
+                                    {
+                                        var total = _barSeries.Sum(s => s.Values[i]);
+                                        var barPct = _chartMaxTotal > 0 ? total / _chartMaxTotal * 100 : 0;
+                                        <div class="flex-1 flex flex-col-reverse rounded-t-sm overflow-hidden"
+                                             style="height:@barPct.ToString("0.#", System.Globalization.CultureInfo.InvariantCulture)%">
+                                            @for (var s = 0; s < _barSeries.Count; s++)
+                                            {
+                                                var segPct = total > 0 ? _barSeries[s].Values[i] / total * 100 : 0;
+                                                var op = (0.85 - s * 0.28).ToString("0.##", System.Globalization.CultureInfo.InvariantCulture);
+                                                <div style="height:@segPct.ToString("0.#", System.Globalization.CultureInfo.InvariantCulture)%;background:hsl(var(--primary) / @op)"></div>
+                                            }
+                                        </div>
+                                    }
+                                </div>
+                            </Placeholder>
+                            <ChildContent>
+                                <BarChart Categories="_barCategories" Series="_barSeries" Stacked="true" Height="100%" ShowLoadingSkeleton="false" />
+                            </ChildContent>
+                        </IdleMount>
                     </div>
                 </div>
 
@@ -1051,6 +1077,9 @@ builder.Services.<span style="color: #a78bfa;">AddLumeo</span>();</pre>
         new() { Name = "Charts",   Values = new() {  8700, 10400, 13100, 15800, 19200, 22700 } },
         new() { Name = "DataGrid", Values = new() {  4100,  6800,  9200, 11400, 14600, 18100 } },
     };
+    // Largest per-category stacked total — scales the static IdleMount placeholder bars.
+    private double _chartMaxTotal => Enumerable.Range(0, _barCategories.Count)
+        .Select(i => _barSeries.Sum(s => s.Values[i])).DefaultIfEmpty(0).Max();
     private int _chartSnapshot;
     private bool _chartHovered;
     private static readonly List<double>[][] _chartSnapshots =

--- a/docs/Lumeo.Docs/Shared/IdleMount.razor
+++ b/docs/Lumeo.Docs/Shared/IdleMount.razor
@@ -1,0 +1,74 @@
+@*
+    IdleMount — defer a heavy ABOVE-THE-FOLD component off the first-paint
+    critical path without hiding it behind a scroll.
+
+    Unlike LazyRender (which waits for the placeholder to scroll into view, and
+    therefore mounts immediately for content that's already visible), IdleMount
+    shows <Placeholder> right away and swaps in <ChildContent> once the browser
+    is idle — i.e. after the WASM runtime has booted and the first interactive
+    render is done. Use it for the hero chart so ECharts' CDN fetch + init runs
+    during idle time instead of inflating TBT.
+
+    During prerender the real content mounts immediately (window.lumeo.onIdle
+    short-circuits) so the static snapshot is complete. Falls back to immediate
+    mount when JS is unavailable (bUnit / SSR).
+
+    Usage:
+        <IdleMount>
+            <Placeholder><MyStaticSvg /></Placeholder>
+            <ChildContent><BarChart ... /></ChildContent>
+        </IdleMount>
+*@
+
+@inject IJSRuntime JS
+@implements IDisposable
+
+@if (_mounted)
+{
+    @ChildContent
+}
+else
+{
+    @Placeholder
+}
+
+@code {
+    /// <summary>The real (heavy) content, mounted once the browser is idle.</summary>
+    [Parameter] public RenderFragment? ChildContent { get; set; }
+
+    /// <summary>Cheap stand-in shown immediately during boot. Should match the
+    /// final content's box so the swap doesn't shift layout.</summary>
+    [Parameter] public RenderFragment? Placeholder { get; set; }
+
+    /// <summary>Upper bound (ms) before the swap is forced even if the browser
+    /// never reports idle. Default 2000.</summary>
+    [Parameter] public int TimeoutMs { get; set; } = 2000;
+
+    private bool _mounted;
+    private DotNetObjectReference<IdleMount>? _selfRef;
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (!firstRender || _mounted) return;
+        try
+        {
+            _selfRef = DotNetObjectReference.Create(this);
+            await JS.InvokeVoidAsync("lumeo.onIdle", _selfRef, TimeoutMs);
+        }
+        catch
+        {
+            // JS unavailable (SSR / bUnit) — mount immediately.
+            _mounted = true;
+            await InvokeAsync(StateHasChanged);
+        }
+    }
+
+    [JSInvokable]
+    public void OnIdle()
+    {
+        _mounted = true;
+        _ = InvokeAsync(StateHasChanged);
+    }
+
+    public void Dispose() => _selfRef?.Dispose();
+}

--- a/docs/Lumeo.Docs/wwwroot/js/docs.js
+++ b/docs/Lumeo.Docs/wwwroot/js/docs.js
@@ -93,6 +93,25 @@ window.lumeo.disconnectObserver = function (io) {
     if (io && typeof io.disconnect === 'function') io.disconnect();
 };
 
+// Idle-mount hook for IdleMount.razor. Keeps a heavy above-the-fold component
+// (e.g. the hero ECharts BarChart) out of the first-paint critical path: we
+// show a cheap static placeholder immediately, then swap in the real component
+// once the browser is idle (past the WASM boot + first interactive render).
+// During prerender we fire immediately so the static snapshot has real content.
+window.lumeo.onIdle = function (dotNetRef, timeoutMs) {
+    if (window.__LUMEO_PRERENDER__) {
+        dotNetRef.invokeMethodAsync('OnIdle');
+        return;
+    }
+    var fire = function () { dotNetRef.invokeMethodAsync('OnIdle'); };
+    if (typeof window.requestIdleCallback === 'function') {
+        window.requestIdleCallback(fire, { timeout: timeoutMs || 2000 });
+    } else {
+        // Safari/older: defer past the current paint with a small timeout.
+        setTimeout(fire, 200);
+    }
+};
+
 // Page-visibility hook. The docs landing page runs several timers (chart
 // reshuffle 2s, toast bank 11s, tabs/steps rotation). Background tabs keep
 // firing the timers (and HTML5 spec throttles them but doesn't pause them),


### PR DESCRIPTION
## Summary

Middle-path landing-perf change (per discussion): keep the live-demo hero, but take the **biggest page-controllable TBT contributor — ECharts — off the first-paint critical path.**

### The lever
The hero "Revenue by package" `BarChart` is above the fold, so `LazyRender` can't help (visible → mounts immediately, like Codex flagged for the DataGrid). Its ECharts CDN fetch (~1 MB) + init + first render run during the post-WASM-boot re-render burst, which is the largest slice of landing TBT we can actually move.

### What changed
- **New `IdleMount` helper** (`docs/Shared/IdleMount.razor`): renders a cheap `Placeholder` immediately, then swaps in `ChildContent` on `requestIdleCallback` (`window.lumeo.onIdle` added to `docs.js`). Mounts immediately during prerender (snapshot stays complete) and falls back to immediate mount when JS is unavailable.
- **BarChart wrapped in `IdleMount`** with a pure-CSS stacked-bar placeholder built from the *same* `_barSeries` data, so it matches the real chart's shape and the swap is layout-stable. ECharts now initialises during idle time.

### What I deliberately did NOT do (and why)
The plan also floated converting the 5 hero `BlurFade`s to CSS-only and gating `NumberTicker`s on visibility. On inspection:
- Hero `BlurFade`s are **prerender-friendly — already fully visible above the fold with no entrance animation on first load** (`lumeo.css:820-836`). Replacing them yields ~zero visual change and only marginal TBT (5 of 20 IntersectionObserver registrations; `Lumeo.Motion` still loads for NumberTicker/ShimmerButton/Marquee). Low ROI, fiddly markup surgery — held.
- `NumberTicker`s are above-the-fold and *are* the KPI "wow" — deferring their animation doesn't help (immediately visible) and removing it loses the effect. Held.

So this PR is the one high-value, low-risk piece.

### Honest caveat on measurement
The container's headless Lighthouse TBT is too noisy to prove the delta (±2.5s run-to-run, larger than the effect). The change is logically sound — ECharts init moves out of the critical window — but the win needs **real-browser DevTools / CI Lighthouse** to quantify. FCP/LCP/visual are unchanged by construction.

## Test plan
- [x] `dotnet build docs/Lumeo.Docs -c Release` succeeds
- [ ] CI build-and-test + e2e
- [ ] Real-browser verification on the preview deploy (TBT delta; confirm chart swaps in correctly and placeholder matches)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LJmBFYeCdQj2G2epoZaRzQ)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The "Revenue by package" chart now displays a loading skeleton placeholder while content loads, providing visual feedback during the loading phase.

* **Performance**
  * Chart rendering deferred until browser idle for faster initial page load times.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Brain2k-0005/Lumeo/pull/139?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->