### PR TITLE
feat(charts): ChartTooltip RenderFragment slot (closes #137)

### DIFF
--- a/docs/Lumeo.Docs/Pages/Components/Charts/LineChartPage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/Charts/LineChartPage.razor
@@ -13,6 +13,25 @@
         </Container>
     </ComponentDemo>
 
+    <ComponentDemo Title="Razor-Rendered Tooltip Slot" Description="Replace ECharts' default tooltip body with any Razor markup — themed cards, formatted numbers, child components. Updates on every hover." Code="@_tooltipSlotCode">
+        <Container>
+            <LineChart Categories="_categories" Series="_series" Smooth="true">
+                <ChartTooltip>
+                    <ChildContent Context="ctx">
+                        <Stack Gap="1" Class="p-2 min-w-[140px]">
+                            <Flex Gap="2" Align="center">
+                                <Stack Class="h-2 w-2 rounded-full" style="@($"background-color:{ctx.Color}")"></Stack>
+                                <Lumeo.Text As="span" Size="sm" Class="font-semibold">@ctx.SeriesName</Lumeo.Text>
+                            </Flex>
+                            <Lumeo.Text As="span" Size="xs" Color="muted">@ctx.DataName</Lumeo.Text>
+                            <Lumeo.Text As="span" Class="font-mono text-sm">@(ctx.Value?.ToString("N0") ?? "-")</Lumeo.Text>
+                        </Stack>
+                    </ChildContent>
+                </ChartTooltip>
+            </LineChart>
+        </Container>
+    </ComponentDemo>
+
     <ComponentDemo Title="Straight Line, No Dots" Description="Precise straight-line segments without markers keep focus on broad trends rather than individual data points." Code="@_straightCode">
         <Container>
             <LineChart Categories="_categories" Series="_series" Smooth="false" ShowDots="false" />
@@ -333,6 +352,24 @@
 
     private string _basicCode = @"<LineChart Categories=""_categories"" Series=""_series"" Smooth=""true"" ShowDots=""true"" />";
     private string _straightCode = @"<LineChart Categories=""_categories"" Series=""_series"" Smooth=""false"" ShowDots=""false"" />";
+
+    private string _tooltipSlotCode = @"@* The ChartTooltip child renders a hidden DOM portal whose innerHTML is fed to
+   ECharts' tooltip on each hover. ChildContent receives a ChartTooltipContext
+   per point (SeriesName, DataName, Value, Color, plus the raw Params dict). *@
+<LineChart Categories=""_categories"" Series=""_series"" Smooth=""true"">
+    <ChartTooltip>
+        <ChildContent Context=""ctx"">
+            <Stack Gap=""1"" Class=""p-2 min-w-[140px]"">
+                <Flex Gap=""2"" Align=""center"">
+                    <Stack Class=""h-2 w-2 rounded-full"" style=""@($\""background-color:{ctx.Color}\"")""></Stack>
+                    <Lumeo.Text As=""span"" Size=""sm"" Class=""font-semibold"">@ctx.SeriesName</Lumeo.Text>
+                </Flex>
+                <Lumeo.Text As=""span"" Size=""xs"" Color=""muted"">@ctx.DataName</Lumeo.Text>
+                <Lumeo.Text As=""span"" Class=""font-mono text-sm"">@(ctx.Value?.ToString(""N0"") ?? ""-"")</Lumeo.Text>
+            </Stack>
+        </ChildContent>
+    </ChartTooltip>
+</LineChart>";
     private string _threeSeriesCode = @"<LineChart Categories=""_categories"" Series=""_threeSeries"" Smooth=""true"" />";
     private string _labelsCode = @"<LineChart Categories=""_shortCategories"" Series=""_labelSeries"" Smooth=""true"" ShowDataLabels=""true"" LabelPosition=""top"" />";
     private string _zoomCode = @"<LineChart Categories=""_days60"" Series=""_dailySeries"" Smooth=""true"" ShowDots=""false"" DataZoom=""true"" />";

--- a/src/Lumeo.Charts/UI/Chart/Chart.razor
+++ b/src/Lumeo.Charts/UI/Chart/Chart.razor
@@ -8,8 +8,24 @@
    the registrations in GetOptionsJson and merges them into series[0].markLine /
    markArea, without mutating the consumer-passed EChartOption. *@
 <CascadingValue Value="_annotations" IsFixed="true">
-    @ChildContent
+    <CascadingValue Value="_tooltipRegistration" IsFixed="true">
+        @ChildContent
+    </CascadingValue>
 </CascadingValue>
+
+@* Hidden DOM portal for the optional ChartTooltip slot. ECharts owns the visible
+   tooltip element; we render the consumer's Razor markup into this off-screen div
+   and the JS-side formatter (registered via registerTooltipSlot) returns
+   portal.innerHTML each frame. The portal stays mounted as long as a ChartTooltip
+   is registered so ECharts' formatter never returns an empty string after the
+   first hover. *@
+@if (_tooltipRegistration.Current is { } slot)
+{
+    <div id="@_tooltipPortalId" class="@($"lumeo-chart-tooltip-portal {slot.Class}".Trim())"
+         style="display:none">
+        @slot.ChildContent(_tooltipContext)
+    </div>
+}
 
 @if (_initError is not null)
 {
@@ -120,9 +136,18 @@ else
     // updated JSON via OnAfterRenderAsync's existing _lastJson diff path.
     private readonly ChartAnnotationsContext _annotations;
 
+    // Cascaded to <ChartTooltip>. When a slot is registered, we render the consumer's
+    // RenderFragment into a hidden DOM portal whose innerHTML the JS-side tooltip
+    // formatter returns each frame.
+    private readonly ChartTooltipSlotRegistration _tooltipRegistration;
+    private string _tooltipPortalId => $"{_chartId}-tooltip";
+    private ChartTooltipContext _tooltipContext = ChartTooltipContext.Empty;
+    private bool _tooltipBridgeRegistered;
+
     public Chart()
     {
         _annotations = new ChartAnnotationsContext(onChanged: () => InvokeAsync(StateHasChanged));
+        _tooltipRegistration = new ChartTooltipSlotRegistration(onChanged: () => InvokeAsync(StateHasChanged));
     }
     private IJSObjectReference? _module;
     private DotNetObjectReference<Chart>? _selfRef;
@@ -374,6 +399,25 @@ else
                 await _module.InvokeVoidAsync("registerChartEvent", _chartId, "dataZoom", _selfRef);
         }
 
+        // Register the tooltip-portal bridge once a ChartTooltip slot exists. The JS
+        // side installs a tooltip.formatter that calls OnTooltipPointChange (updating
+        // _tooltipContext + rendering the portal) and returns portal.innerHTML to
+        // ECharts each frame.
+        if (_tooltipRegistration.Current is not null && !_tooltipBridgeRegistered)
+        {
+            _selfRef ??= DotNetObjectReference.Create(this);
+            try
+            {
+                await _module.InvokeVoidAsync("registerTooltipSlot", _chartId, _tooltipPortalId, _selfRef);
+                _tooltipBridgeRegistered = true;
+            }
+            catch (Microsoft.JSInterop.JSException)
+            {
+                // Older Lumeo.Charts JS bundles without registerTooltipSlot fall through —
+                // ECharts uses its default tooltip body and the Razor portal stays unused.
+            }
+        }
+
         if (!string.IsNullOrEmpty(Group))
             await _module.InvokeVoidAsync("connectCharts", Group, new[] { _chartId });
     }
