### PR TITLE
feat(datagrid): DataGridColumnGroup + per-column FooterFormat (closes #135)

### DIFF
--- a/src/Lumeo.DataGrid/UI/DataGrid/DataGrid.razor
+++ b/src/Lumeo.DataGrid/UI/DataGrid/DataGrid.razor
@@ -1058,6 +1058,8 @@
             existing.FilterType = column.FilterType;
             existing.Aggregate = column.Aggregate;
             existing.Format = column.Format;
+            existing.FooterFormat = column.FooterFormat;
+            existing.ColumnGroupId = column.ColumnGroupId;
             existing.CellTemplate = column.CellTemplate;
             existing.HeaderTemplate = column.HeaderTemplate;
             existing.EditTemplate = column.EditTemplate;

--- a/src/Lumeo.DataGrid/UI/DataGrid/DataGrid.razor
+++ b/src/Lumeo.DataGrid/UI/DataGrid/DataGrid.razor
@@ -88,7 +88,8 @@
         OnHeaderKeyDown: HandleHeaderKeyDownAsync,
         Striped: Striped,
         HasPinnedLeft: _orderedColumns.Any(c => c.Visible && c.Pin == PinDirection.Left),
-        Hoverable: Hoverable
+        Hoverable: Hoverable,
+        ColumnGroups: _columnGroups
     );
 }
 
@@ -1104,6 +1105,24 @@
             _ = InvokeAsync(StateHasChanged);
         }
     }
+
+    // --- Column groups (parent header that spans multiple data columns) ---
+    private List<DataGridColumnGroupInfo> _columnGroups = new();
+
+    /// <summary>
+    /// Called by <see cref="DataGridColumnGroup{TItem}"/> children during initialization to
+    /// register a labelled parent header. The grid uses it during header rendering to add a
+    /// second <c>tr</c> that spans the grouped columns via colspan. Idempotent on group id.
+    /// </summary>
+    public void RegisterColumnGroup(DataGridColumnGroupInfo info)
+    {
+        if (_columnGroups.Any(g => g.Id == info.Id)) return;
+        _columnGroups.Add(info);
+    }
+
+    /// <summary>The registered column groups, surfaced via <see cref="DataGridContext{TItem}"/>
+    /// for the header to look up labels by id.</summary>
+    public IReadOnlyList<DataGridColumnGroupInfo> ColumnGroups => _columnGroups;
 
     /// <summary>Stable identity for a column: prefer Field (user-declared), fallback to Id.</summary>
     private static string ColumnKey(DataGridColumn<TItem> column) =>

--- a/src/Lumeo.DataGrid/UI/DataGrid/DataGridColumn.cs
+++ b/src/Lumeo.DataGrid/UI/DataGrid/DataGridColumn.cs
@@ -32,6 +32,15 @@ public class DataGridColumn<TItem>
     public DataGridFilterType FilterType { get; set; } = DataGridFilterType.Text;
     public AggregateType Aggregate { get; set; } = AggregateType.None;
     public string? Format { get; set; }
+    /// <summary>Optional .NET format string used by the footer aggregate strip — overrides
+    /// the cell <see cref="Format"/> for the totals row (e.g. cell shows <c>"C2"</c> and
+    /// totals show <c>"N0"</c>). When null the footer falls back to <see cref="Format"/>,
+    /// then to the historic <c>"N2"</c> default.</summary>
+    public string? FooterFormat { get; set; }
+    /// <summary>Id of the <see cref="DataGridColumnGroup{TItem}"/> this column belongs to,
+    /// when present. Drives the extra header row that spans grouped columns with a
+    /// single labelled <c>th</c>. Null for ungrouped columns.</summary>
+    public string? ColumnGroupId { get; set; }
     public string? CssClass { get; set; }
     public string? HeaderCssClass { get; set; }
     public RenderFragment<TItem>? CellTemplate { get; set; }

