### PR TITLE
feat(combobox+select): ItemDescription + ItemIcon for data-bound mode (closes #134)

### DIFF
--- a/docs/Lumeo.Docs/Pages/Components/ComboboxPage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/ComboboxPage.razor
@@ -121,6 +121,20 @@
         </Stack>
     </ComponentDemo>
 
+    <ComponentDemo Title="Items with Icons + Descriptions (data-bound)" Code="@_richItemCode">
+        <Container MaxWidth="sm" Center="false" Padding="">
+            <Combobox @bind-Value="_selectedAction" @bind-Open="_isOpenRich"
+                      Items="_actions"
+                      ItemValue="@(o => ((ActionItem)o).Id)"
+                      ItemText="@(o => ((ActionItem)o).Label)"
+                      ItemDescription="@(o => ((ActionItem)o).Hint)"
+                      ItemIcon="@(o => RenderActionIcon((ActionItem)o))">
+                <ComboboxInput Placeholder="Run a command..." />
+                <ComboboxContent />
+            </Combobox>
+        </Container>
+    </ComponentDemo>
+
     <ComponentDemo Title="Async Search" Code="@_asyncCode">
         <Container MaxWidth="sm" Center="false" Padding="">
             <Combobox @bind-Open="_isOpenAsync" OnSearchAsync="@HandleSearchAsync" IsSearchLoading="@_isSearching">
@@ -150,6 +164,26 @@
     private bool _isOpenGrouped;
     private HashSet<string> _selectedTools = new();
     private bool _isOpenGroupedAdv;
+
+    private record ActionItem(string Id, string Label, string Hint, Blazicons.SvgIcon Icon);
+
+    private readonly IEnumerable<object> _actions = new object[]
+    {
+        new ActionItem("new", "New File", "Ctrl + N", Blazicons.Lucide.FilePlus),
+        new ActionItem("open", "Open File", "Ctrl + O", Blazicons.Lucide.FolderOpen),
+        new ActionItem("save", "Save", "Ctrl + S", Blazicons.Lucide.Save),
+    };
+
+    private string? _selectedAction;
+    private bool _isOpenRich;
+
+    private RenderFragment? RenderActionIcon(ActionItem item) => builder =>
+    {
+        builder.OpenComponent<Blazicons.Blazicon>(0);
+        builder.AddAttribute(1, "Svg", item.Icon);
+        builder.AddAttribute(2, "class", "h-4 w-4");
+        builder.CloseComponent();
+    };
     private string _searchText1 = "";
     private HashSet<string> _selectedFrameworks = new();
     private bool _isSearching;
@@ -211,6 +245,19 @@
         _searchResults = allUsers.Where(u => u.Contains(query, StringComparison.OrdinalIgnoreCase)).ToList();
         _isSearching = false;
     }
+
+    private string _richItemCode = @"@* Data-bound mode: ItemIcon + ItemDescription extend the default item renderer
+   without a custom ItemTemplate. Return null per item to mix iconed and un-iconed rows.
+   record ActionItem(string Id, string Label, string Hint, SvgIcon Icon); *@
+<Combobox @bind-Value=""_selectedAction"" @bind-Open=""_isOpenRich""
+          Items=""_actions""
+          ItemValue=""@(o => ((ActionItem)o).Id)""
+          ItemText=""@(o => ((ActionItem)o).Label)""
+          ItemDescription=""@(o => ((ActionItem)o).Hint)""
+          ItemIcon=""@(o => RenderActionIcon((ActionItem)o))"">
+    <ComboboxInput Placeholder=""Run a command..."" />
+    <ComboboxContent />
+</Combobox>";
 
     private string _multipleCode = @"<Combobox Multiple=""true"" @bind-Values=""_selectedFrameworks"" @bind-Open=""_isOpen"">
     <ComboboxInput Placeholder=""Select frameworks..."" />

--- a/docs/Lumeo.Docs/Pages/Components/ComboboxPage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/ComboboxPage.razor
@@ -165,23 +165,26 @@
     private HashSet<string> _selectedTools = new();
     private bool _isOpenGroupedAdv;
 
