### PR TITLE
feat(sidebar): PersistCollapsed + MiniRail variant; bump to 3.10.0 (closes #138)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
   <!-- Lockstep version shared by all Lumeo packages.
        Update this single property to version all packages in unison. -->
   <PropertyGroup>
-    <Version>3.9.0</Version>
+    <Version>3.10.0</Version>
   </PropertyGroup>
 
   <!-- Shared NuGet README packing lives in Directory.Build.targets, NOT here.

--- a/docs/Lumeo.Docs/Pages/Components/SidebarPage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/SidebarPage.razor
@@ -202,6 +202,43 @@
         </Stack>
     </ComponentDemo>
 
+    <ComponentDemo Title="MiniRail (hover-expand)" Code="@_miniRailCode">
+        <Stack Class="h-[400px] w-full rounded-lg border overflow-hidden">
+            <SidebarProvider @bind-IsCollapsed="_miniRailCollapsed" Variant="SidebarProvider.SidebarVariant.MiniRail">
+                <SidebarComponent>
+                    <SidebarContent>
+                        <SidebarGroup>
+                            <SidebarMenu>
+                                <SidebarMenuItem>
+                                    <SidebarMenuButton Href="#" IsActive="true" Tooltip="Home">
+                                        <IconContent><DynamicIcon Name="House" Class="h-4 w-4" /></IconContent>
+                                        <LabelContent><Lumeo.Text As="span">Home</Lumeo.Text></LabelContent>
+                                    </SidebarMenuButton>
+                                </SidebarMenuItem>
+                                <SidebarMenuItem>
+                                    <SidebarMenuButton Href="#" Tooltip="Search">
+                                        <IconContent><DynamicIcon Name="Search" Class="h-4 w-4" /></IconContent>
+                                        <LabelContent><Lumeo.Text As="span">Search</Lumeo.Text></LabelContent>
+                                    </SidebarMenuButton>
+                                </SidebarMenuItem>
+                                <SidebarMenuItem>
+                                    <SidebarMenuButton Href="#" Tooltip="Settings">
+                                        <IconContent><DynamicIcon Name="Settings" Class="h-4 w-4" /></IconContent>
+                                        <LabelContent><Lumeo.Text As="span">Settings</Lumeo.Text></LabelContent>
+                                    </SidebarMenuButton>
+                                </SidebarMenuItem>
+                            </SidebarMenu>
+                        </SidebarGroup>
+                    </SidebarContent>
+                </SidebarComponent>
+                <main class="flex-1 p-6">
+                    <SidebarTrigger />
+                    <Lumeo.Text Size="sm" Color="muted" Class="mt-4">Hover the rail to expand. Click toggle to pin open.</Lumeo.Text>
+                </main>
+            </SidebarProvider>
+        </Stack>
+    </ComponentDemo>
+
     <ComponentDemo Title="Seamless header &amp; footer" Code="@_borderedCode">
         <Stack Gap="2">
             <Lumeo.Text Size="sm" Color="muted">Pass <code class="font-mono">Bordered="false"</code> on <code class="font-mono">SidebarHeader</code> / <code class="font-mono">SidebarFooter</code> to drop the divider rule and let the section flow into the content — replaces the consumer-side <code class="font-mono">!border-b-0</code> / <code class="font-mono">!border-t-0</code> override.</Lumeo.Text>
@@ -357,6 +394,7 @@
     private bool _pushCollapsed;
     private bool _overlayCollapsed = true;
     private bool _iconCollapsed = true;
+    private bool _miniRailCollapsed = true;
     private bool _borderedCollapsed;
 
     private string _borderedCode = @"<SidebarProvider @bind-IsCollapsed=""_isCollapsed"">
@@ -466,6 +504,29 @@
         <SidebarTrigger />
         <Lumeo.Text Size=""sm"" Color=""muted"">Click backdrop to dismiss.</Lumeo.Text>
     </main>
+</SidebarProvider>";
+
+    private string _miniRailCode = @"@* MiniRail: narrow icon rail when collapsed, expands to full width on hover or
+   keyboard focus, collapses back on leave. Toggle() pins it open until toggled again.
+   Add PersistCollapsed=true to remember the pinned state across reloads. *@
+<SidebarProvider @bind-IsCollapsed=""_isCollapsed""
+                 Variant=""SidebarProvider.SidebarVariant.MiniRail""
+                 PersistCollapsed=""true"">
+    <SidebarComponent>
+        <SidebarContent>
+            <SidebarGroup>
+                <SidebarMenu>
+                    <SidebarMenuItem>
+                        <SidebarMenuButton Href=""/"" Tooltip=""Home"">
+                            <IconContent><Blazicon Svg=""Lucide.House"" class=""h-4 w-4"" /></IconContent>
+                            <LabelContent><span>Home</span></LabelContent>
+                        </SidebarMenuButton>
+                    </SidebarMenuItem>
+                </SidebarMenu>
+            </SidebarGroup>
+        </SidebarContent>
+    </SidebarComponent>
+    <main class=""flex-1 p-6""><SidebarTrigger /></main>
 </SidebarProvider>";
 
     private string _iconCode = @"<SidebarProvider @bind-IsCollapsed=""_isCollapsed"" Variant=""SidebarProvider.SidebarVariant.Icon"">

--- a/docs/Lumeo.Docs/Pages/Docs/Changelog.razor
+++ b/docs/Lumeo.Docs/Pages/Docs/Changelog.razor
@@ -15,6 +15,31 @@
 
     <Separator Class="my-4" />
 
+    <!-- v3.10.0 -->
+    <Stack Gap="4">
+        <div class="flex items-center gap-3">
+            <Badge>v3.10.0</Badge>
+            <Lumeo.Text Size="sm" Color="muted">May 2026</Lumeo.Text>
+        </div>
+
+        <Lumeo.Text Size="base" Color="muted" Leading="relaxed">
+            Minor: Sidebar UX upgrades and the Charts tooltip slot &mdash; closing the
+            remaining open enhancement issues after the v3.9.0 picker / DataGrid / Charts
+            sweep.
+        </Lumeo.Text>
+
+        <Stack Gap="3">
+            <Heading Level="3" Size="sm" Class="font-semibold">Added</Heading>
+            <ul class="space-y-1.5 text-sm list-disc list-inside text-muted-foreground">
+                <li><strong><code class="rounded bg-muted px-1 text-xs">SidebarProvider.PersistCollapsed</code> + <code class="rounded bg-muted px-1 text-xs">PersistenceKey</code> (closes #138)</strong> &mdash; opt-in localStorage persistence for the collapsed / expanded state. Reads on first render, writes on every toggle. Falls back to the parameter value when JS is unavailable (SSR, prerender, <code class="rounded bg-muted px-1 text-xs">JSDisconnectedException</code>).</li>
+                <li><strong><code class="rounded bg-muted px-1 text-xs">SidebarVariant.MiniRail</code> (closes #138)</strong> &mdash; new variant that renders as a narrow icon rail (<code>w-16</code>) when collapsed but expands to full width (<code>w-64</code>) on hover or keyboard focus, collapsing back on leave. Material Design&rsquo;s standard collapsed sidebar pattern. <code class="rounded bg-muted px-1 text-xs">aria-expanded</code> reflects the effective state so screen readers see the hover-expansion.</li>
+                <li><strong><code class="rounded bg-muted px-1 text-xs">&lt;ChartTooltip&gt;</code> RenderFragment slot (closes #137)</strong> &mdash; declarative Razor tooltip body for any Chart wrapper. Renders the slot per hovered point via a Razor-backed ECharts formatter. Pairs with the <code class="rounded bg-muted px-1 text-xs">&lt;ChartThreshold&gt;</code> / <code class="rounded bg-muted px-1 text-xs">&lt;ChartReferenceZone&gt;</code> shipped in v3.9.0 to close the remaining half of #137.</li>
+            </ul>
+        </Stack>
+    </Stack>
+
+    <Separator Class="my-4" />
+
     <!-- v3.9.0 -->
     <Stack Gap="4">
         <div class="flex items-center gap-3">

--- a/src/Lumeo/UI/Sidebar/SidebarComponent.razor
+++ b/src/Lumeo/UI/Sidebar/SidebarComponent.razor
@@ -4,7 +4,11 @@
 {
     <div class="absolute inset-0 z-30 bg-black/50 transition-opacity" aria-hidden="true" @onclick="DismissOverlay"></div>
 }
-<aside class="@CssClass" @attributes="AdditionalAttributes">
+<aside class="@CssClass"
+       aria-expanded="@(EffectivelyExpanded ? "true" : "false")"
+       @onmouseenter="OnHoverEnter" @onmouseleave="OnHoverLeave"
+       @onfocusin="OnHoverEnter" @onfocusout="OnHoverLeave"
+       @attributes="AdditionalAttributes">
     @ChildContent
 </aside>
 
@@ -21,6 +25,17 @@
     private bool IsCollapsed => State?.IsCollapsed ?? false;
     private SidebarProvider.SidebarVariant Variant => State?.Variant ?? SidebarProvider.SidebarVariant.Push;
 
+    // Transient hover/focus-driven expansion for the MiniRail variant. Doesn't touch
+    // IsCollapsed (the user's pinned state), only the rendered width / aria-expanded.
+    private bool _hoverExpanded;
+
+    private bool IsMiniRail => Variant == SidebarProvider.SidebarVariant.MiniRail;
+
+    // The effective rendered state. For MiniRail: when collapsed, hover/focus temporarily
+    // expands; when not collapsed it's already full width. For other variants: pinned
+    // expansion is the only signal.
+    private bool EffectivelyExpanded => !IsCollapsed || (IsMiniRail && _hoverExpanded);
+
     private string CssClass
     {
         get
@@ -32,6 +47,9 @@
                 SidebarProvider.SidebarVariant.Overlay =>
                     $"absolute z-40 top-0 {(Side == Lumeo.Side.Right ? "right-0" : "left-0")} w-64 shadow-xl {(IsCollapsed ? (Side == Lumeo.Side.Right ? "translate-x-full" : "-translate-x-full") : "translate-x-0")}",
                 SidebarProvider.SidebarVariant.Icon => $"shrink-0 {(IsCollapsed ? "w-16" : "w-64")}",
+                // MiniRail expands to w-64 whenever effectively expanded (pinned open OR
+                // hover/focus). Otherwise it's the same icon rail as Icon variant.
+                SidebarProvider.SidebarVariant.MiniRail => $"shrink-0 {(EffectivelyExpanded ? "w-64" : "w-16")}",
                 _ => $"shrink-0 {(IsCollapsed ? "w-0 border-r-0" : "w-64")}"
             };
 
@@ -47,4 +65,16 @@
             await State.Toggle.InvokeAsync();
     }
 
+    // Hover / focus handlers are wired for every variant but only MiniRail reacts —
+    // the other variants ignore _hoverExpanded in their CSS computation, so the
+    // state change is harmless (and the no-op render is cheap).
+    private void OnHoverEnter()
+    {
+        if (IsMiniRail && IsCollapsed) _hoverExpanded = true;
+    }
+
+    private void OnHoverLeave()
+    {
+        if (_hoverExpanded) _hoverExpanded = false;
+    }
 }

--- a/src/Lumeo/UI/Sidebar/SidebarProvider.razor
+++ b/src/Lumeo/UI/Sidebar/SidebarProvider.razor
@@ -1,4 +1,5 @@
 @namespace Lumeo
+@inject IComponentInteropService Interop
 
 @{
     var context = new SidebarState(IsCollapsed, EventCallback.Factory.Create(this, Toggle), Variant);
@@ -15,6 +16,23 @@
     [Parameter] public bool IsCollapsed { get; set; }
     [Parameter] public EventCallback<bool> IsCollapsedChanged { get; set; }
     [Parameter] public SidebarVariant Variant { get; set; } = SidebarVariant.Push;
+
+    /// <summary>
+    /// When true, the collapsed / expanded state survives page reloads — the provider
+    /// reads <see cref="IsCollapsed"/> from <c>localStorage[PersistenceKey]</c> on first
+    /// render and writes back on every change. Falls back to the parameter value when
+    /// JS is unavailable (SSR, prerender, JSDisconnectedException). Opt-in to keep
+    /// existing consumers' behaviour untouched.
+    /// </summary>
+    [Parameter] public bool PersistCollapsed { get; set; }
+
+    /// <summary>
+    /// LocalStorage key used when <see cref="PersistCollapsed"/> is true. Override to
+    /// scope a per-route or per-tenant sidebar so multiple sidebars on the same origin
+    /// don't clobber each other's state.
+    /// </summary>
+    [Parameter] public string PersistenceKey { get; set; } = "lumeo.sidebar.collapsed";
+
     [Parameter] public string? Class { get; set; }
     [Parameter(CaptureUnmatchedValues = true)] public Dictionary<string, object>? AdditionalAttributes { get; set; }
 
@@ -27,12 +45,55 @@
         }
     }
 
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (!firstRender || !PersistCollapsed) return;
+        try
+        {
+            var stored = await Interop.LoadFromLocalStorage(PersistenceKey);
+            // Only restore if storage actually held a value AND it differs from the
+            // current parameter — avoids a redundant cascade refresh on every mount.
+            if (stored is "true" or "false")
+            {
+                var restored = stored == "true";
+                if (restored != IsCollapsed)
+                {
+                    IsCollapsed = restored;
+                    await IsCollapsedChanged.InvokeAsync(IsCollapsed);
+                    StateHasChanged();
+                }
+            }
+        }
+        catch (Microsoft.JSInterop.JSDisconnectedException)
+        {
+            // Circuit dropped between firstRender scheduling and the storage call.
+            // Fall through silently — the cascade keeps the parameter default.
+        }
+    }
+
     private async Task Toggle()
     {
         IsCollapsed = !IsCollapsed;
         await IsCollapsedChanged.InvokeAsync(IsCollapsed);
+        if (PersistCollapsed)
+        {
+            try { await Interop.SaveToLocalStorage(PersistenceKey, IsCollapsed ? "true" : "false"); }
+            catch (Microsoft.JSInterop.JSDisconnectedException) { }
+        }
     }
 
     public record SidebarState(bool IsCollapsed, EventCallback Toggle, SidebarVariant Variant);