--- a/src/Lumeo.DataGrid/UI/DataGrid/DataGridColumnDef.razor
+++ b/src/Lumeo.DataGrid/UI/DataGrid/DataGridColumnDef.razor
@@ -3,6 +3,9 @@
 
 @code {
     [CascadingParameter] private DataGrid<TItem>? ParentGrid { get; set; }
+    // Set by the enclosing <DataGridColumnGroup>, when present. Forwarded to the
+    // registered DataGridColumn so the header can emit the spanning parent <th>.
+    [CascadingParameter(Name = "ColumnGroupId")] private string? ColumnGroupId { get; set; }
 
     [Parameter] public string? Title { get; set; }
     [Parameter] public string? Field { get; set; }
@@ -14,6 +17,10 @@
     [Parameter] public DataGridFilterType FilterType { get; set; } = DataGridFilterType.Text;
     [Parameter] public AggregateType Aggregate { get; set; } = AggregateType.None;
     [Parameter] public string? Format { get; set; }
+    /// <summary>Optional .NET format string for the footer aggregate strip — overrides
+    /// <see cref="Format"/> for the totals row only. Useful when the cell format differs
+    /// from the desired totals format (e.g. cells <c>"C2"</c>, totals <c>"N0"</c>).</summary>
+    [Parameter] public string? FooterFormat { get; set; }
     [Parameter] public PinDirection Pin { get; set; } = PinDirection.None;
     [Parameter] public RenderFragment<TItem>? CellTemplate { get; set; }
     [Parameter] public RenderFragment? HeaderTemplate { get; set; }
@@ -56,6 +63,8 @@
             FilterType = FilterType,
             Aggregate = Aggregate,
             Format = Format,
+            FooterFormat = FooterFormat,
+            ColumnGroupId = ColumnGroupId,
             Pin = Pin,
             CellTemplate = CellTemplate,
             HeaderTemplate = HeaderTemplate,

--- a/src/Lumeo.DataGrid/UI/DataGrid/DataGridColumnGroup.razor
+++ b/src/Lumeo.DataGrid/UI/DataGrid/DataGridColumnGroup.razor
@@ -1,0 +1,44 @@
+@namespace Lumeo
+@typeparam TItem
+
+@*  Wraps a contiguous run of <DataGridColumnDef>s under a labelled parent header.
+    The grid renders a second <tr> above the data-column row with a single <th>
+    spanning the grouped columns via colspan, matching DevExpress / Telerik /
+    MUI X / AG Grid's "grouped headers" feature.
+
+    Usage:
+        <DataGridColumnGroup TItem="Sale" Label="Pricing">
+            <DataGridColumnDef Title="Revenue"  Field="Revenue"  Format="C0" />
+            <DataGridColumnDef Title="Cost"     Field="Cost"     Format="C0" />
+            <DataGridColumnDef Title="Margin %" Field="Margin"   Format="P0" />
+        </DataGridColumnGroup>
+
+    The group registers itself with the parent grid and cascades its id to its
+    DataGridColumnDef children. The header row stays flat — colspan handles the
+    visual nesting — so existing row + body rendering is untouched. *@
+
+<CascadingValue Value="_groupId" Name="ColumnGroupId" IsFixed="true">
+    @ChildContent
+</CascadingValue>
+
+@code {
+    [CascadingParameter] private DataGrid<TItem>? ParentGrid { get; set; }
+
+    /// <summary>Header label shown in the spanning <c>th</c> above the grouped columns.</summary>
+    [Parameter] public string Label { get; set; } = "";
+
+    /// <summary>Extra classes for the spanning header cell — theming hook for the group.</summary>
+    [Parameter] public string? HeaderClass { get; set; }
+
+    [Parameter] public RenderFragment? ChildContent { get; set; }
+
+    // Stable per-instance id so the cascaded ColumnGroupId on child DataGridColumnDefs
+    // is matched to one specific DataGridColumnGroup<TItem> registration.
+    // LumeoIds isn't in this assembly (lives in core Lumeo); a plain Guid suffix is fine
+    // since the id is internal — only used to correlate the group header with its child
+    // columns' ColumnGroupId cascade.
+    private readonly string _groupId = "dgcg-" + Guid.NewGuid().ToString("N")[..8];
+
+    protected override void OnInitialized()
+        => ParentGrid?.RegisterColumnGroup(new DataGridColumnGroupInfo(_groupId, Label, HeaderClass));
+}

--- a/src/Lumeo.DataGrid/UI/DataGrid/DataGridContext.cs
+++ b/src/Lumeo.DataGrid/UI/DataGrid/DataGridContext.cs
@@ -132,5 +132,11 @@ public record DataGridContext<TItem>(
     bool HasPinnedLeft,
     /// <summary>True when the grid has <c>Hoverable="true"</c>. Used by pinned cells
     /// to apply a group-hover tint that matches the row hover highlight.</summary>
-    bool Hoverable
+    bool Hoverable,
+
+    // --- Column groups (parent header that spans multiple data columns) ---
+    /// <summary>The registered <c>DataGridColumnGroup</c>s. <see cref="DataGridHeader{TItem}"/>
+    /// reads this to render a second <c>tr</c> above the data-column row with one <c>th</c>
+    /// per group spanning its members via colspan. Empty when no groups are declared.</summary>
+    IReadOnlyList<DataGridColumnGroupInfo> ColumnGroups
 );

--- a/src/Lumeo.DataGrid/UI/DataGrid/DataGridFooter.razor
+++ b/src/Lumeo.DataGrid/UI/DataGrid/DataGridFooter.razor
@@ -79,7 +79,12 @@
         }
 
         if (numericValues.Count == 0) return "-";