-    private record ActionItem(string Id, string Label, string Hint, Blazicons.SvgIcon Icon);
+    private record ActionItem(string Id, string Label, string Hint, string IconName);
 
     private readonly IEnumerable<object> _actions = new object[]
     {
-        new ActionItem("new", "New File", "Ctrl + N", Blazicons.Lucide.FilePlus),
-        new ActionItem("open", "Open File", "Ctrl + O", Blazicons.Lucide.FolderOpen),
-        new ActionItem("save", "Save", "Ctrl + S", Blazicons.Lucide.Save),
+        new ActionItem("new", "New File", "Ctrl + N", "FilePlus"),
+        new ActionItem("open", "Open File", "Ctrl + O", "FolderOpen"),
+        new ActionItem("save", "Save", "Ctrl + S", "Save"),
     };
 
     private string? _selectedAction;
     private bool _isOpenRich;
 
+    // Uses the docs-site DynamicIcon helper so the icon library swap in the docs
+    // shell applies to live demos too. ItemIcon returns null per item to skip its
+    // icon column (useful for mixed iconed / un-iconed lists).
     private RenderFragment? RenderActionIcon(ActionItem item) => builder =>
     {
-        builder.OpenComponent<Blazicons.Blazicon>(0);
-        builder.AddAttribute(1, "Svg", item.Icon);
-        builder.AddAttribute(2, "class", "h-4 w-4");
+        builder.OpenComponent<Lumeo.Docs.Shared.DynamicIcon>(0);
+        builder.AddAttribute(1, "Name", item.IconName);
+        builder.AddAttribute(2, "Class", "h-4 w-4");
         builder.CloseComponent();
     };
     private string _searchText1 = "";
@@ -254,7 +257,7 @@
           ItemValue=""@(o => ((ActionItem)o).Id)""
           ItemText=""@(o => ((ActionItem)o).Label)""
           ItemDescription=""@(o => ((ActionItem)o).Hint)""
-          ItemIcon=""@(o => RenderActionIcon((ActionItem)o))"">
+          ItemIcon=""@(o => @<Blazicon Svg=""@(((ActionItem)o).Icon)"" class=""h-4 w-4"" />)"">
     <ComboboxInput Placeholder=""Run a command..."" />
     <ComboboxContent />
 </Combobox>";
@@ -442,10 +445,22 @@
                             <td class="p-3 text-muted-foreground">Optional data source. When set, ComboboxContent renders options from this list instead of ChildContent.</td>
                         </tr>
                         <tr>
+                            <td class="p-3 font-mono text-xs text-primary">ItemDescription</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">Func&lt;object, string?&gt;?</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">null</td>
+                            <td class="p-3 text-muted-foreground">Optional secondary line per item, rendered below the label in muted text. Return null per item to suppress the sub-line. Only applies when ItemTemplate is unset.</td>
+                        </tr>
+                        <tr>
+                            <td class="p-3 font-mono text-xs text-primary">ItemIcon</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">Func&lt;object, RenderFragment?&gt;?</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">null</td>
+                            <td class="p-3 text-muted-foreground">Optional leading icon per item (typically a Blazicon). Return null per item to skip the icon column entirely so iconed and un-iconed rows can mix. Only applies when ItemTemplate is unset.</td>
+                        </tr>
+                        <tr>
                             <td class="p-3 font-mono text-xs text-primary">ItemTemplate</td>
                             <td class="p-3 font-mono text-xs text-muted-foreground">RenderFragment&lt;object&gt;?</td>
                             <td class="p-3 font-mono text-xs text-muted-foreground">null</td>
-                            <td class="p-3 text-muted-foreground">Optional custom render fragment for an item's content. Receives the raw item object.</td>
+                            <td class="p-3 text-muted-foreground">Optional custom render fragment for an item's content. Receives the raw item object. When set, ItemIcon / ItemDescription are not used (template wins).</td>
                         </tr>
                         <tr>
                             <td class="p-3 font-mono text-xs text-primary">Virtualize</td>

--- a/src/Lumeo/UI/Combobox/Combobox.razor
+++ b/src/Lumeo/UI/Combobox/Combobox.razor
@@ -13,7 +13,7 @@
         _wrapperId, _contentId, _inputId, _focusedIndex, focusedItemId, focusedItemValue,
         EventCallback.Factory.Create<int>(this, SetFocusedIndex),
         RegisterItem, UnregisterItem, _items.Count, EffectiveInvalid, Required,
