### PR TITLE
docs: stop install snippets showing stale versions (3.1.0 / 2.2.3)

### DIFF
--- a/docs/Lumeo.Docs/Pages/Components/CodePage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/CodePage.razor
@@ -24,7 +24,7 @@
     </ComponentDemo>
 
     <ComponentDemo Title="Block" Code="@_blockCode">
-        <Code Variant="block">dotnet add package Lumeo --version 2.2.3</Code>
+        <Code Variant="block">dotnet add package Lumeo --version 3.11.0</Code>
     </ComponentDemo>
 
     <ComponentDemo Title="Custom Size" Code="@_sizeCode">
@@ -123,7 +123,7 @@
     Pass <Code>Variant=""block""</Code> for multi-line blocks.
 </p>";
 
-    private string _blockCode = @"<Code Variant=""block"">dotnet add package Lumeo --version 2.2.3</Code>";
+    private string _blockCode = @"<Code Variant=""block"">dotnet add package Lumeo --version 3.11.0</Code>";
 
     private string _sizeCode = @"<Code Size=""xs"">text-xs code</Code>
 <Code Size=""base"">text-base code</Code>

--- a/docs/Lumeo.Docs/Pages/Docs/Cli.razor
+++ b/docs/Lumeo.Docs/Pages/Docs/Cli.razor
@@ -1,5 +1,6 @@
 @page "/docs/cli"
 @namespace Lumeo.Docs.Pages.Docs
+@using System.Reflection
 
 <PageTitle>CLI — Lumeo</PageTitle>
 
@@ -36,7 +37,7 @@
                 Install as a global <code class="rounded bg-muted px-1.5 py-0.5 text-xs font-mono text-foreground">dotnet</code> tool:
             </Lumeo.Text>
             <Stack Class="code-block rounded-lg border border-border/40 bg-muted px-4 py-3 font-mono text-sm text-foreground">
-                dotnet tool install -g Lumeo.Cli --version 2.2.3
+                dotnet tool install -g Lumeo.Cli --version @_v
             </Stack>
             <Lumeo.Text Size="sm" Color="muted" Leading="relaxed">
                 The tool exposes a single command, <code class="rounded bg-muted px-1.5 py-0.5 text-xs font-mono text-foreground">lumeo</code>.
@@ -473,4 +474,19 @@ npm run watch:css</Stack>
     </Stack>
 
 </Stack>
+
+@code {
+    // Lockstep package version, auto-derived from the assembly InformationalVersion
+    // (built from Directory.Build.props <Version>). The CLI ships at the same version,
+    // so the install snippet tracks releases instead of a stale literal (was 2.2.3).
+    private static readonly string _v = ExtractVersion();
+    private static string ExtractVersion()
+    {
+        var raw = typeof(Cli).Assembly
+            .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion
+            ?? typeof(Cli).Assembly.GetName().Version?.ToString(3) ?? "";
+        var plus = raw.IndexOf('+');
+        return plus >= 0 ? raw[..plus] : raw;
+    }
+}
 </Container>

--- a/docs/Lumeo.Docs/Pages/Docs/Cli.razor
+++ b/docs/Lumeo.Docs/Pages/Docs/Cli.razor
@@ -475,6 +475,8 @@ npm run watch:css</Stack>
 
 </Stack>
 
+</Container>
+
 @code {
     // Lockstep package version, auto-derived from the assembly InformationalVersion
     // (built from Directory.Build.props <Version>). The CLI ships at the same version,
@@ -489,4 +491,3 @@ npm run watch:css</Stack>
         return plus >= 0 ? raw[..plus] : raw;
     }
 }
-</Container>

--- a/docs/Lumeo.Docs/Pages/Docs/Introduction.razor
+++ b/docs/Lumeo.Docs/Pages/Docs/Introduction.razor
@@ -1,5 +1,6 @@
 @page "/docs/introduction"
 @namespace Lumeo.Docs.Pages.Docs
+@using System.Reflection
 
 <PageTitle>Introduction — Lumeo</PageTitle>
 
@@ -228,17 +229,17 @@
                         <span class="font-mono text-[10px]" style="color: rgba(255,255,255,0.70);">.csproj</span>
                     </div>
 <pre class="font-mono text-[12px] leading-relaxed whitespace-pre overflow-x-auto px-4 py-3 m-0" style="color: #e4e4e7;"><span style="color: #94a3b8;">&lt;</span><span style="color: #60a5fa;">ItemGroup</span><span style="color: #94a3b8;">&gt;</span>
-  <span style="color: #94a3b8;">&lt;</span><span style="color: #60a5fa;">PackageReference</span> <span style="color: #fbbf24;">Include</span>=<span style="color: #86efac;">"Lumeo"</span>            <span style="color: #fbbf24;">Version</span>=<span style="color: #86efac;">"3.1.0"</span> <span style="color: #94a3b8;">/&gt;</span>
+  <span style="color: #94a3b8;">&lt;</span><span style="color: #60a5fa;">PackageReference</span> <span style="color: #fbbf24;">Include</span>=<span style="color: #86efac;">"Lumeo"</span>            <span style="color: #fbbf24;">Version</span>=<span style="color: #86efac;">"@_v"</span> <span style="color: #94a3b8;">/&gt;</span>
   <span style="color: #94a3b8;">&lt;!-- add only the satellites you need: --&gt;</span>
