### PR TITLE
fix(charts): tooltip slot surfaces every series + correct demo values (3.10.2)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
   <!-- Lockstep version shared by all Lumeo packages.
        Update this single property to version all packages in unison. -->
   <PropertyGroup>
-    <Version>3.10.1</Version>
+    <Version>3.10.2</Version>
   </PropertyGroup>
 
   <!-- Shared NuGet README packing lives in Directory.Build.targets, NOT here.

--- a/docs/Lumeo.Docs/Pages/Components/Charts/LineChartPage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/Charts/LineChartPage.razor
@@ -13,18 +13,23 @@
         </Container>
     </ComponentDemo>
 
-    <ComponentDemo Title="Razor-Rendered Tooltip Slot" Description="Replace ECharts' default tooltip body with any Razor markup — themed cards, formatted numbers, child components. Updates on every hover." Code="@_tooltipSlotCode">
+    <ComponentDemo Title="Razor-Rendered Tooltip Slot" Description="Replace ECharts' default tooltip body with any Razor markup — themed cards, formatted numbers, child components. With axis-trigger (the default) the slot receives every series at the hovered category via ctx.Points." Code="@_tooltipSlotCode">
         <Container>
             <LineChart Categories="_categories" Series="_series" Smooth="true">
                 <ChartTooltip>
                     <ChildContent Context="ctx">
-                        <Stack Gap="1" Class="p-2 min-w-[140px]">
-                            <Flex Gap="2" Align="center">
-                                <Stack Class="h-2 w-2 rounded-full" style="@($"background-color:{ctx.Color}")"></Stack>
-                                <Lumeo.Text As="span" Size="sm" Class="font-semibold">@ctx.SeriesName</Lumeo.Text>
-                            </Flex>
+                        <Stack Gap="1.5" Class="p-2 min-w-[170px]">
                             <Lumeo.Text As="span" Size="xs" Color="muted">@ctx.DataName</Lumeo.Text>
-                            <Lumeo.Text As="span" Class="font-mono text-sm">@(ctx.Value?.ToString("N0") ?? "-")</Lumeo.Text>
+                            @foreach (var pt in ctx.Points)
+                            {
+                                <Flex Gap="2" Align="center" Justify="between">
+                                    <Flex Gap="2" Align="center">
+                                        <Stack Class="h-2 w-2 rounded-full" style="@($"background-color:{pt.Color}")"></Stack>
+                                        <Lumeo.Text As="span" Size="sm">@pt.SeriesName</Lumeo.Text>
+                                    </Flex>
+                                    <Lumeo.Text As="span" Class="font-mono text-sm font-semibold">@(pt.Value?.ToString("N0") ?? "-")</Lumeo.Text>
+                                </Flex>
+                            }
                         </Stack>
                     </ChildContent>
                 </ChartTooltip>
@@ -37,10 +42,13 @@
                    Code="@_annotationsCode">
         <Container>
             <LineChart Categories="_categories" Series="_series" Smooth="true">
-                <ChartReferenceZone From="60" To="90" Color="#22c55e22" Label="Healthy" />
-                <ChartReferenceZone From="0"  To="40" Color="#ef444422" Label="Critical" />
-                <ChartThreshold Value="80" Label="Target" Color="#22c55e" />
-                <ChartThreshold Value="40" Label="SLA"    Color="#ef4444" LineStyle="dotted" />
+                @* Values match the Revenue series scale (~18k–60k). Putting markLine
+                   values inside the data range is what makes them visually meaningful;
+                   the previous demo used yAxis=80 which sat right at the bottom edge. *@
+                <ChartReferenceZone From="40000" To="60000" Color="#22c55e22" Label="Healthy" />
+                <ChartReferenceZone From="0"     To="20000" Color="#ef444422" Label="Critical" />
+                <ChartThreshold Value="50000" Label="Target" Color="#22c55e" />
+                <ChartThreshold Value="25000" Label="SLA"    Color="#ef4444" LineStyle="dotted" />
             </LineChart>
         </Container>
     </ComponentDemo>