-        Items, ItemValue, ItemText, ItemGroup, ItemDisabled, ItemTemplate, Virtualize, ItemSize);
+        Items, ItemValue, ItemText, ItemGroup, ItemDisabled, ItemDescription, ItemIcon, ItemTemplate, Virtualize, ItemSize);
 }
 
 @if (Label is not null && !InsideFormField)
@@ -120,6 +120,20 @@
     [Parameter] public Func<object, string?>? ItemGroup { get; set; }
     /// <summary>Optional per-item disabled predicate.</summary>
     [Parameter] public Func<object, bool>? ItemDisabled { get; set; }
+    /// <summary>
+    /// Optional per-item secondary line (description) extractor. When set and
+    /// <see cref="ItemTemplate"/> is null, the default item renderer shows the
+    /// description in a smaller, muted line below the label — the standard pattern
+    /// for command pickers (vscode-style "label + helper text").
+    /// </summary>
+    [Parameter] public Func<object, string?>? ItemDescription { get; set; }
+    /// <summary>
+    /// Optional per-item leading icon. Receives the raw item object and returns a
+    /// RenderFragment (typically a single <c>&lt;Blazicon&gt;</c>). Rendered before
+    /// the label when <see cref="ItemTemplate"/> is null. Skip via returning
+    /// <c>null</c> per item to mix iconed and non-iconed rows.
+    /// </summary>
+    [Parameter] public Func<object, RenderFragment?>? ItemIcon { get; set; }
     /// <summary>Optional custom render fragment for an item's content. Receives the raw item object.</summary>
     [Parameter] public RenderFragment<object>? ItemTemplate { get; set; }
     /// <summary>When <c>true</c> and <see cref="Items"/> is set, uses Blazor's Virtualize component for the option list.</summary>
@@ -247,6 +261,8 @@
         Func<object, string>? ItemText,
         Func<object, string?>? ItemGroup,
         Func<object, bool>? ItemDisabled,
+        Func<object, string?>? ItemDescription,
+        Func<object, RenderFragment?>? ItemIcon,
         RenderFragment<object>? ItemTemplate,
         bool Virtualize,
         float ItemSize);

--- a/src/Lumeo/UI/Combobox/ComboboxContent.razor
+++ b/src/Lumeo/UI/Combobox/ComboboxContent.razor
@@ -184,8 +184,38 @@
         }
         else
         {
+            // Default renderer: optional leading icon, label, optional sub-line description.
+            // ItemIcon and ItemDescription return null per item to mix iconed / un-iconed
+            // rows in the same list without forcing every row to allocate the icon column.
+            var icon = Context.ItemIcon?.Invoke(item);
+            if (icon is not null)
+            {
+                builder.OpenElement(12, "span");
+                builder.AddAttribute(13, "class", "flex h-4 w-4 shrink-0 items-center justify-center text-muted-foreground");
+                builder.AddContent(14, icon);
+                builder.CloseElement();
+            }
+
             var label = Context.ItemText?.Invoke(item) ?? value;
-            builder.AddContent(12, label);
+            var description = Context.ItemDescription?.Invoke(item);
+            if (!string.IsNullOrEmpty(description))
+            {
+                builder.OpenElement(15, "span");
+                builder.AddAttribute(16, "class", "flex min-w-0 flex-col");
+                builder.OpenElement(17, "span");
+                builder.AddAttribute(18, "class", "truncate");
+                builder.AddContent(19, label);
+                builder.CloseElement();
+                builder.OpenElement(20, "span");
+                builder.AddAttribute(21, "class", "truncate text-xs text-muted-foreground");
+                builder.AddContent(22, description);
+                builder.CloseElement();
+                builder.CloseElement();
+            }
+            else
+            {
+                builder.AddContent(23, label);
+            }
         }
         builder.CloseElement(); // button
     };

--- a/src/Lumeo/UI/Select/Select.razor
+++ b/src/Lumeo/UI/Select/Select.razor
@@ -13,7 +13,7 @@
         _wrapperId, _contentId, _triggerId, _focusedIndex, focusedItemId, focusedItemValue,
         EventCallback.Factory.Create<int>(this, SetFocusedIndex),
         RegisterItem, UnregisterItem, EffectiveInvalid, Required,