-  <span style="color: #94a3b8;">&lt;</span><span style="color: #60a5fa;">PackageReference</span> <span style="color: #fbbf24;">Include</span>=<span style="color: #86efac;">"Lumeo.Charts"</span>    <span style="color: #fbbf24;">Version</span>=<span style="color: #86efac;">"3.1.0"</span> <span style="color: #94a3b8;">/&gt;</span>
-  <span style="color: #94a3b8;">&lt;</span><span style="color: #60a5fa;">PackageReference</span> <span style="color: #fbbf24;">Include</span>=<span style="color: #86efac;">"Lumeo.DataGrid"</span>  <span style="color: #fbbf24;">Version</span>=<span style="color: #86efac;">"3.1.0"</span> <span style="color: #94a3b8;">/&gt;</span>
-  <span style="color: #94a3b8;">&lt;</span><span style="color: #60a5fa;">PackageReference</span> <span style="color: #fbbf24;">Include</span>=<span style="color: #86efac;">"Lumeo.Editor"</span>    <span style="color: #fbbf24;">Version</span>=<span style="color: #86efac;">"3.1.0"</span> <span style="color: #94a3b8;">/&gt;</span>
-  <span style="color: #94a3b8;">&lt;</span><span style="color: #60a5fa;">PackageReference</span> <span style="color: #fbbf24;">Include</span>=<span style="color: #86efac;">"Lumeo.Scheduler"</span> <span style="color: #fbbf24;">Version</span>=<span style="color: #86efac;">"3.1.0"</span> <span style="color: #94a3b8;">/&gt;</span>
-  <span style="color: #94a3b8;">&lt;</span><span style="color: #60a5fa;">PackageReference</span> <span style="color: #fbbf24;">Include</span>=<span style="color: #86efac;">"Lumeo.Gantt"</span>     <span style="color: #fbbf24;">Version</span>=<span style="color: #86efac;">"3.1.0"</span> <span style="color: #94a3b8;">/&gt;</span>
-  <span style="color: #94a3b8;">&lt;</span><span style="color: #60a5fa;">PackageReference</span> <span style="color: #fbbf24;">Include</span>=<span style="color: #86efac;">"Lumeo.Motion"</span>    <span style="color: #fbbf24;">Version</span>=<span style="color: #86efac;">"3.1.0"</span> <span style="color: #94a3b8;">/&gt;</span>
-  <span style="color: #94a3b8;">&lt;</span><span style="color: #60a5fa;">PackageReference</span> <span style="color: #fbbf24;">Include</span>=<span style="color: #86efac;">"Lumeo.PdfViewer"</span> <span style="color: #fbbf24;">Version</span>=<span style="color: #86efac;">"3.1.0"</span> <span style="color: #94a3b8;">/&gt;</span>
-  <span style="color: #94a3b8;">&lt;</span><span style="color: #60a5fa;">PackageReference</span> <span style="color: #fbbf24;">Include</span>=<span style="color: #86efac;">"Lumeo.Maps"</span>      <span style="color: #fbbf24;">Version</span>=<span style="color: #86efac;">"3.1.0"</span> <span style="color: #94a3b8;">/&gt;</span>
-  <span style="color: #94a3b8;">&lt;</span><span style="color: #60a5fa;">PackageReference</span> <span style="color: #fbbf24;">Include</span>=<span style="color: #86efac;">"Lumeo.CodeEditor"</span> <span style="color: #fbbf24;">Version</span>=<span style="color: #86efac;">"3.1.0"</span> <span style="color: #94a3b8;">/&gt;</span>
+  <span style="color: #94a3b8;">&lt;</span><span style="color: #60a5fa;">PackageReference</span> <span style="color: #fbbf24;">Include</span>=<span style="color: #86efac;">"Lumeo.Charts"</span>    <span style="color: #fbbf24;">Version</span>=<span style="color: #86efac;">"@_v"</span> <span style="color: #94a3b8;">/&gt;</span>
+  <span style="color: #94a3b8;">&lt;</span><span style="color: #60a5fa;">PackageReference</span> <span style="color: #fbbf24;">Include</span>=<span style="color: #86efac;">"Lumeo.DataGrid"</span>  <span style="color: #fbbf24;">Version</span>=<span style="color: #86efac;">"@_v"</span> <span style="color: #94a3b8;">/&gt;</span>
+  <span style="color: #94a3b8;">&lt;</span><span style="color: #60a5fa;">PackageReference</span> <span style="color: #fbbf24;">Include</span>=<span style="color: #86efac;">"Lumeo.Editor"</span>    <span style="color: #fbbf24;">Version</span>=<span style="color: #86efac;">"@_v"</span> <span style="color: #94a3b8;">/&gt;</span>
+  <span style="color: #94a3b8;">&lt;</span><span style="color: #60a5fa;">PackageReference</span> <span style="color: #fbbf24;">Include</span>=<span style="color: #86efac;">"Lumeo.Scheduler"</span> <span style="color: #fbbf24;">Version</span>=<span style="color: #86efac;">"@_v"</span> <span style="color: #94a3b8;">/&gt;</span>
+  <span style="color: #94a3b8;">&lt;</span><span style="color: #60a5fa;">PackageReference</span> <span style="color: #fbbf24;">Include</span>=<span style="color: #86efac;">"Lumeo.Gantt"</span>     <span style="color: #fbbf24;">Version</span>=<span style="color: #86efac;">"@_v"</span> <span style="color: #94a3b8;">/&gt;</span>
+  <span style="color: #94a3b8;">&lt;</span><span style="color: #60a5fa;">PackageReference</span> <span style="color: #fbbf24;">Include</span>=<span style="color: #86efac;">"Lumeo.Motion"</span>    <span style="color: #fbbf24;">Version</span>=<span style="color: #86efac;">"@_v"</span> <span style="color: #94a3b8;">/&gt;</span>
+  <span style="color: #94a3b8;">&lt;</span><span style="color: #60a5fa;">PackageReference</span> <span style="color: #fbbf24;">Include</span>=<span style="color: #86efac;">"Lumeo.PdfViewer"</span> <span style="color: #fbbf24;">Version</span>=<span style="color: #86efac;">"@_v"</span> <span style="color: #94a3b8;">/&gt;</span>
+  <span style="color: #94a3b8;">&lt;</span><span style="color: #60a5fa;">PackageReference</span> <span style="color: #fbbf24;">Include</span>=<span style="color: #86efac;">"Lumeo.Maps"</span>      <span style="color: #fbbf24;">Version</span>=<span style="color: #86efac;">"@_v"</span> <span style="color: #94a3b8;">/&gt;</span>
+  <span style="color: #94a3b8;">&lt;</span><span style="color: #60a5fa;">PackageReference</span> <span style="color: #fbbf24;">Include</span>=<span style="color: #86efac;">"Lumeo.CodeEditor"</span> <span style="color: #fbbf24;">Version</span>=<span style="color: #86efac;">"@_v"</span> <span style="color: #94a3b8;">/&gt;</span>
 <span style="color: #94a3b8;">&lt;/</span><span style="color: #60a5fa;">ItemGroup</span><span style="color: #94a3b8;">&gt;</span></pre>
                 </div>
                 <Alert Variant="Alert.AlertVariant.Info" Title="No extra namespace imports needed" ShowIcon="true">