@@ -368,27 +376,35 @@
 
     private string _annotationsCode = @"@* ChartThreshold = horizontal line at a value (yAxis by default).
    ChartReferenceZone = shaded band between two values on the chosen axis.
-   Both translate to ECharts' native markLine / markArea on series[0]. *@
+   Both translate to ECharts' native markLine / markArea on series[0].
+   Pick values inside the data range — markLine sits on the y-axis. *@
 <LineChart Categories=""_categories"" Series=""_series"" Smooth=""true"">
-    <ChartReferenceZone From=""60"" To=""90"" Color=""#22c55e22"" Label=""Healthy"" />
-    <ChartReferenceZone From=""0""  To=""40"" Color=""#ef444422"" Label=""Critical"" />
-    <ChartThreshold Value=""80"" Label=""Target"" Color=""#22c55e"" />
-    <ChartThreshold Value=""40"" Label=""SLA""    Color=""#ef4444"" LineStyle=""dotted"" />
+    <ChartReferenceZone From=""40000"" To=""60000"" Color=""#22c55e22"" Label=""Healthy"" />
+    <ChartReferenceZone From=""0""     To=""20000"" Color=""#ef444422"" Label=""Critical"" />
+    <ChartThreshold Value=""50000"" Label=""Target"" Color=""#22c55e"" />
+    <ChartThreshold Value=""25000"" Label=""SLA""    Color=""#ef4444"" LineStyle=""dotted"" />
 </LineChart>";
 
     private string _tooltipSlotCode = @"@* The ChartTooltip child renders a hidden DOM portal whose innerHTML is fed to
-   ECharts' tooltip on each hover. ChildContent receives a ChartTooltipContext
-   per point (SeriesName, DataName, Value, Color, plus the raw Params dict). *@
+   ECharts' tooltip on each hover. With axis-trigger (the default) the slot's
+   ctx.Points enumerates every series at the hovered category — iterate it to
+   render a row per series. ctx.SeriesName/Value still surface the headline
+   point for back-compat with single-series / item-trigger tooltips. *@
 <LineChart Categories=""_categories"" Series=""_series"" Smooth=""true"">
     <ChartTooltip>
         <ChildContent Context=""ctx"">
-            <Stack Gap=""1"" Class=""p-2 min-w-[140px]"">
-                <Flex Gap=""2"" Align=""center"">
-                    <Stack Class=""h-2 w-2 rounded-full"" style=""@($\""background-color:{ctx.Color}\"")""></Stack>
-                    <Lumeo.Text As=""span"" Size=""sm"" Class=""font-semibold"">@ctx.SeriesName</Lumeo.Text>
-                </Flex>
+            <Stack Gap=""1.5"" Class=""p-2 min-w-[170px]"">
                 <Lumeo.Text As=""span"" Size=""xs"" Color=""muted"">@ctx.DataName</Lumeo.Text>
-                <Lumeo.Text As=""span"" Class=""font-mono text-sm"">@(ctx.Value?.ToString(""N0"") ?? ""-"")</Lumeo.Text>
+                @foreach (var pt in ctx.Points)
+                {
+                    <Flex Gap=""2"" Align=""center"" Justify=""between"">
+                        <Flex Gap=""2"" Align=""center"">
+                            <Stack Class=""h-2 w-2 rounded-full"" style=""@($\""background-color:{pt.Color}\"")""></Stack>
+                            <Lumeo.Text As=""span"" Size=""sm"">@pt.SeriesName</Lumeo.Text>
+                        </Flex>
+                        <Lumeo.Text As=""span"" Class=""font-mono text-sm font-semibold"">@(pt.Value?.ToString(""N0"") ?? ""-"")</Lumeo.Text>
+                    </Flex>
+                }
             </Stack>
         </ChildContent>
     </ChartTooltip>

--- a/docs/Lumeo.Docs/Pages/Docs/Changelog.razor
+++ b/docs/Lumeo.Docs/Pages/Docs/Changelog.razor
@@ -15,6 +15,37 @@
 
     <Separator Class="my-4" />
 
