### PR TITLE
feat(input): ShowCount + MaxLength counter (closes #136)

### DIFF
--- a/src/Lumeo/UI/Input/Input.razor
+++ b/src/Lumeo/UI/Input/Input.razor
@@ -38,7 +38,7 @@
                type="@(Variant == InputVariant.Search ? "search" : null)"
                aria-required="@Required.ToString().ToLowerInvariant()"
                aria-invalid="@EffectiveInvalid.ToString().ToLowerInvariant()"
-               class="@WrappedInputClass" value="@Value" @oninput="HandleInput" disabled="@Disabled" @attributes="AdditionalAttributes" />
+               maxlength="@MaxLength" class="@WrappedInputClass" value="@Value" @oninput="HandleInput" disabled="@Disabled" @attributes="AdditionalAttributes" />
         @if (Clearable && !string.IsNullOrEmpty(Value))
         {
             <button type="button" class="@($"flex items-center {AccessoryClearPad} text-muted-foreground hover:text-foreground transition-colors")" @onclick="HandleClear" tabindex="-1" aria-label="@L["Common.Clear"]">
@@ -57,7 +57,13 @@ else
            name="@Name"
            aria-required="@Required.ToString().ToLowerInvariant()"
            aria-invalid="@EffectiveInvalid.ToString().ToLowerInvariant()"
-           class="@CssClass" value="@Value" @oninput="HandleInput" disabled="@Disabled" @attributes="AdditionalAttributes" />
+           maxlength="@MaxLength" class="@CssClass" value="@Value" @oninput="HandleInput" disabled="@Disabled" @attributes="AdditionalAttributes" />
+}
+
+@if (ShowCount)
+{
+    @* Counter sits below the input wrapper (after error/helper text), matching Textarea. *@
+    <div class="mt-1 text-xs @CountClass text-right">@CountText</div>
 }
 
 @if (!InsideFormField)
@@ -94,6 +100,17 @@ else
     [Parameter] public string? HelperText { get; set; }
     [Parameter] public string? Label { get; set; }
     [Parameter] public string? Name { get; set; }
+
+    /// <summary>Renders a character counter below the input, matching Textarea's pattern.</summary>
+    [Parameter] public bool ShowCount { get; set; }
+
+    /// <summary>HTML <c>maxlength</c> on the input plus the limit shown in the counter.
+    /// When <c>null</c> and <see cref="ShowCount"/> is true, only the current length is rendered.</summary>
+    [Parameter] public int? MaxLength { get; set; }
+
+    /// <summary>Optional custom counter formatter (e.g. <c>c =&gt; $"{c} of 60 chars"</c>).
+    /// Default renders <c>42</c> or <c>42/60</c> when <see cref="MaxLength"/> is set.</summary>
+    [Parameter] public Func<int, string>? CountFormat { get; set; }
     /// <summary>
     /// Focuses the underlying &lt;input&gt; on first render. The HTML
     /// <c>autofocus</c> attribute doesn't work in Blazor WASM because the
@@ -128,6 +145,15 @@ else
 
     private bool EffectiveInvalid => Invalid || FormField?.HasError == true;
     private bool InsideFormField => FormField is not null;
+
+    // Character-counter helpers, mirroring Textarea's pattern.
+    private bool IsOverLimit => MaxLength.HasValue && (Value?.Length ?? 0) > MaxLength.Value;
+    private string CountClass => IsOverLimit ? "text-destructive" : "text-muted-foreground";
+    private string CountText => CountFormat is { } fmt
+        ? fmt(Value?.Length ?? 0)
+        : MaxLength.HasValue
+            ? $"{Value?.Length ?? 0}/{MaxLength}"
+            : (Value?.Length ?? 0).ToString();
 
     private Lumeo.Density EffectiveDensity => Density ?? InheritedDensity ?? Lumeo.Density.Comfortable;
 

--- a/src/Lumeo/UI/Input/Input.razor
+++ b/src/Lumeo/UI/Input/Input.razor
@@ -62,7 +62,7 @@ else
 
 @if (ShowCount)
 {
-    @* Counter sits below the input wrapper (after error/helper text), matching Textarea. *@
+    @* Counter sits below the input wrapper, matching Textarea. *@
     <div class="mt-1 text-xs @CountClass text-right">@CountText</div>
 }
 

--- a/tests/Lumeo.Tests/Components/Input/InputTests.cs
+++ b/tests/Lumeo.Tests/Components/Input/InputTests.cs
@@ -162,4 +162,57 @@ public class InputTests : IAsyncLifetime
         // and the bare input is rendered instead
         Assert.Empty(cut.FindAll("button"));
     }