@@ -686,3 +687,19 @@
         </div>
     </Container>
 </section>
+
+@code {
+    // Current package version, read from the assembly's InformationalVersion (auto-generated
+    // from Directory.Build.props <Version> at build) with any +commit suffix stripped. Keeps
+    // the multi-package install snippet in lockstep with releases instead of a hand-edited
+    // literal that drifted to 3.1.0.
+    private static readonly string _v = ExtractVersion();
+    private static string ExtractVersion()
+    {
+        var raw = typeof(Introduction).Assembly
+            .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion
+            ?? typeof(Introduction).Assembly.GetName().Version?.ToString(3) ?? "";
+        var plus = raw.IndexOf('+');
+        return plus >= 0 ? raw[..plus] : raw;
+    }
+}


### PR DESCRIPTION
## Summary

You flagged that version numbers on the site looked stale despite 3.11.0 being out. The changelog and the per-component Installation tabs (`InstallUsage.razor`) were already current — but three other user-facing install snippets still showed ancient pinned versions:

| Page | Was | Now |
|---|---|---|
| **Introduction** — multi-package `.csproj` block | `Version="3.1.0"` × 11 PackageReferences | auto-derived `@_v` (assembly `InformationalVersion`, same as InstallUsage) |
| **CLI guide** — `dotnet tool install` | `--version 2.2.3` | auto-derived `@_v` (CLI ships in lockstep) |
| **Code component demo** — sample block | `dotnet add package Lumeo --version 2.2.3` | `3.11.0` (illustrative demo content, static is fine) |

The first two now read the assembly version that's generated from `Directory.Build.props <Version>` at build time, so they track every release automatically and won't drift again — the same fix already applied to `InstallUsage.razor` earlier.

### Note on "since vX" annotations

I deliberately left feature-introduction notes like "Since v3.7.0: the DataGrid export backend…" and "Sizing overlays (3.6.0)" untouched — those correctly record *when* a feature shipped, not the current version. The BundleFacts benchmark figures ("measured against 3.1.0") are dated measurements and also stay as-is.

### Scope

Pure docs change, no source/version touch. Cloudflare auto-deploys from master.

## Test plan
- [x] `dotnet build docs/Lumeo.Docs -c Release` succeeds; `@_v` resolves to `3.11.0` (verified against the generated `AssemblyInformationalVersionAttribute`)
- [ ] Cloudflare preview: Introduction + CLI install snippets show 3.11.0

---
_Generated by [Claude Code](https://claude.ai/code/session_01LJmBFYeCdQj2G2epoZaRzQ)_