-        Items, ItemValue, ItemText, ItemGroup, ItemDisabled, ItemTemplate, Virtualize, ItemSize);
+        Items, ItemValue, ItemText, ItemGroup, ItemDisabled, ItemDescription, ItemIcon, ItemTemplate, Virtualize, ItemSize);
 }
 
 @if (Label is not null && !InsideFormField)
@@ -113,6 +113,19 @@
     [Parameter] public Func<object, string?>? ItemGroup { get; set; }
     /// <summary>Optional per-item disabled predicate.</summary>
     [Parameter] public Func<object, bool>? ItemDisabled { get; set; }
+    /// <summary>
+    /// Optional per-item secondary line (description) extractor. When set and
+    /// <see cref="ItemTemplate"/> is null, the default item renderer shows the
+    /// description in a smaller, muted line below the label.
+    /// </summary>
+    [Parameter] public Func<object, string?>? ItemDescription { get; set; }
+    /// <summary>
+    /// Optional per-item leading icon. Receives the raw item object and returns a
+    /// RenderFragment (typically a single <c>&lt;Blazicon&gt;</c>). Rendered before
+    /// the label when <see cref="ItemTemplate"/> is null. Return <c>null</c> per item
+    /// to mix iconed and non-iconed rows.
+    /// </summary>
+    [Parameter] public Func<object, RenderFragment?>? ItemIcon { get; set; }
     /// <summary>Optional custom render fragment for an item's content. Receives the raw item object.</summary>
     [Parameter] public RenderFragment<object>? ItemTemplate { get; set; }
     /// <summary>When <c>true</c> and <see cref="Items"/> is set, uses Blazor's Virtualize component for the option list.</summary>
@@ -244,6 +257,8 @@
         Func<object, string>? ItemText,
         Func<object, string?>? ItemGroup,
         Func<object, bool>? ItemDisabled,
+        Func<object, string?>? ItemDescription,
+        Func<object, RenderFragment?>? ItemIcon,
         RenderFragment<object>? ItemTemplate,
         bool Virtualize,
         float ItemSize);

--- a/src/Lumeo/UI/Select/SelectContent.razor
+++ b/src/Lumeo/UI/Select/SelectContent.razor
@@ -160,8 +160,38 @@
         }
         else
         {
+            // Default renderer: optional leading icon, label, optional sub-line description.
+            // ItemIcon and ItemDescription can return null per item so iconed and un-iconed
+            // rows can mix in the same list without forcing every row to reserve the column.
+            var icon = Context.ItemIcon?.Invoke(item);
+            if (icon is not null)
+            {
+                builder.OpenElement(13, "span");
+                builder.AddAttribute(14, "class", "flex h-4 w-4 shrink-0 items-center justify-center text-muted-foreground");
+                builder.AddContent(15, icon);
+                builder.CloseElement();
+            }
+
             var label = Context.ItemText?.Invoke(item) ?? value;
-            builder.AddContent(13, label);
+            var description = Context.ItemDescription?.Invoke(item);
+            if (!string.IsNullOrEmpty(description))
+            {
+                builder.OpenElement(16, "span");
+                builder.AddAttribute(17, "class", "flex min-w-0 flex-col");
+                builder.OpenElement(18, "span");
+                builder.AddAttribute(19, "class", "truncate");
+                builder.AddContent(20, label);
+                builder.CloseElement();
+                builder.OpenElement(21, "span");
+                builder.AddAttribute(22, "class", "truncate text-xs text-muted-foreground");
+                builder.AddContent(23, description);
+                builder.CloseElement();
+                builder.CloseElement();
+            }
+            else
+            {
+                builder.AddContent(24, label);
+            }
         }
         builder.CloseElement(); // button
     };

--- a/tests/Lumeo.Tests/Components/Combobox/ComboboxDataBoundTests.cs
+++ b/tests/Lumeo.Tests/Components/Combobox/ComboboxDataBoundTests.cs
@@ -213,4 +213,127 @@ public class ComboboxDataBoundTests : IAsyncLifetime
 
         Assert.Contains("Option 1", cut.Markup);
     }