-    public enum SidebarVariant { Push, Overlay, Icon }
+
+    /// <summary>
+    /// Layout strategy for the sidebar.
+    /// <list type="bullet">
+    /// <item><c>Push</c> &mdash; collapses to zero width, pushing main content to the edge.</item>
+    /// <item><c>Overlay</c> &mdash; floats above content with a dismissible scrim.</item>
+    /// <item><c>Icon</c> &mdash; collapses to a narrow icon rail that stays put until toggled back.</item>
+    /// <item><c>MiniRail</c> &mdash; same icon-rail width when collapsed, but expands to full
+    /// width on hover or keyboard focus and collapses again on leave. Material&rsquo;s standard
+    /// collapsed-sidebar pattern; uses <c>Toggle()</c> to pin open.</item>
+    /// </list>
+    /// </summary>
+    public enum SidebarVariant { Push, Overlay, Icon, MiniRail }
 }

--- a/tests/Lumeo.Tests/Components/Sidebar/SidebarTests.cs
+++ b/tests/Lumeo.Tests/Components/Sidebar/SidebarTests.cs
@@ -224,4 +224,105 @@ public class SidebarTests : IAsyncLifetime
         var aside = cut.Find("aside");
         Assert.Contains("order-last", aside.GetAttribute("class") ?? "");
     }
