### PR TITLE
fix(sidebar): MiniRail hover reveals labels, not just rail width

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
   <!-- Lockstep version shared by all Lumeo packages.
        Update this single property to version all packages in unison. -->
   <PropertyGroup>
-    <Version>3.10.0</Version>
+    <Version>3.10.1</Version>
   </PropertyGroup>
 
   <!-- Shared NuGet README packing lives in Directory.Build.targets, NOT here.

--- a/docs/Lumeo.Docs/Pages/Docs/Changelog.razor
+++ b/docs/Lumeo.Docs/Pages/Docs/Changelog.razor
@@ -15,6 +15,27 @@
 
     <Separator Class="my-4" />
 
+    <!-- v3.10.1 -->
+    <Stack Gap="4">
+        <div class="flex items-center gap-3">
+            <Badge>v3.10.1</Badge>
+            <Lumeo.Text Size="sm" Color="muted">May 2026</Lumeo.Text>
+        </div>
+
+        <Lumeo.Text Size="base" Color="muted" Leading="relaxed">
+            Patch: fixes a label-rendering regression in the v3.10.0 <code class="rounded bg-muted px-1 text-xs">SidebarVariant.MiniRail</code>.
+        </Lumeo.Text>
+
+        <Stack Gap="3">
+            <Heading Level="3" Size="sm" Class="font-semibold">Fixed</Heading>
+            <ul class="space-y-1.5 text-sm list-disc list-inside text-muted-foreground">
+                <li><strong>MiniRail hover now reveals labels</strong>, not just the rail width. The hover state lived only on <code class="rounded bg-muted px-1 text-xs">SidebarComponent</code>, so the cascaded <code class="rounded bg-muted px-1 text-xs">SidebarState</code> kept reporting the pinned <code class="rounded bg-muted px-1 text-xs">IsCollapsed</code> and <code class="rounded bg-muted px-1 text-xs">SidebarMenuButton</code>'s labels stayed at <code class="rounded bg-muted px-1 text-xs">opacity-0</code>. Hover state is now provider-owned and a new <code class="rounded bg-muted px-1 text-xs">EffectiveCollapsed</code> init-property on <code class="rounded bg-muted px-1 text-xs">SidebarState</code> drives both rail width and descendant label visibility. The record's original 3-positional constructor + Deconstruct shape is preserved so v3.10.0 callers compile unchanged.</li>
+            </ul>
+        </Stack>
+    </Stack>
+
+    <Separator Class="my-4" />
+
     <!-- v3.10.0 -->
     <Stack Gap="4">
         <div class="flex items-center gap-3">

--- a/src/Lumeo/UI/Sidebar/SidebarComponent.razor
+++ b/src/Lumeo/UI/Sidebar/SidebarComponent.razor
@@ -24,17 +24,13 @@
 
     private bool IsCollapsed => State?.IsCollapsed ?? false;
     private SidebarProvider.SidebarVariant Variant => State?.Variant ?? SidebarProvider.SidebarVariant.Push;
-
-    // Transient hover/focus-driven expansion for the MiniRail variant. Doesn't touch
-    // IsCollapsed (the user's pinned state), only the rendered width / aria-expanded.
-    private bool _hoverExpanded;
-
     private bool IsMiniRail => Variant == SidebarProvider.SidebarVariant.MiniRail;
 
-    // The effective rendered state. For MiniRail: when collapsed, hover/focus temporarily
-    // expands; when not collapsed it's already full width. For other variants: pinned
-    // expansion is the only signal.
-    private bool EffectivelyExpanded => !IsCollapsed || (IsMiniRail && _hoverExpanded);
+    // The "effective" state from the provider. Drives both the rail width AND the
+    // SidebarMenuButton label visibility via the cascade — without it MiniRail's
+    // hover-expansion only widened the rail while labels stayed hidden.
+    private bool EffectiveCollapsed => State?.EffectiveCollapsed ?? IsCollapsed;
+    private bool EffectivelyExpanded => !EffectiveCollapsed;
 
     private string CssClass
     {
@@ -47,9 +43,10 @@
                 SidebarProvider.SidebarVariant.Overlay =>
                     $"absolute z-40 top-0 {(Side == Lumeo.Side.Right ? "right-0" : "left-0")} w-64 shadow-xl {(IsCollapsed ? (Side == Lumeo.Side.Right ? "translate-x-full" : "-translate-x-full") : "translate-x-0")}",
                 SidebarProvider.SidebarVariant.Icon => $"shrink-0 {(IsCollapsed ? "w-16" : "w-64")}",
-                // MiniRail expands to w-64 whenever effectively expanded (pinned open OR
-                // hover/focus). Otherwise it's the same icon rail as Icon variant.
-                SidebarProvider.SidebarVariant.MiniRail => $"shrink-0 {(EffectivelyExpanded ? "w-64" : "w-16")}",
+                // MiniRail widens to w-64 whenever it's effectively expanded — pinned open
+                // OR hover/focus active. The provider owns the hover bit so the same flag
+                // flows to descendant labels via the cascade.
+                SidebarProvider.SidebarVariant.MiniRail => $"shrink-0 {(EffectiveCollapsed ? "w-16" : "w-64")}",
                 _ => $"shrink-0 {(IsCollapsed ? "w-0 border-r-0" : "w-64")}"
             };
 
