### PR TITLE
docs: add live demos for v3.10.0 features that shipped without one

### DIFF
--- a/docs/Lumeo.Docs/Pages/Components/Charts/LineChartPage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/Charts/LineChartPage.razor
@@ -32,6 +32,19 @@
         </Container>
     </ComponentDemo>
 
+    <ComponentDemo Title="Threshold lines + Reference zones"
+                   Description="Declaratively overlay target lines and healthy / critical bands. Each child translates to ECharts' native markLine / markArea without you touching EChartOption."
+                   Code="@_annotationsCode">
+        <Container>
+            <LineChart Categories="_categories" Series="_series" Smooth="true">
+                <ChartReferenceZone From="60" To="90" Color="#22c55e22" Label="Healthy" />
+                <ChartReferenceZone From="0"  To="40" Color="#ef444422" Label="Critical" />
+                <ChartThreshold Value="80" Label="Target" Color="#22c55e" />
+                <ChartThreshold Value="40" Label="SLA"    Color="#ef4444" LineStyle="dotted" />
+            </LineChart>
+        </Container>
+    </ComponentDemo>
+
     <ComponentDemo Title="Straight Line, No Dots" Description="Precise straight-line segments without markers keep focus on broad trends rather than individual data points." Code="@_straightCode">
         <Container>
             <LineChart Categories="_categories" Series="_series" Smooth="false" ShowDots="false" />
@@ -352,6 +365,16 @@
 
     private string _basicCode = @"<LineChart Categories=""_categories"" Series=""_series"" Smooth=""true"" ShowDots=""true"" />";
     private string _straightCode = @"<LineChart Categories=""_categories"" Series=""_series"" Smooth=""false"" ShowDots=""false"" />";
+
+    private string _annotationsCode = @"@* ChartThreshold = horizontal line at a value (yAxis by default).
+   ChartReferenceZone = shaded band between two values on the chosen axis.
+   Both translate to ECharts' native markLine / markArea on series[0]. *@
+<LineChart Categories=""_categories"" Series=""_series"" Smooth=""true"">
+    <ChartReferenceZone From=""60"" To=""90"" Color=""#22c55e22"" Label=""Healthy"" />
+    <ChartReferenceZone From=""0""  To=""40"" Color=""#ef444422"" Label=""Critical"" />
+    <ChartThreshold Value=""80"" Label=""Target"" Color=""#22c55e"" />
+    <ChartThreshold Value=""40"" Label=""SLA""    Color=""#ef4444"" LineStyle=""dotted"" />
+</LineChart>";
 
     private string _tooltipSlotCode = @"@* The ChartTooltip child renders a hidden DOM portal whose innerHTML is fed to
    ECharts' tooltip on each hover. ChildContent receives a ChartTooltipContext

--- a/docs/Lumeo.Docs/Pages/Components/DataGridPage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/DataGridPage.razor
@@ -72,6 +72,24 @@
         </DataGrid>
     </ComponentDemo>
 
+    <ComponentDemo Title="Column Groups + Footer Aggregates"
+                   Description="Wrap related columns under a labelled parent header that spans them via colspan. Set Aggregate=Sum / Average to get the sticky footer total row; FooterFormat lets totals format independently from cells (cells in C0, totals in N0)."
+                   Code="@_columnGroupCode">
+        <DataGrid TItem="Employee" Items="@_employees" PageSize="5" ShowPagination="true">
+            <DataGridColumnGroup TItem="Employee" Label="Identity">
+                <DataGridColumnDef TItem="Employee" Title="Name" Field="Name" Sortable="true" />
+                <DataGridColumnDef TItem="Employee" Title="Department" Field="Department" Sortable="true" />
+            </DataGridColumnGroup>
+            <DataGridColumnGroup TItem="Employee" Label="Compensation">
+                <DataGridColumnDef TItem="Employee" Title="Salary" Field="Salary"
+                                   Sortable="true" Format="C0"
+                                   Aggregate="AggregateType.Sum" FooterFormat="N0" />
+                <DataGridColumnDef TItem="Employee" Title="Tenure" Field="StartDate"
+                                   Sortable="true" Format="yyyy-MM-dd" />
+            </DataGridColumnGroup>
+        </DataGrid>
+    </ComponentDemo>
+
     <ComponentDemo Title="Toolbar, Search & Filtering" Description="Enable the toolbar for global search, column visibility, and CSV export. Column filters appear as inline popovers." Code="@_toolbarCode">
         <DataGrid TItem="Employee" Items="@_employees" PageSize="5" ShowPagination="true" ShowToolbar="true">
             <DataGridColumnDef TItem="Employee" Title="Name" Field="Name" Sortable="true" Filterable="true" />
