### PR TITLE
docs(changelog): link component mentions across all historical entries

### DIFF
--- a/docs/Lumeo.Docs/Pages/Docs/Changelog.razor
+++ b/docs/Lumeo.Docs/Pages/Docs/Changelog.razor
@@ -113,7 +113,7 @@
         </div>
 
         <Lumeo.Text Size="base" Color="muted" Leading="relaxed">
-            Minor: composition-mode grouping for <code class="rounded bg-muted px-1 text-xs">Combobox</code> —
+            Minor: composition-mode grouping for <Lumeo.Link Href="components/combobox"><code class="rounded bg-muted px-1 text-xs">Combobox</code></Lumeo.Link> —
             labelled headers, multi-level nesting, collapsible groups, and group-level select.
         </Lumeo.Text>
 
@@ -122,7 +122,7 @@
             <ul class="space-y-1.5 text-sm list-disc list-inside text-muted-foreground">
                 <li><strong><code class="rounded bg-muted px-1 text-xs">&lt;ComboboxGroup&gt;</code></strong> — wrap <code class="rounded bg-muted px-1 text-xs">ComboboxItem</code>s under a labelled header. Headers are non-selectable and skipped by keyboard navigation.</li>
                 <li><strong>Multi-level grouping</strong> — nest <code class="rounded bg-muted px-1 text-xs">ComboboxGroup</code> inside another for Category → Subcategory, with automatic indentation.</li>
-                <li><strong>Collapsible groups</strong> — <code class="rounded bg-muted px-1 text-xs">Collapsible</code> + <code class="rounded bg-muted px-1 text-xs">DefaultExpanded</code>. An active search auto-expands groups so matches stay reachable.</li>
+                <li><strong>Collapsible groups</strong> — <Lumeo.Link Href="components/collapsible"><code class="rounded bg-muted px-1 text-xs">Collapsible</code></Lumeo.Link> + <code class="rounded bg-muted px-1 text-xs">DefaultExpanded</code>. An active search auto-expands groups so matches stay reachable.</li>
                 <li><strong>Group-level select</strong> — <code class="rounded bg-muted px-1 text-xs">GroupSelect</code> (Multiple mode) renders a tri-state header checkbox that selects / clears every descendant item.</li>
                 <li><strong>Filter-aware</strong> — groups whose descendants are all filtered out hide automatically; <code class="rounded bg-muted px-1 text-xs">LabelClass</code> is a theming hook for the header.</li>
             </ul>
@@ -262,7 +262,7 @@
         <Stack Gap="3">
             <Heading Level="3" Size="sm" Class="font-semibold">Added</Heading>
             <ul class="space-y-1.5 text-sm list-disc list-inside text-muted-foreground">
-                <li><strong>Cx.Merge — tailwind-merge class composition.</strong> Component root classes now resolve Tailwind conflicts last-wins-per-group across 300 core components, so a consumer's <code class="rounded bg-muted px-1 text-xs">Class</code> overrides a base utility <em>without</em> <code class="rounded bg-muted px-1 text-xs">!important</code> (e.g. <code class="rounded bg-muted px-1 text-xs">&lt;Card Class="p-0"&gt;</code> just works). Models padding/margin supersets, sizing, inset, gap, rounded, border width/style/color, background color/image/size/position, text size vs color, ring, grid col/row span/start/end, and variant chains. (Satellite packages migrate in a later release.)</li>
+                <li><strong>Cx.Merge — tailwind-merge class composition.</strong> Component root classes now resolve Tailwind conflicts last-wins-per-group across 300 core components, so a consumer's <code class="rounded bg-muted px-1 text-xs">Class</code> overrides a base utility <em>without</em> <code class="rounded bg-muted px-1 text-xs">!important</code> (e.g. <Lumeo.Link Href="components/card"><code class="rounded bg-muted px-1 text-xs">&lt;Card Class="p-0"&gt;</code></Lumeo.Link> just works). Models padding/margin supersets, sizing, inset, gap, rounded, border width/style/color, background color/image/size/position, text size vs color, ring, grid col/row span/start/end, and variant chains. (Satellite packages migrate in a later release.)</li>
                 <li><strong>SidebarHeader / SidebarFooter <code class="rounded bg-muted px-1 text-xs">Bordered</code></strong> (default true) — set false for a seamless edge without the divider.</li>
                 <li><strong>Badge <code class="rounded bg-muted px-1 text-xs">Size</code></strong> (Sm/Md/Lg) + <strong><code class="rounded bg-muted px-1 text-xs">Pill</code></strong> shape — for count / quota chips.</li>
                 <li><strong>Card <code class="rounded bg-muted px-1 text-xs">Variant="Flat"</code></strong> — a content-only (borderless) surface; with <code class="rounded bg-muted px-1 text-xs">OnClick</code> it's the natural clickable-list-row primitive.</li>