@@ -65,16 +62,18 @@
             await State.Toggle.InvokeAsync();
     }
 
-    // Hover / focus handlers are wired for every variant but only MiniRail reacts —
-    // the other variants ignore _hoverExpanded in their CSS computation, so the
-    // state change is harmless (and the no-op render is cheap).
-    private void OnHoverEnter()
+    // Hover / focus handlers route to the provider so the effective state propagates
+    // through the cascade. Only MiniRail acts on the flag in its CSS / label logic;
+    // other variants ignore it (cheap no-op).
+    private async Task OnHoverEnter()
     {
-        if (IsMiniRail && IsCollapsed) _hoverExpanded = true;
+        if (!IsMiniRail || !IsCollapsed || State is null) return;
+        await State.SetHoverExpanded.InvokeAsync(true);
     }
 
-    private void OnHoverLeave()
+    private async Task OnHoverLeave()
     {
-        if (_hoverExpanded) _hoverExpanded = false;
+        if (State is null) return;
+        await State.SetHoverExpanded.InvokeAsync(false);
     }
 }

--- a/src/Lumeo/UI/Sidebar/SidebarMenuButton.razor
+++ b/src/Lumeo/UI/Sidebar/SidebarMenuButton.razor
@@ -31,12 +31,16 @@
     [Parameter] public string? Class { get; set; }
     [Parameter(CaptureUnmatchedValues = true)] public Dictionary<string, object>? AdditionalAttributes { get; set; }
 
-    private bool IsCollapsed => State?.IsCollapsed ?? false;
+    // Drives padding + label opacity. EffectiveCollapsed (provider-computed) reflects
+    // hover-expansion on MiniRail too, so the label reveals while the rail is widened
+    // by the cursor — not just on the pinned-toggle path. Other variants ignore the
+    // hover bit so this stays identical to IsCollapsed for them.
+    private bool EffectiveCollapsed => State?.EffectiveCollapsed ?? State?.IsCollapsed ?? false;
 
     private string CssClass => Cx.Merge(
         "flex items-center gap-3 rounded-lg py-2 min-h-11 sm:min-h-0 text-muted-foreground hover:text-foreground hover:bg-sidebar-accent focus-visible:outline-none focus-visible:ring-[1.5px] focus-visible:ring-ring focus-visible:ring-offset-2 w-full overflow-hidden",
         "transition-[padding,background-color,color] duration-300 ease-out",
-        IsCollapsed ? "px-4" : "px-3",
+        EffectiveCollapsed ? "px-4" : "px-3",
         Cx.When(IsActive, "bg-sidebar-accent text-sidebar-accent-foreground font-medium"),
         Class);
 
@@ -47,5 +51,5 @@
     // awkward mid-state where labels are gone but sidebar is still wide.
     private string LabelCssClass => Cx.Join(
         "whitespace-nowrap transition-opacity duration-150 ease-out",
-        IsCollapsed ? "opacity-0 delay-0" : "opacity-100 delay-150");
+        EffectiveCollapsed ? "opacity-0 delay-0" : "opacity-100 delay-150");
 }

--- a/src/Lumeo/UI/Sidebar/SidebarProvider.razor
+++ b/src/Lumeo/UI/Sidebar/SidebarProvider.razor
@@ -2,7 +2,12 @@
 @inject IComponentInteropService Interop
 
 @{
-    var context = new SidebarState(IsCollapsed, EventCallback.Factory.Create(this, Toggle), Variant);
+    var context = new SidebarState(
+        IsCollapsed,
+        EventCallback.Factory.Create(this, Toggle),
+        Variant,
+        EffectiveCollapsed,
+        EventCallback.Factory.Create<bool>(this, SetHoverExpanded));
 }
 
 <CascadingValue Value="context" IsFixed="false">