@@ -1405,6 +1423,23 @@
     <DataGridColumnDef TItem=""Employee"" Title=""Department"" Field=""Department"" Sortable=""true"" />
     <DataGridColumnDef TItem=""Employee"" Title=""Salary"" Field=""Salary"" Sortable=""true"" Format=""C0"" />
     <DataGridColumnDef TItem=""Employee"" Title=""Start Date"" Field=""StartDate"" Format=""yyyy-MM-dd"" />
+</DataGrid>";
+
+    private string _columnGroupCode = @"@* DataGridColumnGroup wraps a contiguous run of column defs under a labelled parent
+   <th colspan>. Set Aggregate on a column to surface a sticky footer total; FooterFormat
+   formats just the total (cells in C0, totals in N0). *@
+<DataGrid TItem=""Employee"" Items=""@employees"">
+    <DataGridColumnGroup TItem=""Employee"" Label=""Identity"">
+        <DataGridColumnDef TItem=""Employee"" Title=""Name"" Field=""Name"" Sortable=""true"" />
+        <DataGridColumnDef TItem=""Employee"" Title=""Department"" Field=""Department"" Sortable=""true"" />
+    </DataGridColumnGroup>
+    <DataGridColumnGroup TItem=""Employee"" Label=""Compensation"">
+        <DataGridColumnDef TItem=""Employee"" Title=""Salary"" Field=""Salary""
+                           Sortable=""true"" Format=""C0""
+                           Aggregate=""AggregateType.Sum"" FooterFormat=""N0"" />
+        <DataGridColumnDef TItem=""Employee"" Title=""Tenure"" Field=""StartDate""
+                           Sortable=""true"" Format=""yyyy-MM-dd"" />
+    </DataGridColumnGroup>
 </DataGrid>";
 
     private string _toolbarCode = @"<DataGrid TItem=""Employee"" Items=""@employees"" PageSize=""5""

--- a/docs/Lumeo.Docs/Pages/Components/InputPage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/InputPage.razor
@@ -101,6 +101,20 @@
         </Stack>
     </ComponentDemo>
 
+    <ComponentDemo Title="Character Counter (ShowCount + MaxLength)" Code="@_countCode">
+        <Stack Gap="3" Class="w-full max-w-sm">
+            <Lumeo.Input @bind-Value="_countedTitle"
+                         Placeholder="Title…"
+                         ShowCount="true"
+                         MaxLength="60" />
+            <Lumeo.Input @bind-Value="_countedSlug"
+                         Placeholder="Slug…"
+                         ShowCount="true"
+                         MaxLength="20"
+                         CountFormat="@(c => $"{c} of 20 chars")" />
+        </Stack>
+    </ComponentDemo>
+
     <ComponentDemo Title="Prefix &amp; Suffix" Code="@_prefixSuffixCode">
         <Stack Gap="3" Class="w-full max-w-sm">
             <Lumeo.Input Placeholder="Search...">