@@ -346,7 +346,7 @@
         <Stack Gap="3">
             <Heading Level="3" Size="sm" Class="font-semibold">Added</Heading>
             <ul class="space-y-1.5 text-sm list-disc list-inside text-muted-foreground">
-                <li><strong>Splash Kit</strong> — <code class="rounded bg-muted px-1 text-xs">Hero</code>, <code class="rounded bg-muted px-1 text-xs">FeatureGrid</code>, <code class="rounded bg-muted px-1 text-xs">FeatureItem</code>, <code class="rounded bg-muted px-1 text-xs">CTASection</code> landing-page components.</li>
+                <li><strong>Splash Kit</strong> — <Lumeo.Link Href="components/hero"><code class="rounded bg-muted px-1 text-xs">Hero</code></Lumeo.Link>, <Lumeo.Link Href="components/feature-grid"><code class="rounded bg-muted px-1 text-xs">FeatureGrid</code></Lumeo.Link>, <code class="rounded bg-muted px-1 text-xs">FeatureItem</code>, <Lumeo.Link Href="components/cta-section"><code class="rounded bg-muted px-1 text-xs">CTASection</code></Lumeo.Link> landing-page components.</li>
                 <li><strong>OverlayForm</strong> — opinionated EditForm wrapper that bakes in the flex-col + min-h-0 + sticky-footer shape for long forms in service-driven Sheets / Dialogs.</li>
                 <li><strong>Theme.Customize</strong> — fluent <code class="rounded bg-muted px-1 text-xs">ThemeBuilder</code> for ad-hoc CSS-variable overrides on top of a base scheme.</li>
                 <li><strong>PdfViewer.FitMode</strong> (<code class="rounded bg-muted px-1 text-xs">Custom</code> / <code class="rounded bg-muted px-1 text-xs">FitWidth</code> / <code class="rounded bg-muted px-1 text-xs">FitPage</code>), <strong>DataGrid.SelectionKeySelector</strong> for server-mode selection across page-fetches.</li>
@@ -381,7 +381,7 @@
             <Heading Level="3" Size="sm" Class="font-semibold">Added</Heading>
             <ul class="space-y-1.5 text-sm list-disc list-inside text-muted-foreground">
                 <li><strong>ConfirmButton</strong> + <strong>UploadTrigger</strong> components.</li>
-                <li><strong>AutoFocus</strong> on Input / Textarea / NumberInput / Combobox / Select / DatePicker / TagInput; <strong>MobileFullscreen</strong> overlay option; <code class="rounded bg-muted px-1 text-xs">Input.Variant.Search</code>; <code class="rounded bg-muted px-1 text-xs">Lumeo.Size.Xxs</code>.</li>
+                <li><strong>AutoFocus</strong> on Input / Textarea / NumberInput / Combobox / Select / DatePicker / TagInput; <strong>MobileFullscreen</strong> overlay option; <Lumeo.Link Href="components/input"><code class="rounded bg-muted px-1 text-xs">Input.Variant.Search</code></Lumeo.Link>; <code class="rounded bg-muted px-1 text-xs">Lumeo.Size.Xxs</code>.</li>
             </ul>
         </Stack>
 
@@ -475,7 +475,7 @@
             <ul class="space-y-1.5 text-sm list-disc list-inside text-muted-foreground">
                 <li><strong>Alert: title heading-order fix.</strong> Alert rendered titles as <code class="rounded bg-muted px-1 text-xs">&lt;h5&gt;</code>, which caused heading-order skips on consumer pages (h2 → h3 → h5). Switched to <code class="rounded bg-muted px-1 text-xs">&lt;p&gt;</code> with the same visual style — Alert titles are notification titles, not document structure headings.</li>
                 <li><strong>DataGridFooter: correct ARIA role.</strong> Had <code class="rounded bg-muted px-1 text-xs">role="row"</code> outside any <code class="rounded bg-muted px-1 text-xs">role="grid"</code> parent — axe-core critical. Changed to <code class="rounded bg-muted px-1 text-xs">role="status" aria-live="polite"</code>, which is the correct pattern for an aggregate summary strip rendered outside the <code class="rounded bg-muted px-1 text-xs">&lt;table&gt;</code>.</li>