+
+    // --- ItemDescription / ItemIcon (data-bound default-renderer extensions) ---
+
+    private record TaggedItem(string Value, string Label, string? Description);
+
+    [Fact]
+    public void ItemDescription_Renders_Below_Label_When_Set()
+    {
+        var items = new object[]
+        {
+            new TaggedItem("apple", "Apple", "Crisp red fruit"),
+            new TaggedItem("banana", "Banana", "Soft yellow fruit"),
+        };
+
+        var cut = _ctx.Render(builder =>
+        {
+            builder.OpenComponent<L.Combobox>(0);
+            builder.AddAttribute(1, "Open", true);
+            builder.AddAttribute(2, "Items", (IEnumerable<object>)items);
+            builder.AddAttribute(3, "ItemValue", (Func<object, string>)(o => ((TaggedItem)o).Value));
+            builder.AddAttribute(4, "ItemText", (Func<object, string>)(o => ((TaggedItem)o).Label));
+            builder.AddAttribute(5, "ItemDescription", (Func<object, string?>)(o => ((TaggedItem)o).Description));
+            builder.AddAttribute(6, "ChildContent", (RenderFragment)(b =>
+            {
+                b.OpenComponent<L.ComboboxContent>(0);
+                b.CloseComponent();
+            }));
+            builder.CloseComponent();
+        });
+
+        Assert.Contains("Apple", cut.Markup);
+        Assert.Contains("Crisp red fruit", cut.Markup);
+        // Description rendered in the muted/sub-line styling.
+        Assert.Contains("text-muted-foreground", cut.Markup);
+    }
+
+    [Fact]
+    public void ItemDescription_Null_For_Item_Falls_Back_To_Plain_Label()
+    {
+        // When ItemDescription returns null for a given item, that row renders just the
+        // label (no extra <span> wrapper) so mixed iconed / un-iconed lists stay tight.
+        var items = new object[]
+        {
+            new TaggedItem("apple", "Apple", null),
+            new TaggedItem("banana", "Banana", "With description"),
+        };
+
+        var cut = _ctx.Render(builder =>
+        {
+            builder.OpenComponent<L.Combobox>(0);
+            builder.AddAttribute(1, "Open", true);
+            builder.AddAttribute(2, "Items", (IEnumerable<object>)items);
+            builder.AddAttribute(3, "ItemValue", (Func<object, string>)(o => ((TaggedItem)o).Value));
+            builder.AddAttribute(4, "ItemText", (Func<object, string>)(o => ((TaggedItem)o).Label));
+            builder.AddAttribute(5, "ItemDescription", (Func<object, string?>)(o => ((TaggedItem)o).Description));
+            builder.AddAttribute(6, "ChildContent", (RenderFragment)(b =>
+            {
+                b.OpenComponent<L.ComboboxContent>(0);
+                b.CloseComponent();
+            }));
+            builder.CloseComponent();
+        });
+
+        Assert.Contains("Apple", cut.Markup);
+        Assert.Contains("Banana", cut.Markup);
+        Assert.Contains("With description", cut.Markup);
+    }
+
+    [Fact]
+    public void ItemIcon_Renders_Leading_Icon_When_Provided()
+    {
+        var items = new object[] { "apple", "banana" };
+
+        var cut = _ctx.Render(builder =>
+        {
+            builder.OpenComponent<L.Combobox>(0);
+            builder.AddAttribute(1, "Open", true);
+            builder.AddAttribute(2, "Items", (IEnumerable<object>)items);
+            builder.AddAttribute(3, "ItemIcon",
+                (Func<object, RenderFragment?>)(o => b =>
+                {
+                    b.OpenElement(0, "i");
+                    b.AddAttribute(1, "data-testid", $"icon-{o}");
+                    b.CloseElement();
+                }));
+            builder.AddAttribute(4, "ChildContent", (RenderFragment)(b =>
+            {
+                b.OpenComponent<L.ComboboxContent>(0);
+                b.CloseComponent();
+            }));
+            builder.CloseComponent();
+        });
+
+        Assert.NotNull(cut.Find("[data-testid='icon-apple']"));
+        Assert.NotNull(cut.Find("[data-testid='icon-banana']"));
+    }
+
+    [Fact]
+    public void ItemIcon_Null_For_Item_Skips_Icon_Slot()
+    {
+        // Mixed list: only the first item gets an icon. The second renders without
+        // an icon span at all.
+        var items = new object[] { "apple", "banana" };
+
+        var cut = _ctx.Render(builder =>
+        {
+            builder.OpenComponent<L.Combobox>(0);
+            builder.AddAttribute(1, "Open", true);
+            builder.AddAttribute(2, "Items", (IEnumerable<object>)items);
+            builder.AddAttribute(3, "ItemIcon",
+                (Func<object, RenderFragment?>)(o => o.ToString() == "apple"
+                    ? b => { b.OpenElement(0, "i"); b.AddAttribute(1, "data-testid", "icon-apple"); b.CloseElement(); }
+                    : null));
+            builder.AddAttribute(4, "ChildContent", (RenderFragment)(b =>
+            {
+                b.OpenComponent<L.ComboboxContent>(0);
+                b.CloseComponent();
+            }));
+            builder.CloseComponent();
+        });
+
+        Assert.Single(cut.FindAll("[data-testid^='icon-']"));
+    }
 }

