### PR TITLE
fix(charts): DonutChart now actually has an inner hole (closes #153)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
   <!-- Lockstep version shared by all Lumeo packages.
        Update this single property to version all packages in unison. -->
   <PropertyGroup>
-    <Version>3.10.2</Version>
+    <Version>3.10.3</Version>
   </PropertyGroup>
 
   <!-- Shared NuGet README packing lives in Directory.Build.targets, NOT here.

--- a/docs/Lumeo.Docs/Pages/Docs/Changelog.razor
+++ b/docs/Lumeo.Docs/Pages/Docs/Changelog.razor
@@ -15,6 +15,34 @@
 
     <Separator Class="my-4" />
 
+    <!-- v3.10.3 -->
+    <Stack Gap="4">
+        <div class="flex items-center gap-3">
+            <Badge>v3.10.3</Badge>
+            <Lumeo.Text Size="sm" Color="muted">June 2026</Lumeo.Text>
+        </div>
+
+        <Lumeo.Text Size="base" Color="muted" Leading="relaxed">
+            Patch: <Lumeo.Link Href="components/charts/donut">DonutChart</Lumeo.Link> rendered identically to <Lumeo.Link Href="components/charts/pie">PieChart</Lumeo.Link> &mdash; no inner hole.
+        </Lumeo.Text>
+
+        <Stack Gap="3">
+            <Heading Level="3" Size="sm" Class="font-semibold">Fixed</Heading>
+            <ul class="space-y-1.5 text-sm list-disc list-inside text-muted-foreground">
+                <li><strong><Lumeo.Link Href="components/charts/donut">DonutChart now actually renders as a donut</Lumeo.Link> (closes #153).</strong>
+                    <code class="rounded bg-muted px-1 text-xs">EChartSeries.RadiusList</code> / <code class="rounded bg-muted px-1 text-xs">CenterList</code> serialized to
+                    <code class="rounded bg-muted px-1 text-xs">radiusList</code> / <code class="rounded bg-muted px-1 text-xs">centerList</code> (camelCase of the C# property name) but
+                    ECharts only honours <code class="rounded bg-muted px-1 text-xs">radius</code> / <code class="rounded bg-muted px-1 text-xs">center</code>. Both keys were ignored
+                    on every render, so the inner radius silently fell back to 0 and the chart looked like a plain pie. Both fields now route through computed
+                    <code class="rounded bg-muted px-1 text-xs">*Serialized</code> properties carrying the right <code class="rounded bg-muted px-1 text-xs">[JsonPropertyName]</code> &mdash;
+                    same pattern <code class="rounded bg-muted px-1 text-xs">BorderRadius</code> already used. PieChart is unaffected (its
+                    <code class="rounded bg-muted px-1 text-xs">RadiusList = ["0%", "70%"]</code> matched the default anyway).</li>
+            </ul>
+        </Stack>
+    </Stack>
+
+    <Separator Class="my-4" />
+
     <!-- v3.10.2 -->
     <Stack Gap="4">
         <div class="flex items-center gap-3">

--- a/src/Lumeo.Charts/UI/Chart/EChartOption.cs
+++ b/src/Lumeo.Charts/UI/Chart/EChartOption.cs
@@ -388,17 +388,39 @@ public class EChartSeries
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public EChartEmphasis? Emphasis { get; set; }
 
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonIgnore]
     public string? Radius { get; set; }
 
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonIgnore]
     public List<string>? RadiusList { get; set; }
 
+    // ECharts accepts either a string ("70%") or a 2-element array (["50%", "70%"])
+    // for `radius`. We expose both strongly-typed setters and pick the right one at
+    // serialization time. Without this RadiusList serialized to "radiusList" (camelCase
+    // of the property name) which ECharts ignores entirely — the donut chart silently
+    // fell back to default radius and rendered as a full pie (#153).
+    [JsonPropertyName("radius")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public object? RadiusSerialized =>
+        RadiusList is { Count: > 0 } list ? list :
+        Radius is string s ? s :
+        null;
+
+    [JsonIgnore]
     public string? Center { get; set; }
 
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonIgnore]
     public List<string>? CenterList { get; set; }
+
+    // Same shape problem as Radius: ECharts wants `center` as either a string or a
+    // 2-element array, but the property-name fallback emitted `centerList` and the
+    // option was dropped on the floor.
+    [JsonPropertyName("center")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public object? CenterSerialized =>
+        CenterList is { Count: > 0 } list ? list :
+        Center is string s ? s :
+        null;
 
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? RoseType { get; set; }

--- a/tests/Lumeo.Tests/Components/Chart/EChartSeriesRadiusSerializationTests.cs
+++ b/tests/Lumeo.Tests/Components/Chart/EChartSeriesRadiusSerializationTests.cs
@@ -1,0 +1,122 @@
+using System.Text.Json;
+using Xunit;
+using Lumeo;
+
+namespace Lumeo.Tests.Components.Chart;
+
+/// <summary>
+/// Regression tests for #153 — DonutChart rendered like a PieChart because the
+/// EChartSeries.RadiusList / CenterList properties serialized under their C#
+/// names (camelCase: <c>radiusList</c> / <c>centerList</c>) instead of the
+/// ECharts-expected <c>radius</c> / <c>center</c>. ECharts ignored both, so
+/// inner-radius / centre-offset settings were silently dropped on the floor.
+///
+/// The fix routes both through computed <c>*Serialized</c> properties carrying
+/// <c>[JsonPropertyName("radius"/"center")]</c>. These tests pin the JSON
+/// keys + shapes so a future refactor can't silently regress the donut again.
+/// </summary>
+public class EChartSeriesRadiusSerializationTests
+{
+    private static string ToJson(EChartSeries s) => JsonSerializer.Serialize(s, new JsonSerializerOptions
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull,
+    });
+
+    [Fact]
+    public void RadiusList_Serializes_As_Radius_Array()
+    {
+        var s = new EChartSeries
+        {
+            Type = "pie",
+            RadiusList = new List<string> { "50%", "70%" }
+        };
+
+        using var doc = JsonDocument.Parse(ToJson(s));
+        var root = doc.RootElement;
+
+        // Must produce { radius: ["50%", "70%"] } — the actual ECharts shape.
+        Assert.True(root.TryGetProperty("radius", out var radius), "Expected 'radius' key");
+        Assert.Equal(JsonValueKind.Array, radius.ValueKind);
+        Assert.Equal(2, radius.GetArrayLength());
+        Assert.Equal("50%", radius[0].GetString());
+        Assert.Equal("70%", radius[1].GetString());
+
+        // Must NOT leak the C# property name through.
+        Assert.False(root.TryGetProperty("radiusList", out _), "Should not emit 'radiusList'");
+    }
+
+    [Fact]
+    public void Radius_Single_String_Serializes_Through_Same_Key()
+    {
+        // The single-string form (e.g. plain pie at "70%") must keep working too —
+        // the *Serialized fallback picks the string when no list is set.
+        var s = new EChartSeries { Type = "pie", Radius = "70%" };
+        using var doc = JsonDocument.Parse(ToJson(s));
+        var radius = doc.RootElement.GetProperty("radius");
+        Assert.Equal(JsonValueKind.String, radius.ValueKind);
+        Assert.Equal("70%", radius.GetString());
+    }
+
+    [Fact]
+    public void RadiusList_Takes_Precedence_Over_Radius_When_Both_Set()
+    {
+        // Defensive: if a consumer sets both, the array wins (donut shape over plain pie).
+        var s = new EChartSeries
+        {
+            Type = "pie",
+            Radius = "70%",
+            RadiusList = new List<string> { "50%", "70%" }
+        };
+        using var doc = JsonDocument.Parse(ToJson(s));
+        var radius = doc.RootElement.GetProperty("radius");
+        Assert.Equal(JsonValueKind.Array, radius.ValueKind);
+    }
+
+    [Fact]
+    public void CenterList_Serializes_As_Center_Array()
+    {
+        var s = new EChartSeries
+        {
+            Type = "pie",
+            CenterList = new List<string> { "50%", "50%" }
+        };
+
+        using var doc = JsonDocument.Parse(ToJson(s));
+        var root = doc.RootElement;
+        Assert.True(root.TryGetProperty("center", out var center), "Expected 'center' key");
+        Assert.Equal(JsonValueKind.Array, center.ValueKind);
+        Assert.False(root.TryGetProperty("centerList", out _), "Should not emit 'centerList'");
+    }
+
+    [Fact]
+    public void DonutChart_Built_Series_Json_Has_Inner_Outer_Radius()
+    {
+        // End-to-end shape: a DonutChart-style series must JSON-render with both
+        // inner and outer radii inside the `radius` array.
+        var s = new EChartSeries
+        {
+            Type = "pie",
+            RadiusList = new List<string> { "50%", "70%" },
+            CenterList = new List<string> { "50%", "50%" },
+        };
+
+        var json = ToJson(s);
+        // Quick string-level sanity that the right shape is in the output.
+        Assert.Contains("\"radius\":[\"50%\",\"70%\"]", json);
+        Assert.Contains("\"center\":[\"50%\",\"50%\"]", json);
+        Assert.DoesNotContain("\"radiusList\"", json);
+        Assert.DoesNotContain("\"centerList\"", json);
+    }
+
+    [Fact]
+    public void Neither_Radius_Nor_RadiusList_Set_Omits_Key()
+    {
+        // When nothing is set the computed property is null and the serializer drops it
+        // — chart still renders with ECharts defaults instead of an explicit empty value.
+        var s = new EChartSeries { Type = "line" };
+        using var doc = JsonDocument.Parse(ToJson(s));
+        Assert.False(doc.RootElement.TryGetProperty("radius", out _));
+        Assert.False(doc.RootElement.TryGetProperty("center", out _));
+    }
+}


### PR DESCRIPTION
## Summary

Closes #153 — `DonutChart` rendered identically to `PieChart` because the radius config never reached ECharts. Reported on https://lumeo.nativ.sh/components/charts/donut.

### Root cause

`EChartSeries` exposes a string `Radius` and a list `RadiusList` (same for `Center` / `CenterList`). The list field serialized under its **C# property name** (camelCase `radiusList` / `centerList`) instead of the ECharts-expected keys `radius` / `center`. ECharts silently ignored both, so the inner radius fell back to 0 % and the chart looked like a plain pie. `PieChart` happened to be unaffected — its `RadiusList = ["0%", "70%"]` matched the default anyway.

### Fix

Same `*Serialized` pattern `BorderRadius` already uses:

- `Radius` (string) + `RadiusList` (list) → both `[JsonIgnore]`
- New computed `RadiusSerialized` carries `[JsonPropertyName("radius")]` and picks list-over-string-over-null
- Same setup for `CenterSerialized`

Net effect: `<DonutChart InnerRadius="50%" />` now renders an actual ring; `<PieChart>` is unchanged.

### Versioning

3.10.2 → 3.10.3 (pure bug-fix patch). `Directory.Build.props` bumped, changelog entry added with deep-links to both component pages.

## Test plan
- [x] **6 new regression tests** in `EChartSeriesRadiusSerializationTests` pin the JSON keys + shapes — pass
- [x] **88/88 Chart suite** passes (82 prior + 6 new) — no regressions
- [x] `dotnet build src/Lumeo.Charts + docs/Lumeo.Docs -c Release` with `-warnaserror` succeeds
- [x] CI build-and-test + e2e
- [x] Cloudflare preview: verify `/components/charts/donut` Simple Donut demo now shows a hole

---
_Generated by [Claude Code](https://claude.ai/code/session_01LJmBFYeCdQj2G2epoZaRzQ)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue with donut chart rendering where the inner-hole configuration was not being properly applied to the chart.

* **Tests**
  * Added test suite for chart serialization validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->