@@ -35,6 +40,18 @@
 
     [Parameter] public string? Class { get; set; }
     [Parameter(CaptureUnmatchedValues = true)] public Dictionary<string, object>? AdditionalAttributes { get; set; }
+
+    // Transient hover/focus-driven expansion for the MiniRail variant. Lives on the
+    // provider (not SidebarComponent) so descendants — most importantly
+    // SidebarMenuButton — can react via the cascaded SidebarState and reveal their
+    // LabelContent during hover-expansion, not just on pinned expand.
+    private bool _hoverExpanded;
+
+    // True when the sidebar should render + behave as collapsed for descendants. For
+    // MiniRail this is IsCollapsed unless the user is hovering / keyboard-focused on
+    // the rail. Other variants ignore the hover state.
+    private bool EffectiveCollapsed
+        => IsCollapsed && !(Variant == SidebarVariant.MiniRail && _hoverExpanded);
 
     private string CssClass
     {
@@ -82,7 +99,27 @@
         }
     }
 
-    public record SidebarState(bool IsCollapsed, EventCallback Toggle, SidebarVariant Variant);
+    // Called by SidebarComponent's @onmouseenter / @onmouseleave / focus handlers.
+    // Only meaningful for MiniRail — other variants set this but their CSS / button
+    // logic ignores it via the EffectiveCollapsed predicate.
+    private void SetHoverExpanded(bool value)
+    {
+        if (_hoverExpanded == value) return;
+        _hoverExpanded = value;
+        StateHasChanged();
+    }
+
+    public record SidebarState(
+        bool IsCollapsed,
+        EventCallback Toggle,
+        SidebarVariant Variant,
+        /// <summary>True when descendants should render in their collapsed appearance.
+        /// For MiniRail this is <see cref="IsCollapsed"/> unless the user is hovering
+        /// the rail; other variants always match <see cref="IsCollapsed"/>.</summary>
+        bool EffectiveCollapsed,
+        /// <summary>Called by <c>SidebarComponent</c> on hover / focus to flip the
+        /// MiniRail hover-expansion. No-op for other variants.</summary>
+        EventCallback<bool> SetHoverExpanded);
 
     /// <summary>
     /// Layout strategy for the sidebar.

--- a/src/Lumeo/UI/Sidebar/SidebarProvider.razor
+++ b/src/Lumeo/UI/Sidebar/SidebarProvider.razor
@@ -5,9 +5,11 @@
     var context = new SidebarState(
         IsCollapsed,
         EventCallback.Factory.Create(this, Toggle),
-        Variant,
-        EffectiveCollapsed,
-        EventCallback.Factory.Create<bool>(this, SetHoverExpanded));
+        Variant)
+    {
+        EffectiveCollapsed = EffectiveCollapsed,
+        SetHoverExpanded = EventCallback.Factory.Create<bool>(this, SetHoverExpanded),
+    };
 }
 
 <CascadingValue Value="context" IsFixed="false">
@@ -109,17 +111,24 @@
         StateHasChanged();
     }
 
+    // Kept as a 3-positional record so the v3.10.0 generated constructor + Deconstruct
+    // signature still compiles for external callers (this record is meant for our own
+    // cascade but is technically public). The two new fields land as init-only props
+    // with defaults — fully additive.
     public record SidebarState(
         bool IsCollapsed,
         EventCallback Toggle,
-        SidebarVariant Variant,
+        SidebarVariant Variant)
+    {
         /// <summary>True when descendants should render in their collapsed appearance.
         /// For MiniRail this is <see cref="IsCollapsed"/> unless the user is hovering
         /// the rail; other variants always match <see cref="IsCollapsed"/>.</summary>
-        bool EffectiveCollapsed,
+        public bool EffectiveCollapsed { get; init; } = IsCollapsed;
+
         /// <summary>Called by <c>SidebarComponent</c> on hover / focus to flip the
         /// MiniRail hover-expansion. No-op for other variants.</summary>
-        EventCallback<bool> SetHoverExpanded);
+        public EventCallback<bool> SetHoverExpanded { get; init; }
+    }
 
     /// <summary>
     /// Layout strategy for the sidebar.

--- a/tests/Lumeo.Tests/Components/Sidebar/SidebarTests.cs
+++ b/tests/Lumeo.Tests/Components/Sidebar/SidebarTests.cs
@@ -305,6 +305,46 @@ public class SidebarTests : IAsyncLifetime
     }
 
     [Fact]