--- a/tests/Lumeo.Tests/Components/Combobox/ComboboxDataBoundTests.cs
+++ b/tests/Lumeo.Tests/Components/Combobox/ComboboxDataBoundTests.cs
@@ -253,7 +253,7 @@ public class ComboboxDataBoundTests : IAsyncLifetime
     public void ItemDescription_Null_For_Item_Falls_Back_To_Plain_Label()
     {
         // When ItemDescription returns null for a given item, that row renders just the
-        // label (no extra <span> wrapper) so mixed iconed / un-iconed lists stay tight.
+        // label (no extra <span> wrapper) so mixed described / undescribed lists stay tight.
         var items = new object[]
         {
             new TaggedItem("apple", "Apple", null),

--- a/tests/Lumeo.Tests/Components/Select/SelectDataBoundTests.cs
+++ b/tests/Lumeo.Tests/Components/Select/SelectDataBoundTests.cs
@@ -230,4 +230,97 @@ public class SelectDataBoundTests : IAsyncLifetime
 
         Assert.Contains("Option 1", cut.Markup);
     }
+
+    // --- ItemDescription / ItemIcon (data-bound default-renderer extensions) ---
+
+    private record TaggedItem(string Value, string Label, string? Description);
+
+    [Fact]
+    public void ItemDescription_Renders_Below_Label_When_Set()
+    {
+        var items = new object[]
+        {
+            new TaggedItem("apple", "Apple", "Crisp red fruit"),
+        };
+
+        var cut = _ctx.Render(builder =>
+        {
+            builder.OpenComponent<L.Select>(0);
+            builder.AddAttribute(1, "Open", true);
+            builder.AddAttribute(2, "Items", (IEnumerable<object>)items);
+            builder.AddAttribute(3, "ItemValue", (Func<object, string>)(o => ((TaggedItem)o).Value));
+            builder.AddAttribute(4, "ItemText", (Func<object, string>)(o => ((TaggedItem)o).Label));
+            builder.AddAttribute(5, "ItemDescription", (Func<object, string?>)(o => ((TaggedItem)o).Description));
+            builder.AddAttribute(6, "ChildContent", (RenderFragment)(b =>
+            {
+                b.OpenComponent<L.SelectTrigger>(0);
+                b.CloseComponent();
+                b.OpenComponent<L.SelectContent>(1);
+                b.CloseComponent();
+            }));
+            builder.CloseComponent();
+        });
+
+        Assert.Contains("Apple", cut.Markup);
+        Assert.Contains("Crisp red fruit", cut.Markup);
+        Assert.Contains("text-muted-foreground", cut.Markup);
+    }
+
+    [Fact]
+    public void ItemIcon_Renders_Leading_Icon_When_Provided()
+    {
+        var items = new object[] { "apple", "banana" };
+
+        var cut = _ctx.Render(builder =>
+        {
+            builder.OpenComponent<L.Select>(0);
+            builder.AddAttribute(1, "Open", true);
+            builder.AddAttribute(2, "Items", (IEnumerable<object>)items);
+            builder.AddAttribute(3, "ItemIcon",
+                (Func<object, RenderFragment?>)(o => b =>
+                {
+                    b.OpenElement(0, "i");
+                    b.AddAttribute(1, "data-testid", $"icon-{o}");
+                    b.CloseElement();
+                }));
+            builder.AddAttribute(4, "ChildContent", (RenderFragment)(b =>
+            {
+                b.OpenComponent<L.SelectTrigger>(0);
+                b.CloseComponent();
+                b.OpenComponent<L.SelectContent>(1);
+                b.CloseComponent();
+            }));
+            builder.CloseComponent();
+        });
+
+        Assert.NotNull(cut.Find("[data-testid='icon-apple']"));
+        Assert.NotNull(cut.Find("[data-testid='icon-banana']"));
+    }
+
+    [Fact]
+    public void ItemIcon_Null_For_Item_Skips_Icon_Slot()
+    {
+        var items = new object[] { "apple", "banana" };
+
+        var cut = _ctx.Render(builder =>
+        {
+            builder.OpenComponent<L.Select>(0);
+            builder.AddAttribute(1, "Open", true);
+            builder.AddAttribute(2, "Items", (IEnumerable<object>)items);
+            builder.AddAttribute(3, "ItemIcon",
+                (Func<object, RenderFragment?>)(o => o.ToString() == "apple"
+                    ? b => { b.OpenElement(0, "i"); b.AddAttribute(1, "data-testid", "icon-apple"); b.CloseElement(); }
+                    : null));
+            builder.AddAttribute(4, "ChildContent", (RenderFragment)(b =>
+            {
+                b.OpenComponent<L.SelectTrigger>(0);
+                b.CloseComponent();
+                b.OpenComponent<L.SelectContent>(1);
+                b.CloseComponent();
+            }));
+            builder.CloseComponent();
+        });
+
+        Assert.Single(cut.FindAll("[data-testid^='icon-']"));
+    }
 }