@@ -246,6 +260,16 @@
 
 @code {
     private string _name = "";
+    private string? _countedTitle;
+    private string? _countedSlug;
+
+    private string _countCode = @"@* ShowCount renders a count below the input. With MaxLength the text reads ""N/Max""
+   and flips to text-destructive once the user types past the limit. CountFormat overrides
+   the default ""N/Max"" rendering for fully custom labels. *@
+<Input @bind-Value=""_title"" Placeholder=""Title..."" ShowCount=""true"" MaxLength=""60"" />
+
+<Input @bind-Value=""_slug"" Placeholder=""Slug..."" ShowCount=""true"" MaxLength=""20""
+       CountFormat=""@(c => $""{c} of 20 chars"")"" />";
     private string _previewSize = "Default";
     private Lumeo.Size _inputSizeEnum =>
         Enum.TryParse<Lumeo.Size>(_previewSize, out var s) ? s : Lumeo.Size.Md;

--- a/docs/Lumeo.Docs/Pages/Components/SelectPage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/SelectPage.razor
@@ -156,6 +156,24 @@
         </Stack>
     </ComponentDemo>
 
+    <ComponentDemo Title="Items with Icons + Descriptions (data-bound)" Code="@_richItemSelectCode">
+        <Stack Gap="2" Class="w-full max-w-sm">
+            <Select @bind-Value="_selectedRegion"
+                    Items="_regions"
+                    ItemValue="@(o => ((RegionItem)o).Id)"
+                    ItemText="@(o => ((RegionItem)o).Label)"
+                    ItemDescription="@(o => ((RegionItem)o).Hint)"
+                    ItemIcon="@(o => RenderRegionIcon((RegionItem)o))">
+                <SelectTrigger>
+                    <Text As="span" Class="@(_selectedRegion == null ? "text-muted-foreground" : "")">
+                        @(_selectedRegion == null ? "Pick a region…" : _regions.Cast<RegionItem>().First(r => r.Id == _selectedRegion).Label)
+                    </Text>
+                </SelectTrigger>
+                <SelectContent />
+            </Select>
+        </Stack>
+    </ComponentDemo>
+
     <ComponentDemo Title="Clearable" Code="@_clearableCode">
         <Container MaxWidth="sm" Center="false" Padding="">
             <Select Clearable="true" @bind-Value="_selectedClearable">
@@ -417,6 +435,26 @@
     private List<string>? _selectedFruits;
     private List<string>? _selectedTools;
     private string? _selectedClearable;
+    private string? _selectedRegion;
+
+    private record RegionItem(string Id, string Label, string Hint, string IconName);
+
+    private readonly IEnumerable<object> _regions = new object[]
+    {
+        new RegionItem("eu-west", "EU West",   "Frankfurt — eu-west-1",  "Globe"),
+        new RegionItem("us-east", "US East",   "N. Virginia — us-east-1", "Globe"),
+        new RegionItem("ap-1",    "Asia Pacific","Tokyo — ap-northeast-1", "Globe"),
+    };
+
+    // Uses the docs-site DynamicIcon helper so the icon library swap in the docs
+    // shell applies to live demos too. Return null per item to skip the icon column.
+    private RenderFragment? RenderRegionIcon(RegionItem item) => builder =>
+    {
+        builder.OpenComponent<Lumeo.Docs.Shared.DynamicIcon>(0);
+        builder.AddAttribute(1, "Name", item.IconName);
+        builder.AddAttribute(2, "Class", "h-4 w-4");
+        builder.CloseComponent();
+    };
     private string? _selectedLoading;
 
     private string _defaultCode = @"<Select @bind-Value=""_selected"">
@@ -510,6 +548,19 @@
 @code {
     private List<string>? _selectedFruits;
 }";
+
+    private string _richItemSelectCode = @"@* Data-bound mode: ItemIcon + ItemDescription drive the default item renderer
+   without a custom ItemTemplate. Same Func<object, …> pattern as ItemValue / ItemText.
+   record RegionItem(string Id, string Label, string Hint, SvgIcon Icon); *@
+<Select @bind-Value=""_selected""
+        Items=""_regions""
+        ItemValue=""@(o => ((RegionItem)o).Id)""
+        ItemText=""@(o => ((RegionItem)o).Label)""
+        ItemDescription=""@(o => ((RegionItem)o).Hint)""
+        ItemIcon=""@(o => @<Blazicon Svg=""@(((RegionItem)o).Icon)"" class=""h-4 w-4"" />)"">
+    <SelectTrigger><Text As=""span"">Pick a region…</Text></SelectTrigger>
+    <SelectContent />
+</Select>";
 
     private string _clearableCode = @"<Select Clearable=""true"" @bind-Value=""_selected"">
     <SelectTrigger>


### PR DESCRIPTION
## Summary

The 3.9.0 / 3.10.0 release train added several public-API features whose docs pages got an API-table entry and a code snippet but no actual live `ComponentDemo`. This sweep fills the gaps so every new parameter / variant can be tried directly on the docs site.

### Added demos

| Page | Demo | Covers |
|---|---|---|
| **InputPage** | "Character Counter (`ShowCount` + `MaxLength`)" — a 60-char title field + a 20-char slug with custom `CountFormat` | #136 |
| **SelectPage** | "Items with Icons + Descriptions (data-bound)" — `RegionItem` record using `ItemValue`/`ItemText`/`ItemDescription`/`ItemIcon` (mirror of the existing Combobox demo) | Select half of #134 |
| **DataGridPage** | "Column Groups + Footer Aggregates" — employee grid with Identity / Compensation column groups, plus `Aggregate=Sum` + `FooterFormat=N0` on Salary so the sticky totals row is visible | #135 |
| **LineChartPage** | "Threshold lines + Reference zones" — Healthy/Critical reference bands + Target/SLA threshold lines via `<ChartThreshold>` and `<ChartReferenceZone>` | Annotations half of #137 |

### Scope / versioning

Pure docs change — **no source / version touch**. Per CLAUDE.md Rule #2, docs-only changes don't get a new tag; Cloudflare Pages auto-deploys from master.

## Test plan
- [x] `dotnet build docs/Lumeo.Docs -c Release` succeeds
- [ ] Cloudflare Pages preview shows all 4 demos render + work end-to-end
- [ ] CI build-docs + preview deploy

---
_Generated by [Claude Code](https://claude.ai/code/session_01LJmBFYeCdQj2G2epoZaRzQ)_