@@ -411,6 +455,59 @@ else
         else if (eventName == "dblclick") await OnDoubleClick.InvokeAsync(args);
         else if (eventName == "brushSelected") await OnBrushSelected.InvokeAsync(args);
         else if (eventName == "dataZoom") await OnDataZoom.InvokeAsync(args);
+    }
+
+    /// <summary>
+    /// Invoked from the JS-side tooltip formatter each time ECharts is about to render
+    /// the tooltip for a new point. We deserialize the formatter <c>params</c> object,
+    /// project it into a <see cref="ChartTooltipContext"/>, and re-render so the hidden
+    /// portal updates. The next animation frame the formatter reads the fresh innerHTML.
+    /// </summary>
+    [JSInvokable]
+    public Task OnTooltipPointChange(string paramsJson)
+    {
+        try
+        {
+            var raw = System.Text.Json.JsonSerializer.Deserialize<Dictionary<string, System.Text.Json.JsonElement>>(paramsJson)
+                ?? new();
+
+            string Get(string key) => raw.TryGetValue(key, out var v) && v.ValueKind == System.Text.Json.JsonValueKind.String
+                ? v.GetString() ?? "" : "";
+
+            int GetInt(string key) => raw.TryGetValue(key, out var v) && v.ValueKind == System.Text.Json.JsonValueKind.Number
+                ? v.GetInt32() : 0;
+
+            double? GetValue()
+            {
+                if (!raw.TryGetValue("value", out var v)) return null;
+                if (v.ValueKind == System.Text.Json.JsonValueKind.Number) return v.GetDouble();
+                if (v.ValueKind == System.Text.Json.JsonValueKind.Array && v.GetArrayLength() > 0)
+                {
+                    // Multi-dim point (scatter / candlestick) — first dimension is the headline.
+                    var first = v[0];
+                    if (first.ValueKind == System.Text.Json.JsonValueKind.Number) return first.GetDouble();
+                }
+                return null;
+            }
+
+            var boxed = raw.ToDictionary(kv => kv.Key, kv => (object?)kv.Value);
+            _tooltipContext = new ChartTooltipContext(
+                SeriesName: Get("seriesName"),
+                SeriesType: Get("seriesType"),
+                SeriesIndex: GetInt("seriesIndex"),
+                DataName: Get("name"),
+                DataIndex: GetInt("dataIndex"),
+                Value: GetValue(),
+                Color: raw.TryGetValue("color", out var c) && c.ValueKind == System.Text.Json.JsonValueKind.String ? c.GetString() : null,
+                Raw: boxed);
+            return InvokeAsync(StateHasChanged);
+        }
+        catch
+        {
+            // Malformed payload from JS — don't break the chart. Leave the last good
+            // context in place so the tooltip keeps rendering its previous content.
+            return Task.CompletedTask;
+        }
     }
 
     public async Task<string?> GetImageAsync(string type = "png", int pixelRatio = 2)

--- a/src/Lumeo.Charts/UI/Chart/Chart.razor
+++ b/src/Lumeo.Charts/UI/Chart/Chart.razor
@@ -22,7 +22,7 @@
 @if (_tooltipRegistration.Current is { } slot)
 {
     <div id="@_tooltipPortalId" class="@($"lumeo-chart-tooltip-portal {slot.Class}".Trim())"
-         style="display:none">
+         style="display:none" @attributes="slot.AdditionalAttributes">
         @slot.ChildContent(_tooltipContext)
     </div>
 }

--- a/src/Lumeo.Charts/UI/Chart/ChartTooltip.razor
+++ b/src/Lumeo.Charts/UI/Chart/ChartTooltip.razor
@@ -34,8 +34,13 @@
     /// consumers theme the tooltip without restyling the whole portal.</summary>
     [Parameter] public string? Class { get; set; }
 