-        return aggregator(numericValues).ToString(format, System.Globalization.CultureInfo.CurrentCulture);
+        // Use the grid's cascaded Culture so footer totals format the same way the cells do
+        // (DataGrid.Culture lets a single grid render in a non-app-default locale; without
+        // this footer-side override we'd silently fall back to CultureInfo.CurrentCulture
+        // and mismatch the column's own cell formatting).
+        var culture = Context?.Culture ?? System.Globalization.CultureInfo.CurrentCulture;
+        return aggregator(numericValues).ToString(format, culture);
     }
 
     private string GetAggregateLabel(AggregateType aggregate) => aggregate switch

--- a/src/Lumeo.DataGrid/UI/DataGrid/DataGridFooter.razor
+++ b/src/Lumeo.DataGrid/UI/DataGrid/DataGridFooter.razor
@@ -45,19 +45,22 @@
         if (items.Count == 0) return "-";
 
         var values = items.Select(i => column.GetValue(i)).Where(v => v is not null).ToList();
+        // FooterFormat wins; falls back to the cell Format; "N2" is the historic default
+        // when neither is set so existing grids keep their familiar 2-decimal totals.
+        var format = column.FooterFormat ?? column.Format ?? "N2";
 
         return column.Aggregate switch
         {
             AggregateType.Count => values.Count.ToString(),
-            AggregateType.Sum => ComputeNumeric(values, vals => vals.Sum()),
-            AggregateType.Average => ComputeNumeric(values, vals => vals.Average()),
-            AggregateType.Min => ComputeNumeric(values, vals => vals.Min()),
-            AggregateType.Max => ComputeNumeric(values, vals => vals.Max()),
+            AggregateType.Sum => ComputeNumeric(values, vals => vals.Sum(), format),
+            AggregateType.Average => ComputeNumeric(values, vals => vals.Average(), format),
+            AggregateType.Min => ComputeNumeric(values, vals => vals.Min(), format),
+            AggregateType.Max => ComputeNumeric(values, vals => vals.Max(), format),
             _ => ""
         };
     }
 
-    private string ComputeNumeric(List<object?> values, Func<IEnumerable<double>, double> aggregator)
+    private string ComputeNumeric(List<object?> values, Func<IEnumerable<double>, double> aggregator, string format)
     {
         var numericValues = new List<double>();
         foreach (var v in values)
@@ -76,8 +79,7 @@
         }
 
         if (numericValues.Count == 0) return "-";
-        var result = aggregator(numericValues);
-        return result.ToString("N2");
+        return aggregator(numericValues).ToString(format, System.Globalization.CultureInfo.CurrentCulture);
     }
 
     private string GetAggregateLabel(AggregateType aggregate) => aggregate switch

--- a/src/Lumeo.DataGrid/UI/DataGrid/DataGridHeader.razor
+++ b/src/Lumeo.DataGrid/UI/DataGrid/DataGridHeader.razor
@@ -2,7 +2,35 @@
 @typeparam TItem
 
 <thead data-slot="datagrid-header" class="@CssClass" @attributes="AdditionalAttributes">
