### PR TITLE
feat(charts): ChartThreshold + ChartReferenceZone declarative annotations (partial #137)

### DIFF
--- a/src/Lumeo.Charts/UI/Chart/Chart.razor
+++ b/src/Lumeo.Charts/UI/Chart/Chart.razor
@@ -2,6 +2,15 @@
 @using Blazicons
 @implements IAsyncDisposable
 
+@* ChildContent renders declarative annotations (ChartThreshold, ChartReferenceZone).
+   Wrapped in a hidden CascadingValue so the children themselves emit no DOM — they just
+   register their config via the cascaded ChartAnnotationsContext. The chart picks up
+   the registrations in GetOptionsJson and merges them into series[0].markLine /
+   markArea, without mutating the consumer-passed EChartOption. *@
+<CascadingValue Value="_annotations" IsFixed="true">
+    @ChildContent
+</CascadingValue>
+
 @if (_initError is not null)
 {
     <div class="@($"flex items-center justify-center text-sm text-destructive border border-destructive/30 rounded-md bg-destructive/5 {Class}".Trim())" style="@StyleStr" @attributes="AdditionalAttributes">
@@ -49,6 +58,9 @@ else
 @code {
     [Parameter] public EChartOption? Option { get; set; }
     [Parameter] public string? OptionJson { get; set; }
+    /// <summary>Declarative children — <see cref="ChartThreshold"/> and
+    /// <see cref="ChartReferenceZone"/>. Other content renders nothing visible.</summary>
+    [Parameter] public RenderFragment? ChildContent { get; set; }
     [Parameter] public string? Theme { get; set; }
     [Parameter] public string? EChartsSource { get; set; }
     [Parameter] public string Width { get; set; } = "100%";
@@ -102,6 +114,16 @@ else
     [Parameter] public string? LoadingText { get; set; }
 
     private readonly string _chartId = $"lumeo-chart-{Guid.NewGuid():N}";
+    // Cascaded to <ChartThreshold> and <ChartReferenceZone> children. They register
+    // their config here on OnParametersSet; GetOptionsJson merges the registrations
+    // into the option JSON before handing it to ECharts. On change we re-emit the
+    // updated JSON via OnAfterRenderAsync's existing _lastJson diff path.
+    private readonly ChartAnnotationsContext _annotations;
+
+    public Chart()
+    {
+        _annotations = new ChartAnnotationsContext(onChanged: () => InvokeAsync(StateHasChanged));
+    }
     private IJSObjectReference? _module;
     private DotNetObjectReference<Chart>? _selfRef;
     private bool _initialized;
@@ -358,17 +380,27 @@ else
 
     private string GetOptionsJson()
     {
-        if (!string.IsNullOrEmpty(OptionJson)) return OptionJson;
-        try
+        string baseJson;
+        if (!string.IsNullOrEmpty(OptionJson)) baseJson = OptionJson;
+        else
         {
-            return Option?.ToJson() ?? "{}";
+            try { baseJson = Option?.ToJson() ?? "{}"; }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine($"[Lumeo Chart] Serialization failed: {ex.Message}");
+                baseJson = "{}";
+            }
         }
-        catch (Exception ex)
-        {
-            Console.Error.WriteLine($"[Lumeo Chart] Serialization failed: {ex.Message}");
-            return "{}";
-        }
+        return MergeAnnotations(baseJson);
     }
+
+    // Merge cascaded <ChartThreshold> / <ChartReferenceZone> registrations into
+    // series[0].markLine.data / markArea.data on the already-serialized JSON. Operating
+    // on JsonNode lets us avoid mutating the consumer's EChartOption — and survives the
+    // pre-serialized OptionJson path the same way. No-op when there are no registrations
+    // or no series to attach to (e.g. an empty placeholder option).
+    private string MergeAnnotations(string baseJson)
+        => ChartAnnotationMerger.Merge(baseJson, _annotations.Thresholds, _annotations.Zones);
 
     [JSInvokable]
     public async Task OnChartEvent(string eventName, string dataJson)

--- a/src/Lumeo.Charts/UI/Chart/ChartAnnotations.cs
+++ b/src/Lumeo.Charts/UI/Chart/ChartAnnotations.cs
@@ -1,0 +1,198 @@
+using System.Text.Json.Nodes;
+
+namespace Lumeo;
+
+/// <summary>
+/// One <see cref="ChartThreshold"/>'s configuration. Translates to a single entry in the
+/// chart's <c>series[0].markLine.data</c> array (ECharts native annotation).
+/// </summary>
+public sealed record ChartThresholdInfo(
+    string Id,
+    /// <summary>Value on the perpendicular axis (yAxis for horizontal threshold, xAxis for
+    /// vertical). Numbers are emitted as-is; strings address category-axis points.</summary>
+    object Value,
+    ChartThresholdAxis Axis,
+    string? Label,
+    /// <summary>CSS / hex color for the line. When null ECharts uses the series' colour.</summary>
+    string? Color,
+    /// <summary>"solid", "dashed", or "dotted". Defaults to "dashed" for visual distinction.</summary>
+    string LineStyle);
+
+/// <summary>Which axis a threshold is perpendicular to. Horizontal = a yAxis line spanning
+/// the chart width; Vertical = an xAxis line spanning the chart height.</summary>
+public enum ChartThresholdAxis
+{
+    Horizontal,
+    Vertical
+}
+
+/// <summary>
+/// One <see cref="ChartReferenceZone"/>'s configuration. Translates to a single entry in
+/// the chart's <c>series[0].markArea.data</c> array — a pair of endpoints describing the
+/// rectangle (or band) ECharts should shade.
+/// </summary>
+public sealed record ChartReferenceZoneInfo(
+    string Id,
+    object From,
+    object To,
+    ChartThresholdAxis Axis,
+    string? Label,
+    /// <summary>Fill colour (typically a low-alpha hex like <c>"#22c55e22"</c>). Required —
+    /// without it the zone would be invisible.</summary>
+    string Color);
+
+/// <summary>
+/// Cascaded by <see cref="Chart"/> to its declared <see cref="ChartThreshold"/> and
+/// <see cref="ChartReferenceZone"/> children. Children register themselves on
+/// <c>OnInitialized</c> and unregister on dispose; the chart picks up the lists in its
+/// JSON build phase and merges them into <c>series[0].markLine</c> / <c>markArea</c>
+/// without mutating the consumer-passed <see cref="EChartOption"/>.
+/// </summary>
+public sealed class ChartAnnotationsContext
+{
+    private readonly Action _onChanged;
+    private readonly Dictionary<string, ChartThresholdInfo> _thresholds = new();
+    private readonly Dictionary<string, ChartReferenceZoneInfo> _zones = new();
+
+    public ChartAnnotationsContext(Action onChanged) => _onChanged = onChanged;
+
+    public IReadOnlyCollection<ChartThresholdInfo> Thresholds => _thresholds.Values;
+    public IReadOnlyCollection<ChartReferenceZoneInfo> Zones => _zones.Values;
+
+    public void RegisterThreshold(ChartThresholdInfo info)
+    {
+        if (_thresholds.TryGetValue(info.Id, out var existing) && existing == info) return;
+        _thresholds[info.Id] = info;
+        _onChanged();
+    }
+
+    public void UnregisterThreshold(string id)
+    {
+        if (_thresholds.Remove(id)) _onChanged();
+    }
+
+    public void RegisterZone(ChartReferenceZoneInfo info)
+    {
+        if (_zones.TryGetValue(info.Id, out var existing) && existing == info) return;
+        _zones[info.Id] = info;
+        _onChanged();
+    }
+
+    public void UnregisterZone(string id)
+    {
+        if (_zones.Remove(id)) _onChanged();
+    }
+}
+
+/// <summary>
+/// Pure JSON-merge helper for the declarative annotation children. Splitting this out
+/// of <c>Chart.razor</c> keeps the merge logic unit-testable without spinning up the
+/// full chart + JS interop and lets <see cref="Chart"/> stay a thin orchestration layer.
+/// </summary>
+public static class ChartAnnotationMerger
+{
+    /// <summary>
+    /// Merge cascaded <see cref="ChartThresholdInfo"/> / <see cref="ChartReferenceZoneInfo"/>
+    /// registrations into <c>series[0].markLine.data</c> / <c>markArea.data</c> on a chart
+    /// option JSON string. Operates on <c>JsonNode</c> so we never mutate the consumer's
+    /// <see cref="EChartOption"/>. No-op when there are no registrations or no series.
+    /// </summary>
+    public static string Merge(
+        string baseJson,
+        IReadOnlyCollection<ChartThresholdInfo> thresholds,
+        IReadOnlyCollection<ChartReferenceZoneInfo> zones)
+    {
+        if (thresholds.Count == 0 && zones.Count == 0) return baseJson;
+        try
+        {
+            var root = JsonNode.Parse(baseJson);
+            if (root is not JsonObject obj) return baseJson;
+            if (obj["series"] is not JsonArray series || series.Count == 0) return baseJson;
+            if (series[0] is not JsonObject targetSeries) return baseJson;
+
+            if (thresholds.Count > 0)
+            {
+                var markLine = EnsureObject(targetSeries, "markLine");
+                var data = EnsureArray(markLine, "data");
+                foreach (var t in thresholds) data.Add(BuildMarkLineEntry(t));
+            }
+
+            if (zones.Count > 0)
+            {
+                var markArea = EnsureObject(targetSeries, "markArea");
+                var data = EnsureArray(markArea, "data");
+                foreach (var z in zones) data.Add(BuildMarkAreaEntry(z));
+            }
+
+            return root.ToJsonString();
+        }
+        catch
+        {
+            // Annotation merge must never break the chart — fall through to the
+            // unmodified base JSON so the data still renders.
+            return baseJson;
+        }
+    }
+
+    private static JsonObject EnsureObject(JsonObject parent, string key)
+    {
+        if (parent[key] is JsonObject existing) return existing;
+        var created = new JsonObject();
+        parent[key] = created;
+        return created;
+    }
+
+    private static JsonArray EnsureArray(JsonObject parent, string key)
+    {
+        if (parent[key] is JsonArray existing) return existing;
+        var created = new JsonArray();
+        parent[key] = created;
+        return created;
+    }
+
+    private static JsonObject BuildMarkLineEntry(ChartThresholdInfo t)
+    {
+        var entry = new JsonObject();
+        var axisKey = t.Axis == ChartThresholdAxis.Horizontal ? "yAxis" : "xAxis";
+        entry[axisKey] = ValueToNode(t.Value);
+        if (!string.IsNullOrEmpty(t.Label)) entry["name"] = t.Label;
+        var lineStyle = new JsonObject();
+        if (!string.IsNullOrEmpty(t.Color)) lineStyle["color"] = t.Color;
+        lineStyle["type"] = t.LineStyle;
+        entry["lineStyle"] = lineStyle;
+        if (!string.IsNullOrEmpty(t.Label))
+        {
+            entry["label"] = new JsonObject
+            {
+                ["formatter"] = t.Label,
+                ["position"] = "insideEndTop"
+            };
+        }
+        return entry;
+    }
+
+    private static JsonArray BuildMarkAreaEntry(ChartReferenceZoneInfo z)
+    {
+        var axisKey = z.Axis == ChartThresholdAxis.Horizontal ? "yAxis" : "xAxis";
+        var fromEnd = new JsonObject();
+        fromEnd[axisKey] = ValueToNode(z.From);
+        if (!string.IsNullOrEmpty(z.Label)) fromEnd["name"] = z.Label;
+        fromEnd["itemStyle"] = new JsonObject { ["color"] = z.Color };
+        var toEnd = new JsonObject();
+        toEnd[axisKey] = ValueToNode(z.To);
+        return new JsonArray { fromEnd, toEnd };
+    }
+
+    private static JsonNode? ValueToNode(object value) => value switch
+    {
+        null => null,
+        string s => JsonValue.Create(s),
+        int i => JsonValue.Create(i),
+        long l => JsonValue.Create(l),
+        double d => JsonValue.Create(d),
+        float f => JsonValue.Create(f),
+        decimal m => JsonValue.Create(m),
+        bool b => JsonValue.Create(b),
+        _ => JsonValue.Create(value.ToString())
+    };
+}

--- a/src/Lumeo.Charts/UI/Chart/ChartReferenceZone.razor
+++ b/src/Lumeo.Charts/UI/Chart/ChartReferenceZone.razor
@@ -1,0 +1,39 @@
+@namespace Lumeo
+@implements IDisposable
+
+@*  Declarative reference band — a shaded rectangle between two values on one axis,
+    spanning the full extent of the other. Wraps ECharts' native series.markArea.data.
+
+    Usage:
+        <LineChart …>
+            <ChartReferenceZone From="80" To="120" Color="#22c55e22" Label="Healthy" />
+            <ChartReferenceZone From="0"  To="50"  Color="#ef444422" Label="Critical" />
+        </LineChart> *@
+
+@code {
+    [CascadingParameter] public ChartAnnotationsContext? Context { get; set; }
+
+    /// <summary>Lower bound on the perpendicular axis.</summary>
+    [Parameter, EditorRequired] public object From { get; set; } = 0;
+
+    /// <summary>Upper bound on the perpendicular axis.</summary>
+    [Parameter, EditorRequired] public object To { get; set; } = 0;
+
+    /// <summary>Which axis the band is perpendicular to. Default <c>Horizontal</c>
+    /// (a yAxis band spanning the chart width).</summary>
+    [Parameter] public ChartThresholdAxis Axis { get; set; } = ChartThresholdAxis.Horizontal;
+
+    /// <summary>Label rendered inside the band. Null or empty hides it.</summary>
+    [Parameter] public string? Label { get; set; }
+
+    /// <summary>Fill colour (typically a low-alpha hex like <c>"#22c55e22"</c>).
+    /// Required — without it the zone would be invisible.</summary>
+    [Parameter, EditorRequired] public string Color { get; set; } = "#3b82f622";
+
+    private readonly string _id = "zone-" + Guid.NewGuid().ToString("N")[..8];
+
+    protected override void OnParametersSet()
+        => Context?.RegisterZone(new ChartReferenceZoneInfo(_id, From, To, Axis, Label, Color));
+
+    public void Dispose() => Context?.UnregisterZone(_id);
+}

--- a/src/Lumeo.Charts/UI/Chart/ChartThreshold.razor
+++ b/src/Lumeo.Charts/UI/Chart/ChartThreshold.razor
@@ -1,0 +1,40 @@
+@namespace Lumeo
+@implements IDisposable
+
+@*  Declarative threshold line — a horizontal yAxis (default) or vertical xAxis line at a
+    given value, optionally labelled. Wraps ECharts' native series.markLine.data so it
+    composes with everything else the underlying option already does.
+
+    Usage:
+        <LineChart …>
+            <ChartThreshold Value="100" Label="Target" Color="#22c55e" />
+            <ChartThreshold Value="80"  Label="SLA"    Color="#ef4444" LineStyle="dotted" />
+        </LineChart> *@
+
+@code {
+    [CascadingParameter] public ChartAnnotationsContext? Context { get; set; }
+
+    /// <summary>Value on the perpendicular axis (yAxis for horizontal, xAxis for vertical).</summary>
+    [Parameter, EditorRequired] public object Value { get; set; } = 0;
+
+    /// <summary>Which axis the line is perpendicular to. Default <c>Horizontal</c>
+    /// (a yAxis line spanning the chart width — the common target / SLA line).</summary>
+    [Parameter] public ChartThresholdAxis Axis { get; set; } = ChartThresholdAxis.Horizontal;
+
+    /// <summary>Label rendered along the line. Null or empty hides it.</summary>
+    [Parameter] public string? Label { get; set; }
+
+    /// <summary>Hex / CSS colour for the line. When null ECharts inherits the series colour.</summary>
+    [Parameter] public string? Color { get; set; }
+
+    /// <summary>Line style passed to ECharts — <c>"solid"</c>, <c>"dashed"</c>, or
+    /// <c>"dotted"</c>. Defaults to <c>"dashed"</c> for visual distinction from data lines.</summary>
+    [Parameter] public string LineStyle { get; set; } = "dashed";
+
+    private readonly string _id = "thr-" + Guid.NewGuid().ToString("N")[..8];
+
+    protected override void OnParametersSet()
+        => Context?.RegisterThreshold(new ChartThresholdInfo(_id, Value, Axis, Label, Color, LineStyle));
+
+    public void Dispose() => Context?.UnregisterThreshold(_id);
+}

--- a/src/Lumeo.Charts/UI/Chart/Charts/AreaChart.razor
+++ b/src/Lumeo.Charts/UI/Chart/Charts/AreaChart.razor
@@ -1,6 +1,6 @@
 @namespace Lumeo
 
-<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" IsLoading="@IsLoading" ShowLoadingSkeleton="@ShowLoadingSkeleton" SkeletonKind="@SkeletonKind" SkeletonStyle="@SkeletonStyle" ShowLoadingLabel="@ShowLoadingLabel" LoadingText="@LoadingText" PhantomCycleMs="@PhantomCycleMs" @attributes="AdditionalAttributes" />
+<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" IsLoading="@IsLoading" ShowLoadingSkeleton="@ShowLoadingSkeleton" SkeletonKind="@SkeletonKind" SkeletonStyle="@SkeletonStyle" ShowLoadingLabel="@ShowLoadingLabel" LoadingText="@LoadingText" PhantomCycleMs="@PhantomCycleMs" ChildContent="@ChildContent" @attributes="AdditionalAttributes" />
 
 @code {
     [Parameter] public List<string> Categories { get; set; } = new();
@@ -16,6 +16,9 @@
     [Parameter] public string Height { get; set; } = "350px";
     [Parameter] public string? Theme { get; set; }
     [Parameter] public string? Class { get; set; }
+    /// <summary>Declarative annotation children — <see cref="ChartThreshold"/> and
+    /// <see cref="ChartReferenceZone"/>. Forwarded to the underlying <see cref="Chart"/>.</summary>
+    [Parameter] public RenderFragment? ChildContent { get; set; }
     [Parameter(CaptureUnmatchedValues = true)] public Dictionary<string, object>? AdditionalAttributes { get; set; }
     /// <summary>When true, overlays a shape-aware loading skeleton on top of the chart (consumer is fetching data). Flips back to the real chart once set to false.</summary>
     [Parameter] public bool IsLoading { get; set; }

--- a/src/Lumeo.Charts/UI/Chart/Charts/BarChart.razor
+++ b/src/Lumeo.Charts/UI/Chart/Charts/BarChart.razor
@@ -1,7 +1,7 @@
 @namespace Lumeo
 @inject Lumeo.Services.Localization.ILumeoLocalizer L
 
-<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" IsLoading="@IsLoading" ShowLoadingSkeleton="@ShowLoadingSkeleton" SkeletonKind="@SkeletonKind" SkeletonStyle="@SkeletonStyle" ShowLoadingLabel="@ShowLoadingLabel" LoadingText="@EffectiveLoadingText" PhantomCycleMs="@PhantomCycleMs" @attributes="AdditionalAttributes" />
+<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" IsLoading="@IsLoading" ShowLoadingSkeleton="@ShowLoadingSkeleton" SkeletonKind="@SkeletonKind" SkeletonStyle="@SkeletonStyle" ShowLoadingLabel="@ShowLoadingLabel" LoadingText="@EffectiveLoadingText" PhantomCycleMs="@PhantomCycleMs" ChildContent="@ChildContent" @attributes="AdditionalAttributes" />
 
 @code {
     [Parameter] public List<string> Categories { get; set; } = new();
@@ -15,6 +15,9 @@
     [Parameter] public string Height { get; set; } = "350px";
     [Parameter] public string? Theme { get; set; }
     [Parameter] public string? Class { get; set; }
+    /// <summary>Declarative annotation children — <see cref="ChartThreshold"/> and
+    /// <see cref="ChartReferenceZone"/>. Forwarded to the underlying <see cref="Chart"/>.</summary>
+    [Parameter] public RenderFragment? ChildContent { get; set; }
     [Parameter(CaptureUnmatchedValues = true)] public Dictionary<string, object>? AdditionalAttributes { get; set; }
     /// <summary>When true, overlays a shape-aware loading skeleton on top of the chart (consumer is fetching data). Flips back to the real chart once set to false.</summary>
     [Parameter] public bool IsLoading { get; set; }

--- a/src/Lumeo.Charts/UI/Chart/Charts/LineChart.razor
+++ b/src/Lumeo.Charts/UI/Chart/Charts/LineChart.razor
@@ -1,6 +1,6 @@
 @namespace Lumeo
 
-<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" IsLoading="@IsLoading" ShowLoadingSkeleton="@ShowLoadingSkeleton" SkeletonKind="@SkeletonKind" SkeletonStyle="@SkeletonStyle" ShowLoadingLabel="@ShowLoadingLabel" LoadingText="@LoadingText" PhantomCycleMs="@PhantomCycleMs" @attributes="AdditionalAttributes" />
+<Chart Option="@_option" Width="@Width" Height="@Height" Theme="@Theme" Class="@Class" IsLoading="@IsLoading" ShowLoadingSkeleton="@ShowLoadingSkeleton" SkeletonKind="@SkeletonKind" SkeletonStyle="@SkeletonStyle" ShowLoadingLabel="@ShowLoadingLabel" LoadingText="@LoadingText" PhantomCycleMs="@PhantomCycleMs" ChildContent="@ChildContent" @attributes="AdditionalAttributes" />
 
 @code {
     [Parameter] public List<string> Categories { get; set; } = new();
@@ -14,6 +14,9 @@
     [Parameter] public string Height { get; set; } = "350px";
     [Parameter] public string? Theme { get; set; }
     [Parameter] public string? Class { get; set; }
+    /// <summary>Declarative annotation children — <see cref="ChartThreshold"/> and
+    /// <see cref="ChartReferenceZone"/>. Forwarded to the underlying <see cref="Chart"/>.</summary>
+    [Parameter] public RenderFragment? ChildContent { get; set; }
     [Parameter(CaptureUnmatchedValues = true)] public Dictionary<string, object>? AdditionalAttributes { get; set; }
     /// <summary>When true, overlays a shape-aware loading skeleton on top of the chart (consumer is fetching data). Flips back to the real chart once set to false.</summary>
     [Parameter] public bool IsLoading { get; set; }

--- a/tests/Lumeo.Tests/Components/Chart/ChartAnnotationsTests.cs
+++ b/tests/Lumeo.Tests/Components/Chart/ChartAnnotationsTests.cs
@@ -1,0 +1,182 @@
+using System.Text.Json.Nodes;
+using Xunit;
+using Lumeo;
+
+namespace Lumeo.Tests.Components.Chart;
+
+/// <summary>
+/// Tests for the JSON merge that wires declarative <see cref="ChartThreshold"/> /
+/// <see cref="ChartReferenceZone"/> children into the chart option. Drives
+/// <see cref="ChartAnnotationMerger"/> directly so we don't depend on the live ECharts
+/// JS bridge.
+/// </summary>
+public class ChartAnnotationsTests
+{
+    private const string BaseJsonOneSeries = """
+        { "series": [ { "type": "line", "data": [1, 2, 3] } ] }
+        """;
+
+    private const string BaseJsonNoSeries = """{ "title": { "text": "Empty" } }""";
+
+    private static IReadOnlyCollection<ChartThresholdInfo> Thresholds(params ChartThresholdInfo[] items) => items;
+    private static IReadOnlyCollection<ChartReferenceZoneInfo> Zones(params ChartReferenceZoneInfo[] items) => items;
+
+    [Fact]
+    public void No_Annotations_Returns_Base_Json_Unchanged()
+    {
+        var result = ChartAnnotationMerger.Merge(BaseJsonOneSeries, Thresholds(), Zones());
+        Assert.Equal(BaseJsonOneSeries, result);
+    }
+
+    [Fact]
+    public void Threshold_Merges_Horizontal_YAxis_Entry()
+    {
+        var result = ChartAnnotationMerger.Merge(
+            BaseJsonOneSeries,
+            Thresholds(new ChartThresholdInfo("t1", 2.5, ChartThresholdAxis.Horizontal, "Target", "#22c55e", "dashed")),
+            Zones());
+
+        var data = JsonNode.Parse(result)!["series"]![0]!["markLine"]!["data"]!.AsArray();
+        Assert.Single(data);
+        var entry = data[0]!;
+        Assert.Equal(2.5, entry["yAxis"]!.GetValue<double>());
+        Assert.Equal("Target", entry["name"]!.GetValue<string>());
+        Assert.Equal("#22c55e", entry["lineStyle"]!["color"]!.GetValue<string>());
+        Assert.Equal("dashed", entry["lineStyle"]!["type"]!.GetValue<string>());
+        Assert.Equal("Target", entry["label"]!["formatter"]!.GetValue<string>());
+    }
+
+    [Fact]
+    public void Vertical_Threshold_Uses_XAxis_Key_And_String_Value()
+    {
+        var result = ChartAnnotationMerger.Merge(
+            BaseJsonOneSeries,
+            Thresholds(new ChartThresholdInfo("t1", "B", ChartThresholdAxis.Vertical, null, null, "solid")),
+            Zones());
+
+        var entry = JsonNode.Parse(result)!["series"]![0]!["markLine"]!["data"]![0]!;
+        Assert.Equal("B", entry["xAxis"]!.GetValue<string>());
+        Assert.Null(entry["yAxis"]);
+        Assert.Null(entry["name"]);  // null label suppressed
+        Assert.Null(entry["label"]); // ditto for the formatter object
+        Assert.Equal("solid", entry["lineStyle"]!["type"]!.GetValue<string>());
+        Assert.Null(entry["lineStyle"]!["color"]); // null color suppressed
+    }
+
+    [Fact]
+    public void Multiple_Thresholds_All_Append_In_Order()
+    {
+        var result = ChartAnnotationMerger.Merge(
+            BaseJsonOneSeries,
+            Thresholds(
+                new ChartThresholdInfo("t1", 100, ChartThresholdAxis.Horizontal, "Target", null, "dashed"),
+                new ChartThresholdInfo("t2", 50,  ChartThresholdAxis.Horizontal, "SLA",    null, "dotted")),
+            Zones());
+
+        var data = JsonNode.Parse(result)!["series"]![0]!["markLine"]!["data"]!.AsArray();
+        Assert.Equal(2, data.Count);
+        Assert.Equal("Target", data[0]!["name"]!.GetValue<string>());
+        Assert.Equal("SLA",    data[1]!["name"]!.GetValue<string>());
+    }
+
+    [Fact]
+    public void Reference_Zone_Merges_Pair_With_Color_And_Label()
+    {
+        var result = ChartAnnotationMerger.Merge(
+            BaseJsonOneSeries,
+            Thresholds(),
+            Zones(new ChartReferenceZoneInfo("z1", 80, 120, ChartThresholdAxis.Horizontal, "Healthy", "#22c55e22")));
+
+        var data = JsonNode.Parse(result)!["series"]![0]!["markArea"]!["data"]!.AsArray();
+        Assert.Single(data);
+        var pair = data[0]!.AsArray();
+        Assert.Equal(2, pair.Count);
+        Assert.Equal(80, pair[0]!["yAxis"]!.GetValue<int>());
+        Assert.Equal(120, pair[1]!["yAxis"]!.GetValue<int>());
+        Assert.Equal("#22c55e22", pair[0]!["itemStyle"]!["color"]!.GetValue<string>());
+        Assert.Equal("Healthy", pair[0]!["name"]!.GetValue<string>());
+    }
+
+    [Fact]
+    public void Threshold_And_Zone_Compose_On_Same_Series()
+    {
+        var result = ChartAnnotationMerger.Merge(
+            BaseJsonOneSeries,
+            Thresholds(new ChartThresholdInfo("t1", 90, ChartThresholdAxis.Horizontal, "Target", "#000", "dashed")),
+            Zones(new ChartReferenceZoneInfo("z1", 80, 100, ChartThresholdAxis.Horizontal, null, "#22c55e22")));
+
+        var series0 = JsonNode.Parse(result)!["series"]![0]!;
+        Assert.Single(series0["markLine"]!["data"]!.AsArray());
+        Assert.Single(series0["markArea"]!["data"]!.AsArray());
+    }
+
+    [Fact]
+    public void Existing_MarkLine_Data_Is_Preserved_And_Appended_To()
+    {
+        // If the consumer already shipped markLine via raw EChartOption, our cascade
+        // adds to it rather than overwriting.
+        var baseJson = """
+            { "series": [ { "type": "line", "markLine": { "data": [ { "yAxis": 10, "name": "Pre" } ] } } ] }
+            """;
+        var result = ChartAnnotationMerger.Merge(
+            baseJson,
+            Thresholds(new ChartThresholdInfo("t1", 20, ChartThresholdAxis.Horizontal, "Added", null, "dashed")),
+            Zones());
+
+        var data = JsonNode.Parse(result)!["series"]![0]!["markLine"]!["data"]!.AsArray();
+        Assert.Equal(2, data.Count);
+        Assert.Equal("Pre",   data[0]!["name"]!.GetValue<string>());
+        Assert.Equal("Added", data[1]!["name"]!.GetValue<string>());
+    }
+
+    [Fact]
+    public void Empty_Series_Returns_Base_Json_Unchanged()
+    {
+        // An option with no series — annotations have nothing to attach to. Returning the
+        // unmodified base is the correct fall-through (per the "never break the chart" rule).
+        var result = ChartAnnotationMerger.Merge(
+            BaseJsonNoSeries,
+            Thresholds(new ChartThresholdInfo("t1", 1, ChartThresholdAxis.Horizontal, null, null, "dashed")),
+            Zones());
+
+        Assert.Equal(BaseJsonNoSeries, result);
+    }
+
+    [Fact]
+    public void Malformed_Base_Json_Returns_Input_Unchanged()
+    {
+        var bad = "not json";
+        var result = ChartAnnotationMerger.Merge(
+            bad,
+            Thresholds(new ChartThresholdInfo("t1", 1, ChartThresholdAxis.Horizontal, null, null, "dashed")),
+            Zones());
+
+        Assert.Equal(bad, result);
+    }
+
+    [Fact]
+    public void Annotations_Context_Registers_And_Unregisters_Items()
+    {
+        var changeCount = 0;
+        var ctx = new ChartAnnotationsContext(() => changeCount++);
+        var t1 = new ChartThresholdInfo("t1", 1, ChartThresholdAxis.Horizontal, null, null, "dashed");
+        var z1 = new ChartReferenceZoneInfo("z1", 1, 2, ChartThresholdAxis.Horizontal, null, "#000");
+
+        ctx.RegisterThreshold(t1);
+        ctx.RegisterZone(z1);
+        Assert.Single(ctx.Thresholds);
+        Assert.Single(ctx.Zones);
+        Assert.Equal(2, changeCount);
+
+        // Re-registering the same value should NOT fire OnChanged again — guards against
+        // a render loop where OnParametersSet calls register on every parameter set.
+        ctx.RegisterThreshold(t1);
+        Assert.Equal(2, changeCount);
+
+        ctx.UnregisterThreshold("t1");
+        ctx.UnregisterZone("z1");
+        Assert.Empty(ctx.Thresholds);
+        Assert.Empty(ctx.Zones);
+        Assert.Equal(4, changeCount);
+    }
+}


### PR DESCRIPTION
## Summary

Partial close for #137 — ships the **annotations half** (ChartThreshold + ChartReferenceZone). The declarative ChartTooltip RenderFragment slot needs a non-trivial async JS bridge and is staged for a follow-up so this one is shippable as 3.9.0 release-train material.

## New components

### `<ChartThreshold>`

```razor
<LineChart Categories="..." Series="...">
    <ChartThreshold Value="100" Label="Target" Color="#22c55e" />
    <ChartThreshold Value="80"  Label="SLA"    Color="#ef4444" LineStyle="dotted" />
</LineChart>
```

A horizontal `yAxis` line by default (the common "target" / "SLA" overlay). `Axis="Vertical"` for an `xAxis` line — e.g. a "today" marker on a time series.

### `<ChartReferenceZone>`

```razor
<LineChart …>
    <ChartReferenceZone From="80" To="120" Color="#22c55e22" Label="Healthy" />
    <ChartReferenceZone From="0"  To="50"  Color="#ef444422" Label="Critical" />
</LineChart>
```

A shaded band between two values on the chosen axis — translates to ECharts' native `markArea`.

## Mechanics

- Children cascade to a `ChartAnnotationsContext` on the parent `Chart`; each `ChartThreshold` / `ChartReferenceZone` registers on `OnParametersSet` and unregisters on dispose. Registration is idempotent so per-render parameter refreshes don't spin the render loop.
- `ChartAnnotationMerger` (extracted as a static helper so the JSON logic is unit-testable in isolation) merges the registered annotations into the option JSON **after** serialization — appending to existing `series[0].markLine.data` / `markArea.data` without mutating the consumer's `EChartOption` object. Merge failure falls through to the original JSON so the chart still renders.
- `LineChart`, `BarChart`, and `AreaChart` forward `ChildContent` so the children work unchanged on the typed wrappers — no need to drop down to `<Chart>` directly.

## What's staged for the tooltip follow-up

The `ChartTooltip` RenderFragment slot needs ECharts' tooltip formatter to call back into Razor with the current hovered point and receive rendered HTML in return. That's a meaningful JS bridge (async formatter Promise + a per-instance `DotNetObjectReference` round-trip) and worth its own scoped PR rather than rushed into this one.

## Release train

Ships in **3.9.0** alongside #140, #141, #142, #143. `Directory.Build.props` version bump lives in #141.

## Test plan
- [x] 10 new bUnit tests in `ChartAnnotationsTests` covering: empty input no-op, horizontal yAxis merge, vertical xAxis merge, multiple thresholds, reference zone with color/label, threshold + zone composing on the same series, preservation of pre-existing markLine data, empty-series no-op, malformed JSON fall-through, context register/unregister idempotency.
- [x] 72/72 Chart tests pass (62 prior + 10 new) — no regressions on the existing chart suite.
- [x] `dotnet build src/Lumeo.Charts -c Release` succeeds.
- [ ] CI build-and-test + e2e

---
_Generated by [Claude Code](https://claude.ai/code/session_01LJmBFYeCdQj2G2epoZaRzQ)_