+    <!-- v3.10.2 -->
+    <Stack Gap="4">
+        <div class="flex items-center gap-3">
+            <Badge>v3.10.2</Badge>
+            <Lumeo.Text Size="sm" Color="muted">May 2026</Lumeo.Text>
+        </div>
+
+        <Lumeo.Text Size="base" Color="muted" Leading="relaxed">
+            Patch: fixes a multi-series tooltip regression in the v3.10.0
+            <Lumeo.Link Href="components/charts/line#razor-rendered-tooltip-slot"><code class="rounded bg-muted px-1 text-xs">&lt;ChartTooltip&gt;</code> slot</Lumeo.Link>
+            and corrects the threshold-demo y-axis values that put the bands at the bottom of the chart.
+        </Lumeo.Text>
+
+        <Stack Gap="3">
+            <Heading Level="3" Size="sm" Class="font-semibold">Fixed</Heading>
+            <ul class="space-y-1.5 text-sm list-disc list-inside text-muted-foreground">
+                <li><strong>Tooltip slot now surfaces every series at the hovered category.</strong>
+                    The JS bridge shipped only <code class="rounded bg-muted px-1 text-xs">params[0]</code>, so on an axis-trigger tooltip with multiple series only the first one was visible.
+                    <code class="rounded bg-muted px-1 text-xs">ChartTooltipContext</code> gains an additive
+                    <code class="rounded bg-muted px-1 text-xs">Points</code> init-only property (list of <code class="rounded bg-muted px-1 text-xs">ChartTooltipPoint</code>) the slot iterates;
+                    the existing typed fields still carry the &ldquo;headline&rdquo; (first point) for back-compat.
+                </li>
+                <li><strong><Lumeo.Link Href="components/charts/line#threshold-lines-reference-zones">Threshold &amp; reference-zone demo</Lumeo.Link>
+                    uses values inside the data range</strong> (<code class="rounded bg-muted px-1 text-xs">25000</code>&hairsp;&hellip;&hairsp;<code class="rounded bg-muted px-1 text-xs">60000</code>) instead of the stale
+                    <code class="rounded bg-muted px-1 text-xs">40</code> / <code class="rounded bg-muted px-1 text-xs">90</code> that sat right at the bottom of the y-axis. Demo-only; the components themselves were always correct.</li>
+            </ul>
+        </Stack>
+    </Stack>
+
+    <Separator Class="my-4" />
+
     <!-- v3.10.1 -->
     <Stack Gap="4">
         <div class="flex items-center gap-3">

--- a/docs/Lumeo.Docs/Pages/Docs/Changelog.razor
+++ b/docs/Lumeo.Docs/Pages/Docs/Changelog.razor
@@ -39,7 +39,7 @@
                 </li>
                 <li><strong><Lumeo.Link Href="components/charts/line#threshold-lines-reference-zones">Threshold &amp; reference-zone demo</Lumeo.Link>
                     uses values inside the data range</strong> (<code class="rounded bg-muted px-1 text-xs">25000</code>&hairsp;&hellip;&hairsp;<code class="rounded bg-muted px-1 text-xs">60000</code>) instead of the stale
-                    <code class="rounded bg-muted px-1 text-xs">40</code> / <code class="rounded bg-muted px-1 text-xs">90</code> that sat right at the bottom of the y-axis. Demo-only; the components themselves were always correct.</li>
+                    <code class="rounded bg-muted px-1 text-xs">80</code> / <code class="rounded bg-muted px-1 text-xs">90</code> / <code class="rounded bg-muted px-1 text-xs">40</code> that sat right at the bottom of the y-axis. Demo-only; the components themselves were always correct.</li>
             </ul>
         </Stack>
     </Stack>

--- a/src/Lumeo.Charts/UI/Chart/Chart.razor
+++ b/src/Lumeo.Charts/UI/Chart/Chart.razor
@@ -491,6 +491,12 @@ else
             }
 
             var boxed = raw.ToDictionary(kv => kv.Key, kv => (object?)kv.Value);