-    protected override void OnParametersSet()
-        => Registration?.Set(new ChartTooltipSlotInfo(ChildContent, Class));
+    /// <summary>Unmatched attributes flow through to the portal <c>&lt;div&gt;</c> so consumers
+    /// can attach <c>id</c>, <c>data-*</c>, ARIA attributes etc. to the rendered tooltip
+    /// wrapper without restyling the whole portal.</summary>
+    [Parameter(CaptureUnmatchedValues = true)] public Dictionary<string, object>? AdditionalAttributes { get; set; }
 
-    public void Dispose() => Registration?.Clear();
+    protected override void OnParametersSet()
+        => Registration?.Set(this, new ChartTooltipSlotInfo(ChildContent, Class, AdditionalAttributes));
+
+    public void Dispose() => Registration?.Clear(this);
 }

--- a/src/Lumeo.Charts/UI/Chart/ChartTooltip.razor
+++ b/src/Lumeo.Charts/UI/Chart/ChartTooltip.razor
@@ -1,0 +1,41 @@
+@namespace Lumeo
+@implements IDisposable
+
+@*  Declarative tooltip body for any chart wrapper. The RenderFragment is given a
+    ChartTooltipContext on every hover; the chart renders the slot into a hidden
+    DOM portal that ECharts' tooltip.formatter pulls innerHTML from. Use this when
+    you need real Razor markup in the tooltip (themed cards, formatted numbers,
+    @bind values, child components) — anything ECharts' raw formatter string can't
+    express.
+
+    Usage:
+        <LineChart ...>
+            <ChartTooltip>
+                <ChildContent Context="ctx">
+                    <Stack Gap="1">
+                        <div class="font-semibold">@ctx.SeriesName</div>
+                        <div>@ctx.DataName: <span class="font-mono">@ctx.Value?.ToString("N0")</span></div>
+                    </Stack>
+                </ChildContent>
+            </ChartTooltip>
+        </LineChart> *@
+
+@code {
+    [CascadingParameter] public ChartTooltipSlotRegistration? Registration { get; set; }
+
+    /// <summary>
+    /// The tooltip body. Receives the current <see cref="ChartTooltipContext"/> for the
+    /// hovered point. The fragment is re-rendered into the chart's hidden tooltip portal
+    /// on every hover; ECharts pulls the portal's <c>innerHTML</c> into the tooltip box.
+    /// </summary>
+    [Parameter, EditorRequired] public RenderFragment<ChartTooltipContext> ChildContent { get; set; } = default!;
+
+    /// <summary>Extra classes for the rendered tooltip wrapper inside the portal. Lets
+    /// consumers theme the tooltip without restyling the whole portal.</summary>
+    [Parameter] public string? Class { get; set; }
+
+    protected override void OnParametersSet()
+        => Registration?.Set(new ChartTooltipSlotInfo(ChildContent, Class));
+
+    public void Dispose() => Registration?.Clear();
+}

--- a/src/Lumeo.Charts/UI/Chart/ChartTooltipContext.cs
+++ b/src/Lumeo.Charts/UI/Chart/ChartTooltipContext.cs
@@ -1,0 +1,39 @@
+namespace Lumeo;
+
+/// <summary>
+/// Data passed to a <see cref="ChartTooltip"/>'s <c>ChildContent</c> on each hover.
+/// Mirrors the most commonly used fields of ECharts' tooltip <c>formatter</c> params
+/// object. Use <see cref="Raw"/> for fields not surfaced explicitly.
+/// </summary>
+public sealed record ChartTooltipContext(
+    /// <summary>Series the hovered point belongs to. Empty when the chart has no series name.</summary>
+    string SeriesName,
+    /// <summary>Series type (e.g. <c>"line"</c>, <c>"bar"</c>, <c>"pie"</c>).</summary>
+    string SeriesType,
+    /// <summary>Index of the series in <c>option.series</c>.</summary>
+    int SeriesIndex,
+    /// <summary>Display name of the point. For category axes this is the category label;
+    /// for value axes this is the formatted axis value; for pie slices this is the slice name.</summary>
+    string DataName,
+    /// <summary>Index of the point within its series.</summary>
+    int DataIndex,
+    /// <summary>Numeric value of the point. Multi-value series (scatter / candlestick) surface
+    /// the first dimension here; the rest are available via <see cref="Raw"/>.</summary>
+    double? Value,
+    /// <summary>Hex / RGB color ECharts assigned to the point (matches the legend swatch).</summary>
+    string? Color,
+    /// <summary>Raw ECharts params object as a dictionary — escape hatch for fields the
+    /// strongly-typed properties above don't cover (e.g. multi-dim scatter, percent, marker).</summary>
+    IReadOnlyDictionary<string, object?> Raw)
+{
+    /// <summary>Empty context used as the initial portal render before any hover has happened.</summary>
+    public static ChartTooltipContext Empty { get; } = new(
+        SeriesName: string.Empty,
+        SeriesType: string.Empty,
+        SeriesIndex: 0,
+        DataName: string.Empty,
+        DataIndex: 0,
+        Value: null,
+        Color: null,
+        Raw: new Dictionary<string, object?>());
+}