### PR DESCRIPTION
## Summary

Closes #134 — adds `ItemDescription` + `ItemIcon` to the data-bound rendering path of both `Combobox` and `Select`, mirroring the existing `ItemValue` / `ItemText` / `ItemGroup` / `ItemDisabled` set.

### New parameters

```csharp
[Parameter] public Func<object, string?>? ItemDescription { get; set; }
[Parameter] public Func<object, RenderFragment?>? ItemIcon { get; set; }
```

Both drive the default item renderer; consumers no longer need a custom `ItemTemplate` for the standard "icon + label + sub-line" pattern that command pickers ship out of the box. Returning `null` per item skips just that row's slot — mixed iconed / un-iconed (or with/without description) lists stay tight.

```razor
<Combobox Items="_actions"
          ItemValue="@(o => ((ActionItem)o).Id)"
          ItemText="@(o => ((ActionItem)o).Label)"
          ItemDescription="@(o => ((ActionItem)o).Hint)"
          ItemIcon="@(o => RenderActionIcon((ActionItem)o))">
    <ComboboxInput Placeholder="Run a command..." />
    <ComboboxContent />
</Combobox>
```

When `ItemTemplate` is set it wins as before — the new fields only apply to the default path.

## Release train

This is purely additive parameters; ships in the **3.9.0 release train** alongside:
- #140 — Input ShowCount + MaxLength counter
- #141 — SelectGroup upgrade + Combobox parity fixes (carries the `Directory.Build.props` bump for the whole train)

This PR intentionally does **not** bump `Directory.Build.props` to avoid a trivial conflict with #141.

## Test plan
- [x] 4 new bUnit tests on `ComboboxDataBoundTests` (description renders, null falls back to plain label, icon renders, null icon skips slot) — pass
- [x] 3 new bUnit tests on `SelectDataBoundTests` — pass
- [x] 114/114 Combobox + Select tests pass (no regressions)
- [x] `dotnet build src/Lumeo + docs/Lumeo.Docs -c Release` succeeds; one new docs demo (command-palette pattern)
- [ ] CI build-and-test + e2e

---
_Generated by [Claude Code](https://claude.ai/code/session_01LJmBFYeCdQj2G2epoZaRzQ)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Combobox and Select components now support item descriptions and leading icons for enhanced option rendering through data-bound configuration.

* **Documentation**
  * Added demo showcasing Combobox with data-bound items, icons, and descriptions.

* **Tests**
  * Comprehensive test coverage for ItemDescription and ItemIcon functionality across both components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->