### PR TITLE
ci(publish): treat npm E409 race as benign duplicate

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -198,13 +198,20 @@ jobs:
         # "cannot publish over previously published versions" returns exit 1
         # which we swallow only for that specific case. Any other failure (auth,
         # network, validation) keeps its exit code.
+        #
+        # E409 catch: the release + push triggers fire publish.yml in parallel.
+        # If both jobs hit `npm publish` at the same instant the runner that loses
+        # the registry-side write race gets HTTP 409 "Failed to save packument"
+        # (different wording from the regular "already published" path) — that's
+        # still a benign duplicate, the winner has the package live, so we treat
+        # it as success too.
         run: |
           set +e
           out=$(npm publish --access public 2>&1)
           code=$?
           echo "$out"
-          if [ $code -ne 0 ] && echo "$out" | grep -qE "cannot publish over|previously published"; then
-            echo "::notice::Version already on npm — treating as success (likely a release re-run after a sibling job failed)."
+          if [ $code -ne 0 ] && echo "$out" | grep -qE "cannot publish over|previously published|E409|Failed to save packument"; then
+            echo "::notice::Version already on npm (or concurrent-publish race) — treating as success."
             exit 0
           fi
           exit $code

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -202,17 +202,29 @@ jobs:
         # E409 catch: the release + push triggers fire publish.yml in parallel.
         # If both jobs hit `npm publish` at the same instant the runner that loses
         # the registry-side write race gets HTTP 409 "Failed to save packument"
-        # (different wording from the regular "already published" path) — that's
-        # still a benign duplicate, the winner has the package live, so we treat
-        # it as success too.
+        # (different wording from the regular "already published" path). Before
+        # swallowing it we VERIFY the version is actually on the registry via
+        # `npm view` — otherwise a single-run workflow_dispatch or a transient
+        # registry outage that happens to surface as E409 would go green while
+        # the package is missing. Only after confirmation do we exit 0.
         run: |
           set +e
           out=$(npm publish --access public 2>&1)
           code=$?
           echo "$out"
-          if [ $code -ne 0 ] && echo "$out" | grep -qE "cannot publish over|previously published|E409|Failed to save packument"; then
-            echo "::notice::Version already on npm (or concurrent-publish race) — treating as success."
+          if [ $code -eq 0 ]; then
             exit 0
+          fi
+          if echo "$out" | grep -qE "cannot publish over|previously published|E409|Failed to save packument"; then
+            version="${{ steps.ver.outputs.version }}"
+            echo "Publish returned a duplicate-shaped error — verifying @lumeo-ui/mcp-server@$version on the registry…"
+            # `npm view <pkg>@<version> version` prints the version on hit, empty + non-zero on miss.
+            registry_version=$(npm view "@lumeo-ui/mcp-server@$version" version 2>/dev/null)
+            if [ "$registry_version" = "$version" ]; then
+              echo "::notice::@lumeo-ui/mcp-server@$version confirmed live on npm — treating duplicate as success."
+              exit 0
+            fi
+            echo "::error::npm reported a duplicate but @lumeo-ui/mcp-server@$version is NOT on the registry (got '$registry_version'). Failing the job."
           fi
           exit $code
         env:


### PR DESCRIPTION
## Summary

CI infrastructure fix. While shipping 3.10.3 the **push-triggered** publish-mcp run failed with `npm error code E409 - 409 Conflict - PUT https://registry.npmjs.org/@lumeo-ui%2fmcp-server - Failed to save packument` — even though the **release-triggered** publish-mcp run had succeeded moments earlier and the npm package was live at 3.10.3.

### Root cause

`publish.yml` fires twice per release — once on `release: published`, once on `push: tags`. Both runs reach `npm publish` almost simultaneously. The npm registry serialises one and returns HTTP 409 to the other ("Failed to save packument"). The existing skip-on-duplicate guard only matched `"cannot publish over"` / `"previously published"`, so the race-losing run surfaced a red workflow status despite the package being correctly published.

### Fix

Extended the grep alternation in the publish step to also match `E409` / `Failed to save packument`. Same benign-duplicate treatment, no behaviour change for genuine failures (auth, validation, network).

## Test plan
- [x] Pure workflow YAML diff — no code / test impact
- [ ] Next release: both parallel publish-mcp runs should show green even when one loses the registry race

---
_Generated by [Claude Code](https://claude.ai/code/session_01LJmBFYeCdQj2G2epoZaRzQ)_