+
+            // points: forwarded by the JS bridge as a flat array of per-series snapshots.
+            // For axis-trigger tooltips this contains every series at the hovered x; for
+            // item-trigger it'll be a single-entry list mirroring the headline fields.
+            var points = ProjectPoints(raw);
+
             _tooltipContext = new ChartTooltipContext(
                 SeriesName: Get("seriesName"),
                 SeriesType: Get("seriesType"),
@@ -499,7 +505,10 @@ else
                 DataIndex: GetInt("dataIndex"),
                 Value: GetValue(),
                 Color: raw.TryGetValue("color", out var c) && c.ValueKind == System.Text.Json.JsonValueKind.String ? c.GetString() : null,
-                Raw: boxed);
+                Raw: boxed)
+            {
+                Points = points,
+            };
             return InvokeAsync(StateHasChanged);
         }
         catch
@@ -508,6 +517,49 @@ else
             // context in place so the tooltip keeps rendering its previous content.
             return Task.CompletedTask;
         }
+    }
+
+    // Extracts the per-series snapshots from the bridge's "points" array. We only need
+    // a handful of fields; everything else stays in Raw on the headline. Defensive on
+    // shape — bad / missing entries collapse to a single-entry list that mirrors the
+    // typed top-level fields so the slot is never empty when at least one point exists.
+    private static IReadOnlyList<ChartTooltipPoint> ProjectPoints(
+        Dictionary<string, System.Text.Json.JsonElement> raw)
+    {
+        if (!raw.TryGetValue("points", out var pts) || pts.ValueKind != System.Text.Json.JsonValueKind.Array)
+            return Array.Empty<ChartTooltipPoint>();
+
+        var result = new List<ChartTooltipPoint>(pts.GetArrayLength());
+        foreach (var p in pts.EnumerateArray())
+        {
+            if (p.ValueKind != System.Text.Json.JsonValueKind.Object) continue;
+
+            string Str(string key) => p.TryGetProperty(key, out var v) && v.ValueKind == System.Text.Json.JsonValueKind.String
+                ? v.GetString() ?? "" : "";
+            int Int(string key) => p.TryGetProperty(key, out var v) && v.ValueKind == System.Text.Json.JsonValueKind.Number
+                ? v.GetInt32() : 0;
+            string? StrOrNull(string key) => p.TryGetProperty(key, out var v) && v.ValueKind == System.Text.Json.JsonValueKind.String
+                ? v.GetString() : null;
+            double? Val()
+            {
+                if (!p.TryGetProperty("value", out var v)) return null;
+                if (v.ValueKind == System.Text.Json.JsonValueKind.Number) return v.GetDouble();
+                if (v.ValueKind == System.Text.Json.JsonValueKind.Array && v.GetArrayLength() > 0
+                    && v[0].ValueKind == System.Text.Json.JsonValueKind.Number)
+                    return v[0].GetDouble();
+                return null;
+            }
+
+            result.Add(new ChartTooltipPoint(
+                SeriesName: Str("seriesName"),
+                SeriesType: Str("seriesType"),
+                SeriesIndex: Int("seriesIndex"),
+                DataIndex: Int("dataIndex"),
+                Value: Val(),
+                Color: StrOrNull("color"),
+                Marker: StrOrNull("marker")));
+        }
+        return result;
     }
 
     public async Task<string?> GetImageAsync(string type = "png", int pixelRatio = 2)

--- a/src/Lumeo.Charts/UI/Chart/Chart.razor
+++ b/src/Lumeo.Charts/UI/Chart/Chart.razor
@@ -521,8 +521,9 @@ else
 
     // Extracts the per-series snapshots from the bridge's "points" array. We only need
     // a handful of fields; everything else stays in Raw on the headline. Defensive on