+
+    // --- ShowCount / MaxLength (parity with Textarea) ---
+
+    [Fact]
+    public void ShowCount_Renders_Character_Count()
+    {
+        var cut = _ctx.Render<Lumeo.Input>(p => p
+            .Add(t => t.ShowCount, true)
+            .Add(t => t.Value, "hello"));
+
+        Assert.Contains("5", cut.Markup);
+    }
+
+    [Fact]
+    public void ShowCount_With_MaxLength_Renders_Count_And_Max()
+    {
+        var cut = _ctx.Render<Lumeo.Input>(p => p
+            .Add(t => t.ShowCount, true)
+            .Add(t => t.MaxLength, 100)
+            .Add(t => t.Value, "hello"));
+
+        Assert.Contains("5/100", cut.Markup);
+    }
+
+    [Fact]
+    public void MaxLength_Forwarded_To_Input_Element()
+    {
+        var cut = _ctx.Render<Lumeo.Input>(p => p.Add(t => t.MaxLength, 42));
+        Assert.Equal("42", cut.Find("input").GetAttribute("maxlength"));
+    }
+
+    [Fact]
+    public void ShowCount_Over_Limit_Uses_Destructive_Color()
+    {
+        var cut = _ctx.Render<Lumeo.Input>(p => p
+            .Add(t => t.ShowCount, true)
+            .Add(t => t.MaxLength, 3)
+            .Add(t => t.Value, "hello")); // 5 > 3
+
+        var counter = cut.FindAll("div").Last(d => d.TextContent.Contains("5/3"));
+        Assert.Contains("text-destructive", counter.GetAttribute("class") ?? "");
+    }
+
+    [Fact]
+    public void ShowCount_With_CountFormat_Uses_Custom_Format()
+    {
+        var cut = _ctx.Render<Lumeo.Input>(p => p
+            .Add(t => t.ShowCount, true)
+            .Add(t => t.Value, "ab")
+            .Add(t => t.CountFormat, c => $"{c} chars"));
+
+        Assert.Contains("2 chars", cut.Markup);
+    }
 }

--- a/tests/Lumeo.Tests/Components/Input/InputTests.cs
+++ b/tests/Lumeo.Tests/Components/Input/InputTests.cs
@@ -201,8 +201,9 @@ public class InputTests : IAsyncLifetime
             .Add(t => t.MaxLength, 3)
             .Add(t => t.Value, "hello")); // 5 > 3
 
-        var counter = cut.FindAll("div").Last(d => d.TextContent.Contains("5/3"));
-        Assert.Contains("text-destructive", counter.GetAttribute("class") ?? "");
+        var counterDivs = cut.FindAll("div").Where(d => d.TextContent.Contains("5/3")).ToList();
+        Assert.Single(counterDivs);
+        Assert.Contains("text-destructive", counterDivs[0].GetAttribute("class") ?? "");
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Closes #136 — brings the character counter to `Input`, matching the pattern Textarea already ships.

### New parameters
- `bool ShowCount` — opt-in counter below the input wrapper.
- `int? MaxLength` — promoted from `AdditionalAttributes` to a real `[Parameter]`. Forwarded to `maxlength` on the `<input>` element on both render branches (Prefix/Suffix/Search wrapper path and the bare-input path).
- `Func<int, string>? CountFormat` — optional custom formatter (`c => $"{c} of 60 chars"`); default renders `42` or `42/60` like Textarea.

### Behavior
Mirrors `Textarea` exactly: counter sits below the wrapper, `text-xs text-right text-muted-foreground`, goes `text-destructive` when length exceeds `MaxLength` via the same `IsOverLimit` predicate.

### Compatibility
Additive only — consumers who never set `ShowCount` see byte-identical output. Consumers who previously set `maxlength` via `AdditionalAttributes` are unaffected unless they ALSO set the new `MaxLength` parameter, which would correctly throw Blazor's duplicate-attribute error (the canonical path is the parameter going forward).

## Test plan
- [x] 5 new bUnit tests in `InputTests` (count rendered, `5/100` format, `maxlength` forwarded, destructive when over limit, `CountFormat` honored) — pass
- [x] All 70 InputTests pass
- [x] `dotnet build src/Lumeo -c Release` — succeeds
- [ ] CI build-and-test + e2e

### Versioning
Targets 3.8.1 (small additive parameter set on an existing component).

---
_Generated by [Claude Code](https://claude.ai/code/session_01LJmBFYeCdQj2G2epoZaRzQ)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Input component now displays an optional character counter with configurable maximum length.
  * Visual indicator changes style when character limit is exceeded.
  * Support for custom counter text formatting.

* **Tests**
  * Added test coverage for character counter functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Brain2k-0005/Lumeo/pull/140?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->