+
+    // --- MiniRail variant ---
+
+    private IRenderedComponent<IComponent> RenderMiniRail(bool isCollapsed)
+    {
+        return _ctx.Render(builder =>
+        {
+            builder.OpenComponent<L.SidebarProvider>(0);
+            builder.AddAttribute(1, "Variant", L.SidebarProvider.SidebarVariant.MiniRail);
+            builder.AddAttribute(2, "IsCollapsed", isCollapsed);
+            builder.AddAttribute(3, "ChildContent", (RenderFragment)(b =>
+            {
+                b.OpenComponent<L.SidebarComponent>(0);
+                b.CloseComponent();
+            }));
+            builder.CloseComponent();
+        });
+    }
+
+    [Fact]
+    public void MiniRail_Collapsed_Renders_Narrow_Rail()
+    {
+        var cut = RenderMiniRail(isCollapsed: true);
+        var cls = cut.Find("aside").GetAttribute("class") ?? "";
+        Assert.Contains("w-16", cls);
+        Assert.DoesNotContain("w-64", cls);
+        Assert.Equal("false", cut.Find("aside").GetAttribute("aria-expanded"));
+    }
+
+    [Fact]
+    public void MiniRail_NotCollapsed_Renders_Full_Width()
+    {
+        var cut = RenderMiniRail(isCollapsed: false);
+        var cls = cut.Find("aside").GetAttribute("class") ?? "";
+        Assert.Contains("w-64", cls);
+        Assert.Equal("true", cut.Find("aside").GetAttribute("aria-expanded"));
+    }
+
+    [Fact]
+    public void MiniRail_MouseEnter_Expands_While_Collapsed()
+    {
+        var cut = RenderMiniRail(isCollapsed: true);
+        var aside = cut.Find("aside");
+        Assert.Contains("w-16", aside.GetAttribute("class") ?? "");
+
+        aside.TriggerEvent("onmouseenter", new Microsoft.AspNetCore.Components.Web.MouseEventArgs());
+
+        // Hover-expanded → renders at full width and reports aria-expanded=true even
+        // though IsCollapsed is still true (the pinned state).
+        var aside2 = cut.Find("aside");
+        Assert.Contains("w-64", aside2.GetAttribute("class") ?? "");
+        Assert.Equal("true", aside2.GetAttribute("aria-expanded"));
+    }
+
+    [Fact]
+    public void MiniRail_MouseLeave_Collapses_Back()
+    {
+        var cut = RenderMiniRail(isCollapsed: true);
+        var aside = cut.Find("aside");
+        aside.TriggerEvent("onmouseenter", new Microsoft.AspNetCore.Components.Web.MouseEventArgs());
+        Assert.Contains("w-64", cut.Find("aside").GetAttribute("class") ?? "");
+
+        aside.TriggerEvent("onmouseleave", new Microsoft.AspNetCore.Components.Web.MouseEventArgs());
+
+        Assert.Contains("w-16", cut.Find("aside").GetAttribute("class") ?? "");
+        Assert.Equal("false", cut.Find("aside").GetAttribute("aria-expanded"));
+    }
+
+    [Fact]
+    public void MiniRail_FocusIn_Expands_For_Keyboard_Users()
+    {
+        // Tab-focusing an item inside the rail counts as "user wants the sidebar
+        // open" for accessibility — same expansion as hover.
+        var cut = RenderMiniRail(isCollapsed: true);
+        cut.Find("aside").TriggerEvent("onfocusin", new Microsoft.AspNetCore.Components.Web.FocusEventArgs());
+
+        Assert.Contains("w-64", cut.Find("aside").GetAttribute("class") ?? "");
+        Assert.Equal("true", cut.Find("aside").GetAttribute("aria-expanded"));
+    }
+
+    [Fact]
+    public void MiniRail_Icon_Variant_Ignores_Hover()
+    {
+        // Sanity guard — only MiniRail responds to hover. Icon stays narrow on hover.
+        var cut = _ctx.Render(builder =>
+        {
+            builder.OpenComponent<L.SidebarProvider>(0);
+            builder.AddAttribute(1, "Variant", L.SidebarProvider.SidebarVariant.Icon);
+            builder.AddAttribute(2, "IsCollapsed", true);
+            builder.AddAttribute(3, "ChildContent", (RenderFragment)(b =>
+            {
+                b.OpenComponent<L.SidebarComponent>(0);
+                b.CloseComponent();
+            }));
+            builder.CloseComponent();
+        });
+
+        cut.Find("aside").TriggerEvent("onmouseenter", new Microsoft.AspNetCore.Components.Web.MouseEventArgs());
+        Assert.Contains("w-16", cut.Find("aside").GetAttribute("class") ?? "");
+        Assert.DoesNotContain("w-64", cut.Find("aside").GetAttribute("class") ?? "");
+    }
 }