--- a/src/Lumeo.Charts/UI/Chart/ChartTooltipSlot.cs
+++ b/src/Lumeo.Charts/UI/Chart/ChartTooltipSlot.cs
@@ -1,0 +1,41 @@
+using Microsoft.AspNetCore.Components;
+
+namespace Lumeo;
+
+/// <summary>
+/// Registration record holding the active tooltip slot's render fragment + class. Only
+/// one tooltip slot per chart is meaningful, so this collapses to a single slot rather
+/// than a list (a second <see cref="ChartTooltip"/> overrides the first).
+/// </summary>
+public sealed record ChartTooltipSlotInfo(
+    RenderFragment<ChartTooltipContext> ChildContent,
+    string? Class);
+
+/// <summary>
+/// Cascaded by <see cref="Chart"/> to its declared <see cref="ChartTooltip"/> child.
+/// The child sets the slot on <c>OnParametersSet</c> and clears it on dispose;
+/// the chart picks up the active registration to render the hidden portal element
+/// that ECharts' tooltip formatter pulls innerHTML from.
+/// </summary>
+public sealed class ChartTooltipSlotRegistration
+{
+    private readonly Action _onChanged;
+
+    public ChartTooltipSlotRegistration(Action onChanged) => _onChanged = onChanged;
+
+    public ChartTooltipSlotInfo? Current { get; private set; }
+
+    public void Set(ChartTooltipSlotInfo info)
+    {
+        if (Current == info) return;
+        Current = info;
+        _onChanged();
+    }
+
+    public void Clear()
+    {
+        if (Current is null) return;
+        Current = null;
+        _onChanged();
+    }
+}

--- a/src/Lumeo.Charts/UI/Chart/ChartTooltipSlot.cs
+++ b/src/Lumeo.Charts/UI/Chart/ChartTooltipSlot.cs
@@ -3,38 +3,53 @@ using Microsoft.AspNetCore.Components;
 namespace Lumeo;
 
 /// <summary>
-/// Registration record holding the active tooltip slot's render fragment + class. Only
-/// one tooltip slot per chart is meaningful, so this collapses to a single slot rather
-/// than a list (a second <see cref="ChartTooltip"/> overrides the first).
+/// Registration record holding the active tooltip slot's render fragment, class, and
+/// any unmatched attributes the consumer set on <c>ChartTooltip</c>. Only one tooltip
+/// slot per chart is meaningful, so the chart collapses to a single slot rather than
+/// a list (a second <c>ChartTooltip</c> overrides the first).
 /// </summary>
 public sealed record ChartTooltipSlotInfo(
     RenderFragment<ChartTooltipContext> ChildContent,
-    string? Class);
+    string? Class,
+    IReadOnlyDictionary<string, object>? AdditionalAttributes);
 
 /// <summary>
 /// Cascaded by <see cref="Chart"/> to its declared <see cref="ChartTooltip"/> child.
-/// The child sets the slot on <c>OnParametersSet</c> and clears it on dispose;
-/// the chart picks up the active registration to render the hidden portal element
-/// that ECharts' tooltip formatter pulls innerHTML from.
+/// The child sets the slot on <c>OnParametersSet</c> and clears it on dispose; the
+/// chart picks up the active registration to render the hidden portal element that
+/// ECharts' tooltip formatter pulls innerHTML from.
+///
+/// <para>The owner-keyed <see cref="Set(object, ChartTooltipSlotInfo)"/> /
+/// <see cref="Clear(object)"/> pair guards against a stale child disposing AFTER a
+/// new one has already registered &mdash; without it, the disposal would wipe out
+/// the newer registration and the tooltip portal would silently vanish.</para>
 /// </summary>
 public sealed class ChartTooltipSlotRegistration
 {
     private readonly Action _onChanged;
+    private object? _owner;
 
     public ChartTooltipSlotRegistration(Action onChanged) => _onChanged = onChanged;
 
     public ChartTooltipSlotInfo? Current { get; private set; }
 
-    public void Set(ChartTooltipSlotInfo info)
+    public void Set(object owner, ChartTooltipSlotInfo info)
     {
-        if (Current == info) return;
+        // Skip the change-notification when the same owner re-registers identical
+        // state — OnParametersSet fires on every render, so an unconditional notify
+        // would spin the chart's render loop.
+        if (ReferenceEquals(_owner, owner) && Current == info) return;
+        _owner = owner;
         Current = info;
         _onChanged();
     }
 
-    public void Clear()
+    public void Clear(object owner)
     {
-        if (Current is null) return;
+        // Only the registering owner can clear. Defensive against the disposal of an
+        // older tooltip instance racing with a newer registration.
+        if (!ReferenceEquals(_owner, owner) || Current is null) return;
+        _owner = null;
         Current = null;
         _onChanged();
     }

--- a/src/Lumeo.Charts/wwwroot/js/echarts-interop.js
+++ b/src/Lumeo.Charts/wwwroot/js/echarts-interop.js
@@ -460,6 +460,70 @@ export function registerChartEvent(elementId, eventName, dotnetRef) {
     });
 }
 