-    // shape — bad / missing entries collapse to a single-entry list that mirrors the
-    // typed top-level fields so the slot is never empty when at least one point exists.
+    // shape — a missing / non-array "points" payload yields an empty list, and malformed
+    // (non-object) entries are skipped. Consumers fall back to the typed headline fields
+    // when Points is empty.
     private static IReadOnlyList<ChartTooltipPoint> ProjectPoints(
         Dictionary<string, System.Text.Json.JsonElement> raw)
     {

--- a/src/Lumeo.Charts/UI/Chart/ChartTooltipContext.cs
+++ b/src/Lumeo.Charts/UI/Chart/ChartTooltipContext.cs
@@ -1,6 +1,22 @@
 namespace Lumeo;
 
 /// <summary>
+/// One series&rsquo; snapshot at the hovered category. Axis-trigger tooltips fire once per
+/// hover with N entries (one per series at that x-position); the chart projects them into
+/// <see cref="ChartTooltipContext.Points"/> so the slot can iterate. The 8 positional
+/// fields on <see cref="ChartTooltipContext"/> still surface the <em>first</em> point as
+/// the &ldquo;headline&rdquo; for back-compat.
+/// </summary>
+public sealed record ChartTooltipPoint(
+    string SeriesName,
+    string SeriesType,
+    int SeriesIndex,
+    int DataIndex,
+    double? Value,
+    string? Color,
+    string? Marker);
+
+/// <summary>
 /// Data passed to a <see cref="ChartTooltip"/>'s <c>ChildContent</c> on each hover.
 /// Mirrors the most commonly used fields of ECharts' tooltip <c>formatter</c> params
 /// object. Use <see cref="Raw"/> for fields not surfaced explicitly.
@@ -22,10 +38,18 @@ public sealed record ChartTooltipContext(
     double? Value,
     /// <summary>Hex / RGB color ECharts assigned to the point (matches the legend swatch).</summary>
     string? Color,
-    /// <summary>Raw ECharts params object as a dictionary — escape hatch for fields the
+    /// <summary>Raw ECharts params object as a dictionary &mdash; escape hatch for fields the
     /// strongly-typed properties above don't cover (e.g. multi-dim scatter, percent, marker).</summary>
     IReadOnlyDictionary<string, object?> Raw)
 {
+    /// <summary>
+    /// All series&rsquo; points at the hovered category. For an axis-trigger tooltip on a
+    /// multi-series chart this carries one entry per visible series; item-trigger tooltips
+    /// surface a single entry that matches the typed fields above. Added as an init-only
+    /// property so existing callers using the 8-positional constructor continue to compile.
+    /// </summary>
+    public IReadOnlyList<ChartTooltipPoint> Points { get; init; } = Array.Empty<ChartTooltipPoint>();
+
     /// <summary>Empty context used as the initial portal render before any hover has happened.</summary>
     public static ChartTooltipContext Empty { get; } = new(
         SeriesName: string.Empty,

--- a/src/Lumeo.Charts/wwwroot/js/echarts-interop.js
+++ b/src/Lumeo.Charts/wwwroot/js/echarts-interop.js
@@ -490,54 +490,70 @@ export function registerTooltipSlot(elementId, portalId, dotnetRef) {
     // drag would then ship the stale first-point to Razor while the user's already on
     // a different point. Updating latestPoint on every formatter call keeps the rAF
     // send aligned with what the user is currently hovering.
-    let latestPoint = null;
+    let latestPoints = null;
 
     chart.setOption({
         tooltip: {
             formatter: function (params) {
-                // axis-trigger gives an array of points; pick the first as the headline.
-                const p = Array.isArray(params) ? params[0] : params;
-                if (!p) return '';
+                // Axis-trigger fires with an ARRAY of points (one per series at the
+                // hovered x); item-trigger fires with a single point object. Normalize
+                // to an array so the Razor slot can iterate across all series — the
+                // previous code shipped only points[0] and silently hid every series
+                // past the first.
+                const arr = Array.isArray(params) ? params : (params ? [params] : []);
+                if (arr.length === 0) return '';
+                const head = arr[0];
 
-                const sig = `${p.seriesIndex}|${p.dataIndex}|${p.name}`;
+                const sig = `${head.seriesIndex}|${head.dataIndex}|${head.name}|${arr.length}`;
                 if (sig !== lastSig) {
                     lastSig = sig;
-                    latestPoint = p;
+                    latestPoints = arr;
                     if (pendingFrame === null) {
                         pendingFrame = requestAnimationFrame(() => {
                             pendingFrame = null;
-                            const current = latestPoint;
-                            if (!current) return;
+                            const current = latestPoints;
+                            if (!current || current.length === 0) return;
                             try {
+                                const projectPoint = (q) => ({
+                                    seriesName: q.seriesName || '',
+                                    seriesType: q.seriesType || '',
+                                    seriesIndex: q.seriesIndex ?? 0,
+                                    dataIndex: q.dataIndex ?? 0,
+                                    value: q.value,
+                                    color: typeof q.color === 'string' ? q.color : null,
+                                    marker: typeof q.marker === 'string' ? q.marker : null,
+                                });
+
+                                const h = current[0];
                                 // Forward a richer payload than the bare typed fields:
                                 // ChartTooltipContext.Raw exposes everything here so
                                 // consumers can pull formatter-only fields like
-                                // marker / percent / axisValueLabel / data without a
-                                // second round-trip. The hand-built whitelist avoids
-                                // serializing ECharts' internal back-refs (which carry
-                                // cycles JSON.stringify would crash on).
+                                // percent / axisValueLabel / data without a second
+                                // round-trip. points[] is the new entry that lets the
+                                // Razor slot iterate across all series at the same x.
                                 const payload = {
-                                    seriesName: current.seriesName || '',
-                                    seriesType: current.seriesType || '',
-                                    seriesIndex: current.seriesIndex ?? 0,
-                                    componentType: current.componentType || '',
-                                    componentSubType: current.componentSubType || '',
-                                    name: current.name || '',
-                                    dataIndex: current.dataIndex ?? 0,
-                                    value: current.value,
-                                    data: current.data,
-                                    color: typeof current.color === 'string' ? current.color : null,
-                                    marker: typeof current.marker === 'string' ? current.marker : null,
-                                    percent: current.percent ?? null,
-                                    axisValue: current.axisValue ?? null,
-                                    axisValueLabel: current.axisValueLabel ?? null,
-                                    axisIndex: current.axisIndex ?? null,
-                                    axisType: current.axisType ?? null,
-                                    axisId: current.axisId ?? null,
-                                    axisDim: current.axisDim ?? null,
-                                    dimensionNames: current.dimensionNames ?? null,
-                                    encode: current.encode ?? null,
-                                    dataType: current.dataType ?? null,
+                                    seriesName: h.seriesName || '',
+                                    seriesType: h.seriesType || '',
+                                    seriesIndex: h.seriesIndex ?? 0,
+                                    componentType: h.componentType || '',
+                                    componentSubType: h.componentSubType || '',
+                                    name: h.name || '',
+                                    dataIndex: h.dataIndex ?? 0,
+                                    value: h.value,
+                                    data: h.data,
+                                    color: typeof h.color === 'string' ? h.color : null,
+                                    marker: typeof h.marker === 'string' ? h.marker : null,
+                                    percent: h.percent ?? null,
+                                    axisValue: h.axisValue ?? null,
+                                    axisValueLabel: h.axisValueLabel ?? null,
+                                    axisIndex: h.axisIndex ?? null,
+                                    axisType: h.axisType ?? null,
+                                    axisId: h.axisId ?? null,
+                                    axisDim: h.axisDim ?? null,
+                                    dimensionNames: h.dimensionNames ?? null,
+                                    encode: h.encode ?? null,
+                                    dataType: h.dataType ?? null,
+                                    points: current.map(projectPoint),
                                 };
                                 dotnetRef.invokeMethodAsync('OnTooltipPointChange', JSON.stringify(payload));
                             } catch (_) {

--- a/tests/Lumeo.Tests/Components/Chart/ChartTooltipSlotTests.cs
+++ b/tests/Lumeo.Tests/Components/Chart/ChartTooltipSlotTests.cs
@@ -170,6 +170,77 @@ public class ChartTooltipSlotTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task OnTooltipPointChange_Multi_Series_Surfaces_All_Points()
+    {
+        // Bug fix: previously the JS bridge sent only points[0] so a multi-series
+        // axis-trigger tooltip silently lost every series past the first. The bridge
+        // now sends a `points` array; ctx.Points iterates them.
+        var cut = _ctx.Render<Lumeo.Chart>(p => p
+            .Add(c => c.OptionJson, "{\"series\":[{\"type\":\"line\",\"data\":[1,2]},{\"type\":\"line\",\"data\":[3,4]}]}")
+            .Add(c => c.ShowLoadingSkeleton, false)
+            .Add(c => c.ChildContent, (RenderFragment)(b =>
+            {
+                b.OpenComponent<ChartTooltip>(0);
+                b.AddAttribute(1, "ChildContent",
+                    (RenderFragment<ChartTooltipContext>)(ctx => cb =>
+                    {
+                        cb.OpenElement(0, "ul");
+                        var i = 0;
+                        foreach (var pt in ctx.Points)
+                        {
+                            cb.OpenElement(1 + i, "li");
+                            cb.AddContent(2 + i, $"{pt.SeriesName}={pt.Value?.ToString() ?? "-"}");
+                            cb.CloseElement();
+                            i++;
+                        }
+                        cb.CloseElement();
+                    }));
+                b.CloseComponent();
+            })));
+
+        var payload = """
+            {
+              "seriesName": "Revenue",
+              "name": "Aug",
+              "value": 37700,
+              "points": [
+                { "seriesName": "Revenue",  "seriesIndex": 0, "value": 37700, "color": "#fff" },
+                { "seriesName": "Expenses", "seriesIndex": 1, "value": 16900, "color": "#22c55e" }
+              ]
+            }
+            """;
+        await cut.Instance.OnTooltipPointChange(payload);
+
+        var portal = cut.Find(".lumeo-chart-tooltip-portal");
+        Assert.Contains("Revenue=37700", portal.TextContent);
+        Assert.Contains("Expenses=16900", portal.TextContent);
+    }
+
+    [Fact]
+    public async Task OnTooltipPointChange_Without_Points_Falls_Back_Empty_List()
+    {
+        // Legacy single-point payloads (no `points` field) shouldn't crash — Points
+        // becomes empty and the slot consumer falls back to the typed headline fields.
+        var cut = _ctx.Render<Lumeo.Chart>(p => p
+            .Add(c => c.OptionJson, "{\"series\":[{\"type\":\"line\",\"data\":[1]}]}")
+            .Add(c => c.ShowLoadingSkeleton, false)
+            .Add(c => c.ChildContent, (RenderFragment)(b =>
+            {
+                b.OpenComponent<ChartTooltip>(0);
+                b.AddAttribute(1, "ChildContent",
+                    (RenderFragment<ChartTooltipContext>)(ctx => cb =>
+                        cb.AddContent(0, $"count={ctx.Points.Count} headline={ctx.SeriesName}")));
+                b.CloseComponent();
+            })));
+
+        await cut.Instance.OnTooltipPointChange("{\"seriesName\":\"OnlyOne\",\"value\":42}");
+
+        var portal = cut.Find(".lumeo-chart-tooltip-portal");
+        Assert.Contains("count=0", portal.TextContent);
+        Assert.Contains("headline=OnlyOne", portal.TextContent);
+    }
+
+    [Fact]
     public void ChartTooltip_Class_Applies_To_Portal_Wrapper()
     {
         var cut = _ctx.Render<Lumeo.Chart>(p => p

--- a/tests/Lumeo.Tests/Components/Chart/ChartTooltipSlotTests.cs
+++ b/tests/Lumeo.Tests/Components/Chart/ChartTooltipSlotTests.cs
@@ -185,13 +185,12 @@ public class ChartTooltipSlotTests : IAsyncLifetime
                     (RenderFragment<ChartTooltipContext>)(ctx => cb =>
                     {
                         cb.OpenElement(0, "ul");
-                        var i = 0;
+                        var seq = 1;
                         foreach (var pt in ctx.Points)
                         {
-                            cb.OpenElement(1 + i, "li");
-                            cb.AddContent(2 + i, $"{pt.SeriesName}={pt.Value?.ToString() ?? "-"}");
+                            cb.OpenElement(seq++, "li");
+                            cb.AddContent(seq++, $"{pt.SeriesName}={pt.Value?.ToString() ?? "-"}");
                             cb.CloseElement();
-                            i++;
                         }
                         cb.CloseElement();
                     }));


### PR DESCRIPTION
## Summary

Two regressions reported off the live docs site at https://lumeo.nativ.sh/components/charts/line.

### 1. ChartTooltip slot only showed the first series (multi-series bug)

`registerTooltipSlot` in `echarts-interop.js` picked `params[0]` when ECharts' axis-trigger formatter fired with an array of points. On a multi-series chart that **silently hid every series past the first** — exactly the case the docs demo shows. User report: hovering "Aug" displayed only `Revenue` and never `Expenses`.

**Fix:**
- `ChartTooltipContext` gains an additive **`Points`** init-only property (list of new `ChartTooltipPoint` records: `SeriesName / SeriesType / SeriesIndex / DataIndex / Value / Color / Marker`). Init-only on a sealed record so the v3.10.x 8-positional constructor still compiles.
- JS bridge forwards the full `params` array as `points`; the headline fields (the existing typed properties) still surface the first point for back-compat with item-trigger and single-series tooltips.
- Razor `OnTooltipPointChange` deserialises `points` via `ProjectPoints`; missing/malformed payloads fall back to an empty list so legacy callers stay on the typed headline path.
- LineChart demo updated to iterate `ctx.Points` and render a row per series.

### 2. Threshold-demo y-axis values out of data range

The "Threshold lines + Reference zones" demo used `yAxis=80 / 90 / 40` markLines, but the Revenue series is in the 10k–60k range — the bands all collapsed onto y≈0 and the labels piled up at the bottom of the chart. Updated the demo values to `25000`–`60000` so they actually overlay the data line. **Components themselves were always correct**; only the demo markup needed fixing.

### Versioning

Source-additive (new `Points` property + new `ChartTooltipPoint` type) → **3.10.2 patch**. `Directory.Build.props` bumped; changelog entry added.

## Test plan
- [x] 2 new bUnit tests on `ChartTooltipSlotTests`:
  - `OnTooltipPointChange_Multi_Series_Surfaces_All_Points` — axis-trigger payload with two series renders both rows in the portal.
  - `OnTooltipPointChange_Without_Points_Falls_Back_Empty_List` — legacy single-point payloads (no `points` field) keep working.
- [x] 10/10 `ChartTooltipSlotTests` pass (8 prior + 2 new) — no regressions
- [x] `dotnet build src/Lumeo.Charts + docs/Lumeo.Docs -c Release` succeeds with `-warnaserror`
- [ ] CI build-and-test + e2e
- [ ] Cloudflare preview: hover the tooltip demo, verify both series render

---
_Generated by [Claude Code](https://claude.ai/code/session_01LJmBFYeCdQj2G2epoZaRzQ)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes – v3.10.2

* **Bug Fixes**
  * Fixed multi-series chart tooltip regression—tooltips now correctly display all series data for the hovered category
  * Corrected threshold-line demo values to render within proper chart ranges

* **Documentation**
  * Updated Line Chart documentation with revised tooltip slot examples showing per-series value rendering
  * Enhanced annotation and threshold-line demo examples with corrected axis values

<!-- end of auto-generated comment: release notes by coderabbit.ai -->