### PR DESCRIPTION
## Summary

Closes #138 — adds Sidebar persistence + the MiniRail variant, plus the version bump for the **3.10.0 release train** (paired with the upcoming ChartTooltip slot PR that closes the remaining half of #137).

### `PersistCollapsed` + `PersistenceKey`

Opt-in localStorage persistence for the collapsed / expanded state:

```razor
<SidebarProvider @bind-IsCollapsed="_isCollapsed"
                 PersistCollapsed="true"
                 PersistenceKey="app.nav.collapsed">
    …
</SidebarProvider>
```

`OnAfterRenderAsync(firstRender)` reads the cached value; `Toggle()` writes it back. Falls back silently on `JSDisconnectedException` so SSR / prerender continue to work with the parameter default. `PersistenceKey` defaults to `"lumeo.sidebar.collapsed"` — override to scope per route or per tenant.

### `SidebarVariant.MiniRail`

New enum member. Renders the narrow icon rail (`w-16`) when collapsed but **expands to full width (`w-64`) on hover or keyboard focus**, collapsing back on leave. `aria-expanded` reflects the *effective* state (hover-expansion counts as expanded for screen readers).

Mechanics:
- `_hoverExpanded` local state on `SidebarComponent`, flipped by `@onmouseenter` / `@onmouseleave` / `@onfocusin` / `@onfocusout`. Only MiniRail consults it for its CSS — the other variants ignore it (cheap no-op render).
- `EffectivelyExpanded = !IsCollapsed || (IsMiniRail && _hoverExpanded)`. `IsCollapsed` (the pinned state) is unchanged by hover, so `Toggle()` still pins the rail open until toggled back.

## Versioning

`Directory.Build.props` 3.9.0 → 3.10.0 (additive parameter + new enum value = minor bump per semver). Changelog v3.10.0 entry added covering this PR plus the upcoming ChartTooltip slot PR.

## Test plan
- [x] 6 new bUnit tests in `SidebarTests` (collapsed/not-collapsed widths, mouseenter expands, mouseleave collapses, focusin expands for keyboard a11y, Icon variant ignores hover) — pass
- [x] 21/21 Sidebar suite passes (15 prior + 6 new) — no regressions
- [x] `dotnet build src/Lumeo + docs/Lumeo.Docs -c Release` succeeds; one new docs demo
- [ ] CI build-and-test + e2e

---
_Generated by [Claude Code](https://claude.ai/code/session_01LJmBFYeCdQj2G2epoZaRzQ)_