-    <tr role="row" aria-rowindex="1">
+    @* When the grid has DataGridColumnGroups, render a parent header row above the data
+       row. Each registered group spans its child columns via colspan; columns without a
+       group get a blank cell so visual alignment stays intact. The data row that follows
+       carries the actual sort / filter / resize handles per column. *@
+    @if (Context is not null && HasColumnGroups)
+    {
+        <tr role="row" aria-rowindex="1" class="border-b border-border/40">
+            @if (Context.RowReorderable) { <th class="bg-muted/30"></th> }
+            @if (Context.SelectionMode != DataGridSelectionMode.None) { <th class="bg-muted/30"></th> }
+            @if (HasDetailTemplate) { <th class="bg-muted/30"></th> }
+            @foreach (var run in GetGroupHeaderRuns())
+            {
+                if (run.Info is { } info)
+                {
+                    <th colspan="@run.Span"
+                        class="@($"px-3 py-2 text-xs font-semibold text-foreground/80 bg-muted/40 text-center border-x border-border/40 {info.HeaderClass}".Trim())">
+                        @info.Label
+                    </th>
+                }
+                else
+                {
+                    @* Ungrouped column(s) — colspan over the run keeps the parent row aligned. *@
+                    <th colspan="@run.Span" class="bg-muted/30"></th>
+                }
+            }
+            @if (Context.EditMode == DataGridEditMode.Row) { <th class="bg-muted/30"></th> }
+        </tr>
+    }
+    <tr role="row" aria-rowindex="@(HasColumnGroups ? 2 : 1)">
         @* Row reorder handle column *@
         @if (Context?.RowReorderable == true)
         {
@@ -148,6 +176,46 @@
     }
 
     private int GetTotalSortCount() => Context?.Sorts.Count(s => s.Direction != SortDirection.None) ?? 0;