+    public void MiniRail_Hover_Reveals_Menu_Button_Labels()
+    {
+        // Bug fix: previously _hoverExpanded lived only on SidebarComponent so the
+        // cascade only saw the pinned IsCollapsed — SidebarMenuButton kept its
+        // labels at opacity-0 even after the rail widened on hover.
+        var cut = _ctx.Render(builder =>
+        {
+            builder.OpenComponent<L.SidebarProvider>(0);
+            builder.AddAttribute(1, "Variant", L.SidebarProvider.SidebarVariant.MiniRail);
+            builder.AddAttribute(2, "IsCollapsed", true);
+            builder.AddAttribute(3, "ChildContent", (RenderFragment)(b =>
+            {
+                b.OpenComponent<L.SidebarComponent>(0);
+                b.AddAttribute(1, "ChildContent", (RenderFragment)(inner =>
+                {
+                    inner.OpenComponent<L.SidebarMenuButton>(0);
+                    inner.AddAttribute(1, "Href", "#");
+                    inner.AddAttribute(2, "IconContent", (RenderFragment)(i => i.AddContent(0, "ICN")));
+                    inner.AddAttribute(3, "LabelContent", (RenderFragment)(l => l.AddContent(0, "Home")));
+                    inner.CloseComponent();
+                }));
+                b.CloseComponent();
+            }));
+            builder.CloseComponent();
+        });
+
+        // Label span exists but starts at opacity-0 (collapsed rail).
+        var labelSpan = cut.FindAll("span").First(s => s.TextContent.Trim() == "Home");
+        Assert.Contains("opacity-0", labelSpan.GetAttribute("class") ?? "");
+
+        // Hover the rail.
+        cut.Find("aside").TriggerEvent("onmouseenter", new Microsoft.AspNetCore.Components.Web.MouseEventArgs());
+
+        // Now the same label flips to opacity-100 — driven by the cascaded
+        // EffectiveCollapsed flag from SidebarProvider.
+        var labelSpan2 = cut.FindAll("span").First(s => s.TextContent.Trim() == "Home");
+        Assert.Contains("opacity-100", labelSpan2.GetAttribute("class") ?? "");
+    }
+
+    [Fact]
     public void MiniRail_Icon_Variant_Ignores_Hover()
     {
         // Sanity guard — only MiniRail responds to hover. Icon stays narrow on hover.


### PR DESCRIPTION
## Summary

Bugfix for v3.10.0 — the MiniRail variant widened the rail on hover but kept `SidebarMenuButton` labels at `opacity-0`. The user reported it on the live docs demo (screenshot showed the rail expanded but no text).

### Root cause

`_hoverExpanded` lived on `SidebarComponent`, so the cascaded `SidebarState` only carried the pinned `IsCollapsed` flag. `SidebarMenuButton`'s `LabelCssClass` read that pinned state, never the effective one — labels stayed hidden even while the rail was visually widened.

### Fix

Moved the hover state up to `SidebarProvider` where the cascade originates:

- `SidebarState` gains **`EffectiveCollapsed`** (pinned-collapsed AND not hover-expanded, MiniRail-only) plus a `SetHoverExpanded` callback.
- `SidebarProvider` owns `_hoverExpanded` and exposes `SetHoverExpanded`; `EffectiveCollapsed` is computed from it + `Variant`.
- `SidebarComponent`'s `@onmouseenter`/`leave`/`focusin`/`focusout` call `State.SetHoverExpanded`; its width CSS reads `EffectiveCollapsed`.
- `SidebarMenuButton`'s padding + label-opacity CSS reads `EffectiveCollapsed` instead of `IsCollapsed`.

Net effect: hovering the rail now reveals labels in addition to widening the column, matching Material's behaviour. `Toggle()` still pins it open (unchanged).

### Versioning

Pure bugfix on existing public surface → **PATCH bump (3.10.0 → 3.10.1)**. Not included in this PR — let me know if you want me to bump `Directory.Build.props` here for an immediate patch release, or land the fix on master and bundle with the next minor.

## Test plan
- [x] New `MiniRail_Hover_Reveals_Menu_Button_Labels` bUnit test asserts label flips `opacity-0` → `opacity-100` on `@onmouseenter` — pass
- [x] 22/22 Sidebar tests pass (21 prior + 1 new) — no regressions
- [x] `dotnet build src/Lumeo -c Release` succeeds
- [ ] CI build-and-test + e2e + Cloudflare preview to verify the live demo

---
_Generated by [Claude Code](https://claude.ai/code/session_01LJmBFYeCdQj2G2epoZaRzQ)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * MiniRail sidebar now displays menu button labels on hover when in collapsed mode, improving accessibility.

* **Tests**
  * Added test coverage for MiniRail hover-driven label visibility behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->