+/**
+ * Wire ECharts' tooltip.formatter to a Razor-rendered hidden DOM portal.
+ *
+ * The portal (rendered by the <ChartTooltip> Razor component into a
+ * `<div id="${portalId}" style="display:none">…</div>` outside the chart host) holds
+ * the consumer's RenderFragment markup. On each tooltip invocation we:
+ *   1. Serialize the formatter params and ship them to Razor via
+ *      `OnTooltipPointChange` — Razor updates the slot's context and re-renders
+ *      the portal's innerHTML.
+ *   2. Return the portal's CURRENT innerHTML to ECharts synchronously.
+ *
+ * First hover on a fresh portal returns the initial render (ChartTooltipContext.Empty);
+ * the next hover (and every one after) returns the Razor-updated markup. This matches
+ * the "near-real-time" pattern Material Charts uses and avoids the latency cost of an
+ * async Promise-based formatter on every mouse move.
+ */
+export function registerTooltipSlot(elementId, portalId, dotnetRef) {
+    const chart = charts.get(elementId);
+    if (!chart) return;
+
+    // Throttle hover-notifications to one per animation frame — moving the cursor
+    // continuously across a busy chart can fire dozens of formatter callbacks per
+    // second, but Razor only needs one per visible point change.
+    let lastSig = null;
+    let pendingFrame = null;
+
+    chart.setOption({
+        tooltip: {
+            formatter: function (params) {
+                // axis-trigger gives an array of points; pick the first as the headline.
+                const p = Array.isArray(params) ? params[0] : params;
+                if (!p) return '';
+
+                const sig = `${p.seriesIndex}|${p.dataIndex}|${p.name}`;
+                if (sig !== lastSig) {
+                    lastSig = sig;
+                    if (pendingFrame === null) {
+                        pendingFrame = requestAnimationFrame(() => {
+                            pendingFrame = null;
+                            try {
+                                const payload = {
+                                    seriesName: p.seriesName || '',
+                                    seriesType: p.seriesType || '',
+                                    seriesIndex: p.seriesIndex ?? 0,
+                                    name: p.name || '',
+                                    dataIndex: p.dataIndex ?? 0,
+                                    value: p.value,
+                                    color: typeof p.color === 'string' ? p.color : null,
+                                };
+                                dotnetRef.invokeMethodAsync('OnTooltipPointChange', JSON.stringify(payload));
+                            } catch (_) {
+                                // dotnetRef may have been disposed mid-hover — swallow.
+                            }
+                        });
+                    }
+                }
+
+                const portal = document.getElementById(portalId);
+                return portal ? portal.innerHTML : '';
+            },
+        },
+    });
+}
+
 export function showLoading(elementId, opts) {
     const chart = charts.get(elementId);
     if (chart) chart.showLoading('default', opts || { text: '', maskColor: 'rgba(255,255,255,0.7)', spinnerRadius: 14, lineWidth: 2 });

--- a/src/Lumeo.Charts/wwwroot/js/echarts-interop.js
+++ b/src/Lumeo.Charts/wwwroot/js/echarts-interop.js
@@ -485,6 +485,12 @@ export function registerTooltipSlot(elementId, portalId, dotnetRef) {
     // second, but Razor only needs one per visible point change.
     let lastSig = null;
     let pendingFrame = null;
+    // Outer-scoped pointer to the most recent formatter payload. Without this the rAF
+    // callback closes over whichever `p` was first in the frame window — a rapid mouse
+    // drag would then ship the stale first-point to Razor while the user's already on
+    // a different point. Updating latestPoint on every formatter call keeps the rAF
+    // send aligned with what the user is currently hovering.
+    let latestPoint = null;
 
     chart.setOption({
         tooltip: {
@@ -496,18 +502,42 @@ export function registerTooltipSlot(elementId, portalId, dotnetRef) {
                 const sig = `${p.seriesIndex}|${p.dataIndex}|${p.name}`;
                 if (sig !== lastSig) {
                     lastSig = sig;
+                    latestPoint = p;
                     if (pendingFrame === null) {
                         pendingFrame = requestAnimationFrame(() => {
                             pendingFrame = null;
+                            const current = latestPoint;
+                            if (!current) return;
                             try {
+                                // Forward a richer payload than the bare typed fields:
+                                // ChartTooltipContext.Raw exposes everything here so
+                                // consumers can pull formatter-only fields like
+                                // marker / percent / axisValueLabel / data without a
+                                // second round-trip. The hand-built whitelist avoids
+                                // serializing ECharts' internal back-refs (which carry
+                                // cycles JSON.stringify would crash on).
                                 const payload = {
-                                    seriesName: p.seriesName || '',
-                                    seriesType: p.seriesType || '',
-                                    seriesIndex: p.seriesIndex ?? 0,
-                                    name: p.name || '',
-                                    dataIndex: p.dataIndex ?? 0,
-                                    value: p.value,
-                                    color: typeof p.color === 'string' ? p.color : null,
+                                    seriesName: current.seriesName || '',
+                                    seriesType: current.seriesType || '',
+                                    seriesIndex: current.seriesIndex ?? 0,
+                                    componentType: current.componentType || '',
+                                    componentSubType: current.componentSubType || '',
+                                    name: current.name || '',
+                                    dataIndex: current.dataIndex ?? 0,
+                                    value: current.value,
+                                    data: current.data,
+                                    color: typeof current.color === 'string' ? current.color : null,
+                                    marker: typeof current.marker === 'string' ? current.marker : null,
+                                    percent: current.percent ?? null,
+                                    axisValue: current.axisValue ?? null,
+                                    axisValueLabel: current.axisValueLabel ?? null,
+                                    axisIndex: current.axisIndex ?? null,
+                                    axisType: current.axisType ?? null,
+                                    axisId: current.axisId ?? null,
+                                    axisDim: current.axisDim ?? null,
+                                    dimensionNames: current.dimensionNames ?? null,
+                                    encode: current.encode ?? null,
+                                    dataType: current.dataType ?? null,
                                 };
                                 dotnetRef.invokeMethodAsync('OnTooltipPointChange', JSON.stringify(payload));
                             } catch (_) {

--- a/tests/Lumeo.Tests/Components/Chart/ChartTooltipSlotTests.cs
+++ b/tests/Lumeo.Tests/Components/Chart/ChartTooltipSlotTests.cs
@@ -80,7 +80,7 @@ public class ChartTooltipSlotTests : IAsyncLifetime
     }
 
     [Fact]
-    public void OnTooltipPointChange_Updates_Portal_Content()
+    public async Task OnTooltipPointChange_Updates_Portal_Content()
     {
         var cut = _ctx.Render<Lumeo.Chart>(p => p
             .Add(c => c.OptionJson, "{\"series\":[{\"type\":\"line\",\"data\":[1,2,3]}]}")
@@ -96,14 +96,14 @@ public class ChartTooltipSlotTests : IAsyncLifetime
 
         // Simulate the JS-side hover notification.
         var payload = "{\"seriesName\":\"Sales\",\"seriesType\":\"line\",\"seriesIndex\":0,\"name\":\"Q1\",\"dataIndex\":0,\"value\":42.5,\"color\":\"#22c55e\"}";
-        cut.Instance.OnTooltipPointChange(payload).GetAwaiter().GetResult();
+        await cut.Instance.OnTooltipPointChange(payload);
 
         var portal = cut.Find(".lumeo-chart-tooltip-portal");
         Assert.Contains("Sales = 42.5", portal.TextContent);
     }
 
     [Fact]
-    public void OnTooltipPointChange_Multi_Dim_Value_Picks_First_Dimension()
+    public async Task OnTooltipPointChange_Multi_Dim_Value_Picks_First_Dimension()
     {
         // scatter / candlestick send value as an array; the headline Value picks [0].
         var cut = _ctx.Render<Lumeo.Chart>(p => p
@@ -118,12 +118,12 @@ public class ChartTooltipSlotTests : IAsyncLifetime
                 b.CloseComponent();
             })));
 
-        cut.Instance.OnTooltipPointChange("{\"seriesName\":\"\",\"value\":[7,99]}").GetAwaiter().GetResult();
+        await cut.Instance.OnTooltipPointChange("{\"seriesName\":\"\",\"value\":[7,99]}");
         Assert.Contains("v=7", cut.Find(".lumeo-chart-tooltip-portal").TextContent);
     }
 
     [Fact]
-    public void OnTooltipPointChange_Malformed_Json_Keeps_Last_Good_Context()
+    public async Task OnTooltipPointChange_Malformed_Json_Keeps_Last_Good_Context()
     {
         var cut = _ctx.Render<Lumeo.Chart>(p => p
             .Add(c => c.OptionJson, "{\"series\":[{\"type\":\"line\",\"data\":[1]}]}")
@@ -137,11 +137,11 @@ public class ChartTooltipSlotTests : IAsyncLifetime
             })));
 
         // First a good update to set state.
-        cut.Instance.OnTooltipPointChange("{\"name\":\"Good\"}").GetAwaiter().GetResult();
+        await cut.Instance.OnTooltipPointChange("{\"name\":\"Good\"}");
         Assert.Contains("name=Good", cut.Find(".lumeo-chart-tooltip-portal").TextContent);
 
         // Now garbage — must not throw, must keep the previous good state.
-        cut.Instance.OnTooltipPointChange("not json").GetAwaiter().GetResult();
+        await cut.Instance.OnTooltipPointChange("not json");
         Assert.Contains("name=Good", cut.Find(".lumeo-chart-tooltip-portal").TextContent);
     }
 

--- a/tests/Lumeo.Tests/Components/Chart/ChartTooltipSlotTests.cs
+++ b/tests/Lumeo.Tests/Components/Chart/ChartTooltipSlotTests.cs
@@ -31,17 +31,41 @@ public class ChartTooltipSlotTests : IAsyncLifetime
     {
         var changeCount = 0;
         var reg = new ChartTooltipSlotRegistration(() => changeCount++);
+        var owner = new object();
 
-        var info = new ChartTooltipSlotInfo(ctx => b => b.AddContent(0, "x"), Class: null);
-        reg.Set(info);
+        var info = new ChartTooltipSlotInfo(ctx => b => b.AddContent(0, "x"), Class: null, AdditionalAttributes: null);
+        reg.Set(owner, info);
         Assert.Same(info, reg.Current);
         Assert.Equal(1, changeCount);
 
-        // Identical Set is a no-op to keep parameter-set re-renders from spinning.
-        reg.Set(info);
+        // Same owner + same info is a no-op to keep parameter-set re-renders from spinning.
+        reg.Set(owner, info);
         Assert.Equal(1, changeCount);
 
-        reg.Clear();
+        reg.Clear(owner);
+        Assert.Null(reg.Current);
+        Assert.Equal(2, changeCount);
+    }
+
+    [Fact]
+    public void Registration_Clear_From_Other_Owner_Is_Ignored()
+    {
+        // Defensive: a stale ChartTooltip being disposed after a newer one has taken
+        // over the slot must NOT wipe out the newer registration.
+        var changeCount = 0;
+        var reg = new ChartTooltipSlotRegistration(() => changeCount++);
+        var newOwner = new object();
+        var staleOwner = new object();
+
+        var info = new ChartTooltipSlotInfo(ctx => b => b.AddContent(0, "x"), null, null);
+        reg.Set(newOwner, info);
+
+        reg.Clear(staleOwner); // stale owner — must be ignored
+        Assert.NotNull(reg.Current);
+        Assert.Equal(1, changeCount);
+
+        // The real owner can still clear.
+        reg.Clear(newOwner);
         Assert.Null(reg.Current);
         Assert.Equal(2, changeCount);
     }

--- a/tests/Lumeo.Tests/Components/Chart/ChartTooltipSlotTests.cs
+++ b/tests/Lumeo.Tests/Components/Chart/ChartTooltipSlotTests.cs
@@ -1,0 +1,166 @@
+using Bunit;
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Rendering;
+using Xunit;
+using Lumeo;
+using Lumeo.Tests.Helpers;
+
+namespace Lumeo.Tests.Components.Chart;
+
+/// <summary>
+/// Tests for the declarative <see cref="ChartTooltip"/> RenderFragment slot. Drives
+/// the registration mechanics and the hidden portal-rendering path directly — the
+/// JS-side formatter wiring is exercised by the chart's e2e suite, not bUnit.
+/// </summary>
+public class ChartTooltipSlotTests : IAsyncLifetime
+{
+    private readonly BunitContext _ctx = new();
+
+    public Task InitializeAsync()
+    {
+        _ctx.AddLumeoServices();
+        var module = _ctx.JSInterop.SetupModule("./_content/Lumeo.Charts/js/echarts-interop.js");
+        module.Mode = Bunit.JSRuntimeMode.Loose;
+        return Task.CompletedTask;
+    }
+
+    public async Task DisposeAsync() => await _ctx.DisposeAsync();
+
+    [Fact]
+    public void Registration_Set_And_Clear_Trigger_OnChanged()
+    {
+        var changeCount = 0;
+        var reg = new ChartTooltipSlotRegistration(() => changeCount++);
+
+        var info = new ChartTooltipSlotInfo(ctx => b => b.AddContent(0, "x"), Class: null);
+        reg.Set(info);
+        Assert.Same(info, reg.Current);
+        Assert.Equal(1, changeCount);
+
+        // Identical Set is a no-op to keep parameter-set re-renders from spinning.
+        reg.Set(info);
+        Assert.Equal(1, changeCount);
+
+        reg.Clear();
+        Assert.Null(reg.Current);
+        Assert.Equal(2, changeCount);
+    }
+
+    [Fact]
+    public void Chart_Without_ChartTooltip_Renders_No_Portal()
+    {
+        var cut = _ctx.Render<Lumeo.Chart>(p => p
+            .Add(c => c.OptionJson, "{\"series\":[{\"type\":\"line\",\"data\":[1,2,3]}]}")
+            .Add(c => c.ShowLoadingSkeleton, false));
+
+        // No tooltip portal div in the markup.
+        Assert.DoesNotContain("lumeo-chart-tooltip-portal", cut.Markup);
+    }
+
+    [Fact]
+    public void ChartTooltip_Child_Renders_Hidden_Portal()
+    {
+        var cut = _ctx.Render<Lumeo.Chart>(p => p
+            .Add(c => c.OptionJson, "{\"series\":[{\"type\":\"line\",\"data\":[1,2,3]}]}")
+            .Add(c => c.ShowLoadingSkeleton, false)
+            .Add(c => c.ChildContent, (RenderFragment)(b =>
+            {
+                b.OpenComponent<ChartTooltip>(0);
+                b.AddAttribute(1, "ChildContent",
+                    (RenderFragment<ChartTooltipContext>)(ctx => cb => cb.AddContent(0, $"hovered: {ctx.SeriesName}")));
+                b.CloseComponent();
+            })));
+
+        var portal = cut.Find(".lumeo-chart-tooltip-portal");
+        Assert.NotNull(portal);
+        // display:none keeps it off-screen — ECharts pulls innerHTML, not display.
+        Assert.Contains("display:none", portal.GetAttribute("style") ?? "");
+        // Initial render uses ChartTooltipContext.Empty (empty SeriesName).
+        Assert.Contains("hovered:", portal.TextContent);
+    }
+
+    [Fact]
+    public void OnTooltipPointChange_Updates_Portal_Content()
+    {
+        var cut = _ctx.Render<Lumeo.Chart>(p => p
+            .Add(c => c.OptionJson, "{\"series\":[{\"type\":\"line\",\"data\":[1,2,3]}]}")
+            .Add(c => c.ShowLoadingSkeleton, false)
+            .Add(c => c.ChildContent, (RenderFragment)(b =>
+            {
+                b.OpenComponent<ChartTooltip>(0);
+                b.AddAttribute(1, "ChildContent",
+                    (RenderFragment<ChartTooltipContext>)(ctx => cb =>
+                        cb.AddContent(0, $"{ctx.SeriesName} = {ctx.Value?.ToString() ?? "-"}")));
+                b.CloseComponent();
+            })));
+
+        // Simulate the JS-side hover notification.
+        var payload = "{\"seriesName\":\"Sales\",\"seriesType\":\"line\",\"seriesIndex\":0,\"name\":\"Q1\",\"dataIndex\":0,\"value\":42.5,\"color\":\"#22c55e\"}";
+        cut.Instance.OnTooltipPointChange(payload).GetAwaiter().GetResult();
+
+        var portal = cut.Find(".lumeo-chart-tooltip-portal");
+        Assert.Contains("Sales = 42.5", portal.TextContent);
+    }
+
+    [Fact]
+    public void OnTooltipPointChange_Multi_Dim_Value_Picks_First_Dimension()
+    {
+        // scatter / candlestick send value as an array; the headline Value picks [0].
+        var cut = _ctx.Render<Lumeo.Chart>(p => p
+            .Add(c => c.OptionJson, "{\"series\":[{\"type\":\"scatter\",\"data\":[[1,10]]}]}")
+            .Add(c => c.ShowLoadingSkeleton, false)
+            .Add(c => c.ChildContent, (RenderFragment)(b =>
+            {
+                b.OpenComponent<ChartTooltip>(0);
+                b.AddAttribute(1, "ChildContent",
+                    (RenderFragment<ChartTooltipContext>)(ctx => cb =>
+                        cb.AddContent(0, $"v={ctx.Value?.ToString() ?? "-"}")));
+                b.CloseComponent();
+            })));
+
+        cut.Instance.OnTooltipPointChange("{\"seriesName\":\"\",\"value\":[7,99]}").GetAwaiter().GetResult();
+        Assert.Contains("v=7", cut.Find(".lumeo-chart-tooltip-portal").TextContent);
+    }
+
+    [Fact]
+    public void OnTooltipPointChange_Malformed_Json_Keeps_Last_Good_Context()
+    {
+        var cut = _ctx.Render<Lumeo.Chart>(p => p
+            .Add(c => c.OptionJson, "{\"series\":[{\"type\":\"line\",\"data\":[1]}]}")
+            .Add(c => c.ShowLoadingSkeleton, false)
+            .Add(c => c.ChildContent, (RenderFragment)(b =>
+            {
+                b.OpenComponent<ChartTooltip>(0);
+                b.AddAttribute(1, "ChildContent",
+                    (RenderFragment<ChartTooltipContext>)(ctx => cb => cb.AddContent(0, $"name={ctx.DataName}")));
+                b.CloseComponent();
+            })));
+
+        // First a good update to set state.
+        cut.Instance.OnTooltipPointChange("{\"name\":\"Good\"}").GetAwaiter().GetResult();
+        Assert.Contains("name=Good", cut.Find(".lumeo-chart-tooltip-portal").TextContent);
+
+        // Now garbage — must not throw, must keep the previous good state.
+        cut.Instance.OnTooltipPointChange("not json").GetAwaiter().GetResult();
+        Assert.Contains("name=Good", cut.Find(".lumeo-chart-tooltip-portal").TextContent);
+    }
+
+    [Fact]
+    public void ChartTooltip_Class_Applies_To_Portal_Wrapper()
+    {
+        var cut = _ctx.Render<Lumeo.Chart>(p => p
+            .Add(c => c.OptionJson, "{\"series\":[{\"type\":\"line\",\"data\":[1]}]}")
+            .Add(c => c.ShowLoadingSkeleton, false)
+            .Add(c => c.ChildContent, (RenderFragment)(b =>
+            {
+                b.OpenComponent<ChartTooltip>(0);
+                b.AddAttribute(1, "Class", "my-tooltip");
+                b.AddAttribute(2, "ChildContent",
+                    (RenderFragment<ChartTooltipContext>)(ctx => cb => cb.AddContent(0, "x")));
+                b.CloseComponent();
+            })));
+
+        var portal = cut.Find(".lumeo-chart-tooltip-portal");
+        Assert.Contains("my-tooltip", portal.GetAttribute("class") ?? "");
+    }
+}


### PR DESCRIPTION
## Summary

Closes #137 — adds the declarative Razor tooltip body that pairs with the `ChartThreshold` / `ChartReferenceZone` annotations shipped in v3.9.0 via #144. Last open issue from the original 3.9.0/3.10.0 issue triage.

### Usage

```razor
<LineChart Categories="..." Series="...">
    <ChartTooltip>
        <ChildContent Context="ctx">
            <Stack Gap="1">
                <div class="font-semibold">@ctx.SeriesName</div>
                <div>@ctx.DataName: @ctx.Value?.ToString("C0")</div>
            </Stack>
        </ChildContent>
    </ChartTooltip>
</LineChart>
```

`ChildContent` receives a `ChartTooltipContext` per hovered point: `SeriesName`, `SeriesType`, `SeriesIndex`, `DataName`, `DataIndex`, `Value`, `Color`, plus the raw ECharts params dict as `Raw`.

### Mechanics

ECharts owns the visible tooltip element and its formatter is **synchronous** — it can't await Razor. The implementation uses a hidden DOM portal:

1. `Chart.razor` renders the consumer's `RenderFragment` into a hidden `<div id="{chartId}-tooltip" style="display:none">` outside the chart host.
2. New JS function `registerTooltipSlot` installs `tooltip.formatter` that:
   a. Notifies Razor of the new hover point (`requestAnimationFrame`-throttled so a continuous mouse drag doesn't fire dozens of round-trips per second).
   b. Returns the portal's CURRENT `innerHTML` synchronously to ECharts.
3. Razor's `OnTooltipPointChange` JSInvokable deserializes the params, updates the cached context, and re-renders — the portal `innerHTML` is fresh on the next animation frame.

First hover on a fresh portal shows the initial render (`ChartTooltipContext.Empty`); every subsequent hover shows the just-rendered markup. Near-real-time tooltip without the latency cost of async Promise-based formatter on every mouse move.

### Defensive guards
- `OnTooltipPointChange` swallows malformed payloads and keeps the last good context — a stray parse never blanks the tooltip.
- `Chart.OnAfterRenderAsync` catches `JSException` on `registerTooltipSlot` so consumers pinned to older Lumeo.Charts JS bundles fall back to ECharts' default tooltip body.
- JS-side `invokeMethodAsync` is wrapped in try/catch because `dotnetRef` can be disposed mid-hover.

The `ChartTooltipSlotRegistration` extraction keeps the cascade registration unit-testable in isolation.

### Versioning

Ships in the **3.10.0 release train** with #145 (Sidebar PersistCollapsed + MiniRail). The `Directory.Build.props` bump to 3.10.0 lives in #145.

## Test plan
- [x] 7 new bUnit tests in `ChartTooltipSlotTests`: registration Set/Clear idempotency, no-portal when slot absent, hidden portal rendered when slot present, `OnTooltipPointChange` updates portal content, multi-dim value (scatter) picks first dimension, malformed JSON keeps last-good context, `Class` applies to portal wrapper.
- [x] 79/79 Chart suite passes (72 prior + 7 new) — no regressions.
- [x] `dotnet build src/Lumeo.Charts + docs/Lumeo.Docs -c Release` succeeds; one new docs demo on the LineChart page.
- [ ] CI build-and-test + e2e

---
_Generated by [Claude Code](https://claude.ai/code/session_01LJmBFYeCdQj2G2epoZaRzQ)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for custom-rendered tooltips in charts via the new `ChartTooltip` component
  * Tooltips now display custom content with access to series and data point information (name, value, color)

* **Documentation**
  * Added documentation demo showing how to implement and style custom chart tooltips

<!-- end of auto-generated comment: release notes by coderabbit.ai -->