+
+    private bool HasColumnGroups
+        => Context is not null
+           && Context.ColumnGroups.Count > 0
+           && Context.VisibleColumns.Any(c => c.ColumnGroupId is not null);
+
+    // A contiguous run of visible columns that all share the same ColumnGroupId.
+    // Info is the resolved group metadata (null for the "ungrouped" runs). Span is
+    // the colspan to emit on the parent <th>.
+    private record GroupHeaderRun(DataGridColumnGroupInfo? Info, int Span);
+
+    // Compute the parent-row cells in one pass over VisibleColumns. Each maximal run
+    // of consecutive columns with the same ColumnGroupId collapses into one cell.
+    private IEnumerable<GroupHeaderRun> GetGroupHeaderRuns()
+    {
+        if (Context is null) yield break;
+        var groupsById = Context.ColumnGroups.ToDictionary(g => g.Id);
+        string? currentId = null;
+        DataGridColumnGroupInfo? currentInfo = null;
+        var span = 0;
+        foreach (var col in Context.VisibleColumns)
+        {
+            if (col.ColumnGroupId == currentId)
+            {
+                span++;
+                continue;
+            }
+            if (span > 0)
+            {
+                yield return new GroupHeaderRun(currentInfo, span);
+            }
+            currentId = col.ColumnGroupId;
+            currentInfo = currentId is not null && groupsById.TryGetValue(currentId, out var info) ? info : null;
+            span = 1;
+        }
+        if (span > 0)
+        {
+            yield return new GroupHeaderRun(currentInfo, span);
+        }
+    }
 
     private void OnSelectAllChanged(bool value)
     {

--- a/src/Lumeo.DataGrid/UI/DataGrid/DataGridRow.razor
+++ b/src/Lumeo.DataGrid/UI/DataGrid/DataGridRow.razor
@@ -169,8 +169,12 @@
     private string DetailChevronClasses =>
         $"h-4 w-4 shrink-0 text-muted-foreground transition-transform duration-200{(IsExpanded ? "" : " -rotate-90")}";
 
-    // 1-based ARIA row index; header occupies row 1 so body rows start at 2.
-    private int AriaRowIndex => RowIndex + 2;
+    // 1-based ARIA row index. The header normally occupies row 1, so body rows start at 2.
+    // When DataGridColumnGroups are declared the header is a 2-row block (parent labels +
+    // data-column row) and body rows must start at 3 — otherwise the first body row reports
+    // the same aria-rowindex the data-header already uses, giving assistive tech duplicate
+    // row positions.
+    private int AriaRowIndex => RowIndex + (Context?.ColumnGroups.Count > 0 ? 3 : 2);
 
     // ARIA tree-grid attributes — only meaningful when IsTreeGrid is true.
     private int? AriaLevel => (Context?.IsTreeGrid == true) ? (Context.TreeLevelOf(Item) + 1) : null;

--- a/src/Lumeo.DataGrid/UI/DataGrid/DataGridState.cs
+++ b/src/Lumeo.DataGrid/UI/DataGrid/DataGridState.cs
@@ -24,6 +24,11 @@ public enum DataGridExportFormat
 
 public record SortDescriptor(string Field, SortDirection Direction);
 
+/// <summary>Metadata for a <c>DataGridColumnGroup</c> — the labelled parent header that
+/// spans one or more contiguous data columns via colspan. The grid keeps an ordered list
+/// of these for the header renderer to look up by id.</summary>
+public record DataGridColumnGroupInfo(string Id, string Label, string? HeaderClass);
+
 public record FilterDescriptor(
     string Field,
     FilterOperator Operator,

--- a/tests/Lumeo.Tests/Components/DataGrid/DataGridColumnGroupTests.cs
+++ b/tests/Lumeo.Tests/Components/DataGrid/DataGridColumnGroupTests.cs
@@ -1,0 +1,218 @@
+using Bunit;
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Rendering;
+using Xunit;
+using Lumeo;
+using Lumeo.Tests.Helpers;
+
+namespace Lumeo.Tests.Components.DataGrid;
+
+/// <summary>
+/// Tests for <see cref="DataGridColumnGroup{TItem}"/> — the labelled parent header that
+/// spans multiple data columns via colspan, plus the new <c>FooterFormat</c> column
+/// parameter that lets the totals row format independently from the cell.
+/// </summary>
+public class DataGridColumnGroupTests : IAsyncLifetime
+{
+    private readonly BunitContext _ctx = new();
+
+    public DataGridColumnGroupTests() => _ctx.AddLumeoServices();
+
+    public Task InitializeAsync() => Task.CompletedTask;
+    public async Task DisposeAsync() => await _ctx.DisposeAsync();
+
+    private record Sale(string Product, decimal Revenue, decimal Cost);
+
+    private static IEnumerable<Sale> Sales => new[]
+    {
+        new Sale("A", 100m, 40m),
+        new Sale("B", 200m, 80m),
+        new Sale("C", 300m, 90m),
+    };
+
+    // Renders a DataGrid with two column groups (Sales: Revenue+Cost, Meta: Product).
+    private IRenderedComponent<IComponent> RenderGrouped()
+    {
+        return _ctx.Render(builder =>
+        {
+            builder.OpenComponent<DataGrid<Sale>>(0);
+            builder.AddAttribute(1, "Items", Sales);
+            builder.AddAttribute(2, "ChildContent", (RenderFragment)(b =>
+            {
+                // Meta group with just Product
+                b.OpenComponent<DataGridColumnGroup<Sale>>(0);
+                b.AddAttribute(1, "Label", "Meta");
+                b.AddAttribute(2, "ChildContent", (RenderFragment)(g =>
+                {
+                    g.OpenComponent<DataGridColumnDef<Sale>>(0);
+                    g.AddAttribute(1, "Title", "Product");
+                    g.AddAttribute(2, "Field", "Product");
+                    g.CloseComponent();
+                }));
+                b.CloseComponent();
+
+                // Pricing group spans Revenue + Cost
+                b.OpenComponent<DataGridColumnGroup<Sale>>(3);
+                b.AddAttribute(1, "Label", "Pricing");
+                b.AddAttribute(2, "ChildContent", (RenderFragment)(g =>
+                {
+                    g.OpenComponent<DataGridColumnDef<Sale>>(0);
+                    g.AddAttribute(1, "Title", "Revenue");
+                    g.AddAttribute(2, "Field", "Revenue");
+                    g.CloseComponent();
+                    g.OpenComponent<DataGridColumnDef<Sale>>(3);
+                    g.AddAttribute(1, "Title", "Cost");
+                    g.AddAttribute(2, "Field", "Cost");
+                    g.CloseComponent();
+                }));
+                b.CloseComponent();
+            }));
+            builder.CloseComponent();
+        });
+    }
+
+    [Fact]
+    public void Renders_Parent_Header_Row_When_Column_Groups_Declared()
+    {
+        var cut = RenderGrouped();
+
+        // <thead> contains two <tr> when groups exist: the parent row + the data row.
+        var thead = cut.Find("thead");
+        var headerRows = thead.QuerySelectorAll("tr");
+        Assert.Equal(2, headerRows.Length);
+    }
+
+    [Fact]
+    public void Group_Label_Appears_In_Parent_Header()
+    {
+        var cut = RenderGrouped();
+
+        Assert.Contains("Pricing", cut.Markup);
+        Assert.Contains("Meta", cut.Markup);
+    }
+
+    [Fact]
+    public void Group_Header_Spans_Member_Columns_Via_Colspan()
+    {
+        var cut = RenderGrouped();
+
+        // Find the parent row (first <tr> inside <thead>).
+        var parentRow = cut.Find("thead tr");
+        // Pricing group spans 2 columns (Revenue + Cost) → colspan="2".
+        var pricingTh = parentRow.QuerySelectorAll("th").First(t => t.TextContent.Contains("Pricing"));
+        Assert.Equal("2", pricingTh.GetAttribute("colspan"));
+    }
+
+    [Fact]
+    public void Ungrouped_Columns_Get_Blank_Parent_Cells()
+    {
+        // Column outside any group → blank <th> in the parent row keeps alignment.
+        var cut = _ctx.Render(builder =>
+        {
+            builder.OpenComponent<DataGrid<Sale>>(0);
+            builder.AddAttribute(1, "Items", Sales);
+            builder.AddAttribute(2, "ChildContent", (RenderFragment)(b =>
+            {
+                // Ungrouped column first
+                b.OpenComponent<DataGridColumnDef<Sale>>(0);
+                b.AddAttribute(1, "Title", "Product");
+                b.AddAttribute(2, "Field", "Product");
+                b.CloseComponent();
+
+                b.OpenComponent<DataGridColumnGroup<Sale>>(3);
+                b.AddAttribute(1, "Label", "Pricing");
+                b.AddAttribute(2, "ChildContent", (RenderFragment)(g =>
+                {
+                    g.OpenComponent<DataGridColumnDef<Sale>>(0);
+                    g.AddAttribute(1, "Title", "Revenue");
+                    g.AddAttribute(2, "Field", "Revenue");
+                    g.CloseComponent();
+                }));
+                b.CloseComponent();
+            }));
+            builder.CloseComponent();
+        });
+
+        // Two rows in the header now. The parent row has 2 ths: one blank + Pricing.
+        var thead = cut.Find("thead");
+        Assert.Equal(2, thead.QuerySelectorAll("tr").Length);
+        var parentTHs = thead.QuerySelectorAll("tr").First().QuerySelectorAll("th");
+        Assert.Equal(2, parentTHs.Length);
+        Assert.Contains(parentTHs, th => th.TextContent.Contains("Pricing"));
+        // The other one is empty
+        Assert.Contains(parentTHs, th => string.IsNullOrWhiteSpace(th.TextContent));
+    }
+
+    [Fact]
+    public void No_Parent_Row_When_No_Column_Groups()
+    {
+        // Plain DataGrid without any DataGridColumnGroup keeps the single header row
+        // (no behavioural change for existing consumers).
+        var cut = _ctx.Render(builder =>
+        {
+            builder.OpenComponent<DataGrid<Sale>>(0);
+            builder.AddAttribute(1, "Items", Sales);
+            builder.AddAttribute(2, "ChildContent", (RenderFragment)(b =>
+            {
+                b.OpenComponent<DataGridColumnDef<Sale>>(0);
+                b.AddAttribute(1, "Title", "Product");
+                b.AddAttribute(2, "Field", "Product");
+                b.CloseComponent();
+            }));
+            builder.CloseComponent();
+        });
+
+        Assert.Single(cut.Find("thead").QuerySelectorAll("tr"));
+    }
+
+    // --- FooterFormat ---
+
+    [Fact]
+    public void Footer_Uses_FooterFormat_When_Set()
+    {
+        var cut = _ctx.Render(builder =>
+        {
+            builder.OpenComponent<DataGrid<Sale>>(0);
+            builder.AddAttribute(1, "Items", Sales);
+            builder.AddAttribute(2, "ChildContent", (RenderFragment)(b =>
+            {
+                b.OpenComponent<DataGridColumnDef<Sale>>(0);
+                b.AddAttribute(1, "Title", "Revenue");
+                b.AddAttribute(2, "Field", "Revenue");
+                b.AddAttribute(3, "Aggregate", AggregateType.Sum);
+                b.AddAttribute(4, "Format", "C2");          // cells: currency w/ 2 decimals
+                b.AddAttribute(5, "FooterFormat", "N0");    // totals: plain integer
+                b.CloseComponent();
+            }));
+            builder.CloseComponent();
+        });
+
+        // 100 + 200 + 300 = 600, formatted as N0 → "600" (no decimals).
+        var footer = cut.Find("[data-slot='datagrid-aggregate-strip']");
+        Assert.Contains("600", footer.TextContent);
+    }
+
+    [Fact]
+    public void Footer_Falls_Back_To_Column_Format_When_FooterFormat_Unset()
+    {
+        var cut = _ctx.Render(builder =>
+        {
+            builder.OpenComponent<DataGrid<Sale>>(0);
+            builder.AddAttribute(1, "Items", Sales);
+            builder.AddAttribute(2, "ChildContent", (RenderFragment)(b =>
+            {
+                b.OpenComponent<DataGridColumnDef<Sale>>(0);
+                b.AddAttribute(1, "Title", "Revenue");
+                b.AddAttribute(2, "Field", "Revenue");
+                b.AddAttribute(3, "Aggregate", AggregateType.Sum);
+                b.AddAttribute(4, "Format", "N0"); // cell + totals both N0
+                b.CloseComponent();
+            }));
+            builder.CloseComponent();
+        });
+
+        var footer = cut.Find("[data-slot='datagrid-aggregate-strip']");
+        Assert.Contains("600", footer.TextContent);
+        Assert.DoesNotContain("600.00", footer.TextContent);
+    }
+}


### PR DESCRIPTION
## Summary

Closes #135 — two additive DataGrid features for the 3.9.0 release train.

### `DataGridColumnGroup<TItem>` — labelled parent headers

New wrapper component. Renders a second `<tr>` above the data row with a single `<th>` spanning its member columns via `colspan`:

```razor
<DataGridColumnGroup TItem="Sale" Label="Pricing">
    <DataGridColumnDef Title="Revenue"  Field="Revenue" Format="C0" />
    <DataGridColumnDef Title="Cost"     Field="Cost"    Format="C0" />
    <DataGridColumnDef Title="Margin %" Field="Margin"  Format="P0" />
</DataGridColumnGroup>
```

**Mechanics**: the group cascades a `ColumnGroupId` to its `DataGridColumnDef` children, which forward it into the registered `DataGridColumn`. The header walks `VisibleColumns` once, collapsing maximal runs of same-group columns into a single `<th colspan=N>`. Columns outside any group get a blank parent cell so visual alignment stays intact. The data row is untouched, so sort / filter / resize / pinning / row-edit all continue to work without change.

### `FooterFormat` — per-column footer formatting

`DataGridFooter` already aggregates over the full processed item list (so issue #135's "no total row without GroupBy" is partly out of date — `Aggregate=Sum` on any column already renders a total). What was missing: the footer hardcoded `"N2"` and ignored the column's own `Format`. The new `FooterFormat` parameter gives totals their own format string; when null the footer falls back to the column `Format`, then to the historic `"N2"` default. Net effect: a column with `Format="C2"` now produces a currency-formatted total instead of `"600.00"` without the consumer changing anything.

### Versioning

Both changes ship in the **3.9.0 release train** with #140, #141, #142. The `Directory.Build.props` bump lives in #141.

## Test plan
- [x] 7 new bUnit tests in `DataGridColumnGroupTests` (parent row, label, colspan computation, ungrouped runs, no-groups regression, `FooterFormat` override, fallback to `Format`) — pass
- [x] 207/207 DataGrid tests pass (no regressions)
- [x] `dotnet build src/Lumeo.DataGrid -c Release` succeeds
- [ ] CI build-and-test + e2e

---
_Generated by [Claude Code](https://claude.ai/code/session_01LJmBFYeCdQj2G2epoZaRzQ)_