-                <li><strong>NumberInput &amp; RadioGroupItem: accessible names.</strong> Added explicit <code class="rounded bg-muted px-1 text-xs">AriaLabel</code> parameter with an <code class="rounded bg-muted px-1 text-xs">EffectiveAriaLabel</code> fallback (falls back to the input's value or label). Fixes axe-core <code class="rounded bg-muted px-1 text-xs">button-name</code> violations when these inputs render without a wrapping <code class="rounded bg-muted px-1 text-xs">&lt;Label&gt;</code>.</li>
+                <li><strong>NumberInput &amp; RadioGroupItem: accessible names.</strong> Added explicit <code class="rounded bg-muted px-1 text-xs">AriaLabel</code> parameter with an <code class="rounded bg-muted px-1 text-xs">EffectiveAriaLabel</code> fallback (falls back to the input's value or label). Fixes axe-core <code class="rounded bg-muted px-1 text-xs">button-name</code> violations when these inputs render without a wrapping <Lumeo.Link Href="components/label"><code class="rounded bg-muted px-1 text-xs">&lt;Label&gt;</code></Lumeo.Link>.</li>
             </ul>
         </Stack>
 
@@ -510,7 +510,7 @@
         <Stack Gap="3">
             <Heading Level="3" Size="sm" Class="font-semibold">RichTextEditor + Mention (core / Lumeo.Editor)</Heading>
             <ul class="space-y-1.5 text-sm list-disc list-inside text-muted-foreground">
-                <li><strong>Toolbar buttons keep the editor selection on touch.</strong> <code class="rounded bg-muted px-1 text-xs">BubbleMenu</code>, <code class="rounded bg-muted px-1 text-xs">TriggerDropdown</code>, <code class="rounded bg-muted px-1 text-xs">AiActionMenu</code> and <code class="rounded bg-muted px-1 text-xs">Mention</code> used <code class="rounded bg-muted px-1 text-xs">@@onmousedown:preventDefault</code> to stop the toolbar button from stealing focus from the editor (which would collapse the selection and the next <code class="rounded bg-muted px-1 text-xs">bold</code> / <code class="rounded bg-muted px-1 text-xs">italic</code> click would apply to nothing). <code class="rounded bg-muted px-1 text-xs">mousedown</code> doesn't fire during a touch sequence; switched to <code class="rounded bg-muted px-1 text-xs">@@onpointerdown:preventDefault</code> which fires for mouse, pen and touch. 8 call sites across 4 files.</li>
+                <li><strong>Toolbar buttons keep the editor selection on touch.</strong> <code class="rounded bg-muted px-1 text-xs">BubbleMenu</code>, <code class="rounded bg-muted px-1 text-xs">TriggerDropdown</code>, <code class="rounded bg-muted px-1 text-xs">AiActionMenu</code> and <Lumeo.Link Href="components/mention"><code class="rounded bg-muted px-1 text-xs">Mention</code></Lumeo.Link> used <code class="rounded bg-muted px-1 text-xs">@@onmousedown:preventDefault</code> to stop the toolbar button from stealing focus from the editor (which would collapse the selection and the next <code class="rounded bg-muted px-1 text-xs">bold</code> / <code class="rounded bg-muted px-1 text-xs">italic</code> click would apply to nothing). <code class="rounded bg-muted px-1 text-xs">mousedown</code> doesn't fire during a touch sequence; switched to <code class="rounded bg-muted px-1 text-xs">@@onpointerdown:preventDefault</code> which fires for mouse, pen and touch. 8 call sites across 4 files.</li>
             </ul>
         </Stack>
 
@@ -532,13 +532,13 @@
         </div>
 
         <Lumeo.Text Size="base" Color="muted" Leading="relaxed">
-            Mobile-readiness patch. The docs site was unusable on phones — root cause was the same in any consumer app using <code class="rounded bg-muted px-1 text-xs">Bento</code> or HTML5 drag. Three fixes, no API changes.
+            Mobile-readiness patch. The docs site was unusable on phones — root cause was the same in any consumer app using <Lumeo.Link Href="components/bento"><code class="rounded bg-muted px-1 text-xs">Bento</code></Lumeo.Link> or HTML5 drag. Three fixes, no API changes.
         </Lumeo.Text>
 
         <Stack Gap="3">
             <Heading Level="3" Size="sm" Class="font-semibold">Bento (core)</Heading>
             <ul class="space-y-1.5 text-sm list-disc list-inside text-muted-foreground">
-                <li><strong>Responsive column collapse.</strong> <code class="rounded bg-muted px-1 text-xs">Bento Columns="4"</code> now renders as 1 column on mobile (&lt; 640 px), 2 columns at <code class="rounded bg-muted px-1 text-xs">sm:</code>, and the configured count at <code class="rounded bg-muted px-1 text-xs">lg:</code>. Previously the grid stayed at 4 narrow columns on a phone, squashing every embedded component.</li>
+                <li><strong>Responsive column collapse.</strong> <Lumeo.Link Href="components/bento"><code class="rounded bg-muted px-1 text-xs">Bento Columns="4"</code></Lumeo.Link> now renders as 1 column on mobile (&lt; 640 px), 2 columns at <code class="rounded bg-muted px-1 text-xs">sm:</code>, and the configured count at <code class="rounded bg-muted px-1 text-xs">lg:</code>. Previously the grid stayed at 4 narrow columns on a phone, squashing every embedded component.</li>
                 <li><strong>BentoTile span + row-span at lg: only.</strong> Wide and tall tiles ( <code class="rounded bg-muted px-1 text-xs">Span="2" RowSpan="2"</code>) collapse to a single-cell tile on mobile so they don't punch holes in the 1-column stack. Behaviour at <code class="rounded bg-muted px-1 text-xs">lg:</code> is unchanged. Implementation moved from inline <code class="rounded bg-muted px-1 text-xs">grid-column: span N</code> styles to literal Tailwind <code class="rounded bg-muted px-1 text-xs">col-span-* / row-span-*</code> classes so they can be media-queried.</li>
                 <li><strong>Auto-rows-fr at lg: only.</strong> The "every row the same fr unit" rule that keeps mixed-RowSpan tiles aligned only applies on desktop. On mobile each tile sizes to its actual content, so short KPI cards stay short instead of inheriting the height of the tallest possible row.</li>
             </ul>
@@ -576,7 +576,7 @@
             <Heading Level="3" Size="sm" Class="font-semibold">Maps (Lumeo.Maps)</Heading>
             <ul class="space-y-1.5 text-sm list-disc list-inside text-muted-foreground">
                 <li><strong>MapLibre GL JS 4.7.1 → 5.7.1.</strong> Upgraded to the MapLibre 5 stable release, which ships globe projection as a first-class supported mode.</li>
-                <li><strong>Globe projection.</strong> New <code class="rounded bg-muted px-1 text-xs">Projection="globe"</code> parameter on <code class="rounded bg-muted px-1 text-xs">Map</code> renders the map as a 3-D sphere with back-face culling — existing flat usage is unchanged.</li>
+                <li><strong>Globe projection.</strong> New <code class="rounded bg-muted px-1 text-xs">Projection="globe"</code> parameter on <Lumeo.Link Href="components/map"><code class="rounded bg-muted px-1 text-xs">Map</code></Lumeo.Link> renders the map as a 3-D sphere with back-face culling — existing flat usage is unchanged.</li>
                 <li><strong>MapHeatmap.</strong> New component — renders a density heat map layer from a list of <code class="rounded bg-muted px-1 text-xs">(Lat, Lon, Weight)</code> points. Configurable radius, blur, intensity, and colour gradient.</li>
                 <li><strong>MapLegend / MapLegendItem.</strong> New components — a positioned card overlay listing colour swatches, lines, or symbols. Accepts any child <code class="rounded bg-muted px-1 text-xs">MapLegendItem</code> nodes; position controlled via <code class="rounded bg-muted px-1 text-xs">Position</code> (TopLeft / TopRight / BottomLeft / BottomRight).</li>
                 <li><strong>MapPopup.</strong> New component — attaches an HTML balloon to a geographic coordinate. Configurable close button, max-width, and offset. Content is arbitrary Blazor markup via <code class="rounded bg-muted px-1 text-xs">ChildContent</code>.</li>
@@ -660,7 +660,7 @@
         <Stack Gap="3">
             <Heading Level="3" Size="sm" Class="font-semibold">Improved</Heading>
             <ul class="space-y-1.5 text-sm list-disc list-inside text-muted-foreground">
-                <li><strong>DataGrid per-column toggles are reactive.</strong> <code class="rounded bg-muted px-1 text-xs">Sortable</code> and <code class="rounded bg-muted px-1 text-xs">Filterable</code> on <code class="rounded bg-muted px-1 text-xs">DataGridColumnDef</code> now update at runtime — the column re-registers on <code class="rounded bg-muted px-1 text-xs">OnParametersSet</code> instead of only on first render, so toggling them from parent state works without an explicit grid refresh.</li>
+                <li><strong>DataGrid per-column toggles are reactive.</strong> <Lumeo.Link Href="components/sortable"><code class="rounded bg-muted px-1 text-xs">Sortable</code></Lumeo.Link> and <code class="rounded bg-muted px-1 text-xs">Filterable</code> on <code class="rounded bg-muted px-1 text-xs">DataGridColumnDef</code> now update at runtime — the column re-registers on <code class="rounded bg-muted px-1 text-xs">OnParametersSet</code> instead of only on first render, so toggling them from parent state works without an explicit grid refresh.</li>
             </ul>
         </Stack>
 
@@ -690,7 +690,7 @@
             <ul class="space-y-1.5 text-sm list-disc list-inside text-muted-foreground">
                 <li><strong>Soft borders sweep — 27 components.</strong> <code class="rounded bg-muted px-1 text-xs">border-border</code> → <code class="rounded bg-muted px-1 text-xs">border-border/40</code> on popovers, menus, hover cards, cards, and other neutral surfaces. Semantic borders (focus rings, active states, destructive variants) deliberately left at full opacity so they still read as state changes.</li>
                 <li><strong>Accessibility + keyboard polish — 23 components.</strong> Dialog / Sheet / Drawer / Popover / AlertDialog triggers and close buttons now handle <code class="rounded bg-muted px-1 text-xs">Enter</code> and <code class="rounded bg-muted px-1 text-xs">Space</code>. Icon-only buttons across the library gained <code class="rounded bg-muted px-1 text-xs">aria-label</code> + explicit <code class="rounded bg-muted px-1 text-xs">type="button"</code>. Image / ImageGallery preview overlays announce as <code class="rounded bg-muted px-1 text-xs">role="dialog"</code> with auto-focus on open. Pagination current page gets <code class="rounded bg-muted px-1 text-xs">aria-current="page"</code>; Steps active step gets <code class="rounded bg-muted px-1 text-xs">aria-current="step"</code>; Sidebar collapsible groups expose <code class="rounded bg-muted px-1 text-xs">aria-expanded</code>.</li>
-                <li><strong>Icon resolver coverage.</strong> ~66 new Lucide names mapped in the <code class="rounded bg-muted px-1 text-xs">DynamicIcon</code> resolver — fewer fall-throughs to the default icon when consumers wire up arbitrary Lucide names.</li>
+                <li><strong>Icon resolver coverage.</strong> ~66 new Lucide names mapped in the <Lumeo.Link Href="components/dynamic-icon"><code class="rounded bg-muted px-1 text-xs">DynamicIcon</code></Lumeo.Link> resolver — fewer fall-throughs to the default icon when consumers wire up arbitrary Lucide names.</li>
             </ul>
         </Stack>
 


### PR DESCRIPTION
## Summary

Follow-up to #149 — the previous changelog sweep only linked component mentions in the v3.9.0 / v3.10.0 / v3.10.1 entries. This extends the same treatment to **every section back to v3.0.x**.

### Approach

A small Python pass walked the slug map generated from `/Pages/Components/**/*.razor` `@page` directives and wrapped every `<code>` span whose content starts with a known component name in `<Lumeo.Link Href="components/...">`. Tag-form (`&lt;Foo&gt;`), bare form (`Foo`), and dotted member access (`Foo.Bar`) all route to the right page.

### Coverage

- **14 historical component mentions** (v3.8.0 down to v3.0.5) became clickable
- **0 missed mentions** in a follow-up audit across the slug map
- Sections without component refs (service / infra / build patches) intentionally stay link-free — nothing to link

### Scope

Pure docs change. Cloudflare auto-deploys from master.

## Test plan
- [x] `dotnet build docs/Lumeo.Docs -c Release` succeeds
- [x] Audit script reports zero unlinked component mentions matching the slug map
- [ ] Cloudflare preview spot-check on /docs/changelog

---
_Generated by [Claude Code](https://claude.ai/code/session_01LJmBFYeCdQj2G2epoZaRzQ)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced changelog with improved navigation links to component references across multiple release versions for easier browsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->