### PR TITLE
fix(mcp): correct stale Combobox/Select curated examples and add gotchas

### DIFF
--- a/src/Lumeo/UI/Combobox/Combobox.razor
+++ b/src/Lumeo/UI/Combobox/Combobox.razor
@@ -2,6 +2,8 @@
 @implements IDisposable
 @inject IComponentInteropService Interop
 
+@* <gotcha>Data-bound mode (the Items parameter) still requires <ComboboxInput /> and <ComboboxContent /> children — a bare <Combobox Items="..." /> with no children renders only an empty wrapper. Map items with ItemValue/ItemText (there is no ItemLabel parameter); items are typed as object, so the Combobox is not generic (no TItem).</gotcha> *@
+
 @{
     var focusedItemId = _focusedIndex >= 0 && _focusedIndex < _items.Count ? _items[_focusedIndex].Id : null;
     var focusedItemValue = _focusedIndex >= 0 && _focusedIndex < _items.Count ? _items[_focusedIndex].Value : null;

--- a/src/Lumeo/UI/Select/Select.razor
+++ b/src/Lumeo/UI/Select/Select.razor
@@ -1,6 +1,8 @@
 @namespace Lumeo
 @inject IComponentInteropService Interop
 
+@* <gotcha>Data-bound mode (the Items parameter) still requires <SelectTrigger /> and <SelectContent /> children — a bare <Select Items="..." /> with no children shows only an empty field. Map items with ItemValue/ItemText; items are typed as object, so the data-bound Select is not generic.</gotcha> *@
+
 @{
     var focusedItemId = _focusedIndex >= 0 && _focusedIndex < _items.Count ? _items[_focusedIndex].Id : null;
     var focusedItemValue = _focusedIndex >= 0 && _focusedIndex < _items.Count ? _items[_focusedIndex].Value : null;

--- a/tools/lumeo-mcp/src/components.ts
+++ b/tools/lumeo-mcp/src/components.ts
@@ -142,16 +142,19 @@ export const components: ComponentDoc[] = [
   {
     name: "Select",
     category: "Forms",
-    description: "Dropdown select with options.",
+    description: "Dropdown select with options. Value is a string; use SelectItem children for static options or the Items parameter for data binding.",
     params: p([
-      { name: "Value", type: "TValue?", default: "default", description: "Current selection (two-way bindable)." },
-      { name: "ValueChanged", type: "EventCallback<TValue?>", default: "—", description: "Raised on selection." },
+      { name: "Value", type: "string?", default: "null", description: "Current selection value (two-way bindable)." },
+      { name: "ValueChanged", type: "EventCallback<string?>", default: "—", description: "Raised on selection." },
       { name: "Placeholder", type: "string?", default: "null", description: "Placeholder when no value selected." },
+      { name: "Items", type: "IEnumerable<object>?", default: "null", description: "Data source for data-bound mode. Rendered by the child SelectContent." },
+      { name: "ItemValue", type: "Func<object, string>", default: "ToString()", description: "Maps an item to its string value (data-bound mode)." },
+      { name: "ItemText", type: "Func<object, string>?", default: "ItemValue", description: "Maps an item to its display label (data-bound mode)." },
     ]),
     slots: [
-      { name: "ChildContent", description: "One or more <SelectItem Value=\"...\">…</SelectItem> entries." },
+      { name: "ChildContent", description: "Static mode: one or more <SelectItem Value=\"...\">…</SelectItem> entries. Data-bound mode (Items): still requires <SelectTrigger /> and <SelectContent /> children — a bare <Select Items=\"...\" /> renders an empty field." },
     ],
-    example: `<Select TValue="string" @bind-Value="_country" Placeholder="Select a country">
+    example: `<Select @bind-Value="_country" Placeholder="Select a country">
     <SelectItem Value="@("us")">United States</SelectItem>
     <SelectItem Value="@("de")">Germany</SelectItem>
     <SelectItem Value="@("fr")">France</SelectItem>
@@ -161,18 +164,26 @@ export const components: ComponentDoc[] = [
   {
     name: "Combobox",
     category: "Forms",
-    description: "Searchable dropdown select, supports async data and custom item templates.",
+    description: "Searchable dropdown select, supports async data and custom item templates. Not generic — items are typed as object.",
     params: p([
-      { name: "Items", type: "IEnumerable<TItem>", default: "[]", description: "Source list." },
-      { name: "Value", type: "TItem?", default: "default", description: "Current selection (two-way bindable)." },
-      { name: "ValueChanged", type: "EventCallback<TItem?>", default: "—", description: "Raised on selection." },
-      { name: "ItemLabel", type: "Func<TItem, string>", default: "—", description: "Maps item to display label." },
-      { name: "Placeholder", type: "string?", default: "null", description: "Placeholder text." },
+      { name: "Items", type: "IEnumerable<object>?", default: "null", description: "Data source for data-bound mode. Rendered by the child ComboboxContent." },
+      { name: "Value", type: "string?", default: "null", description: "Current selection value (two-way bindable)." },
+      { name: "ValueChanged", type: "EventCallback<string>", default: "—", description: "Raised on selection." },
+      { name: "ItemValue", type: "Func<object, string>", default: "ToString()", description: "Maps an item to its string value." },
+      { name: "ItemText", type: "Func<object, string>?", default: "ItemValue", description: "Maps an item to its display label. Defaults to ItemValue when null." },
+      { name: "Placeholder", type: "string?", default: "null", description: "Placeholder shown by the child ComboboxInput when it has none of its own." },
     ]),
     slots: [
-      { name: "ItemTemplate", description: "Custom template per item (RenderFragment<TItem>)." },
+      { name: "ChildContent", description: "Required. Must contain <ComboboxInput /> and <ComboboxContent /> — even in data-bound (Items) mode, a Combobox with no children renders nothing." },
+      { name: "ItemTemplate", description: "Custom template per item (RenderFragment<object>)." },
     ],
-    example: `<Combobox TItem="string" Items="_countries" @bind-Value="_country" ItemLabel="c => c" Placeholder="Search country..." />`,
+    example: `<Combobox Items="_frameworks" @bind-Value="_selected"
+          ItemValue="@(o => ((Framework)o).Id)"
+          ItemText="@(o => ((Framework)o).Name)"
+          Placeholder="Search frameworks...">
+    <ComboboxInput />
+    <ComboboxContent />
+</Combobox>`,
     cssVars: ["--color-popover", "--color-accent"],
   },
   {


### PR DESCRIPTION
Fixes #160.

## Problem
The MCP server returned stale/incorrect info for the data-bound form components:

1. **Combobox curated example referenced a non-existent `ItemLabel`** parameter and a `TItem` generic — neither exists. The real API maps items via `ItemValue` / `ItemText`, and the component is **not** generic (items are typed as `object`).
2. **The example showed a bare `<Combobox Items="…" />` with no children**, which renders nothing. `ComboboxInput` + `ComboboxContent` are required even in data-bound mode (verified against `src/Lumeo/UI/Combobox/Combobox.razor` — the root only renders `@ChildContent`).
3. **`gotchas` arrays were empty** for Combobox/Select.
4. Select has the same data-bound requirement (`SelectTrigger` + `SelectContent`).

## Changes
- **`tools/lumeo-mcp/src/components.ts`**
  - Combobox: fixed params (`ItemLabel` → `ItemValue` + `ItemText`, dropped `TItem`, corrected `Value`/`Items` types) and rewrote the curated example to include the required `<ComboboxInput />` + `<ComboboxContent />` children.
  - Select: added the data-bound `Items` / `ItemValue` / `ItemText` params and a slot note that data-bound mode still needs `<SelectTrigger />` + `<SelectContent />`.
- **`src/Lumeo/UI/Combobox/Combobox.razor` / `Select.razor`**: added `<gotcha>` markers. `RegistryGen` reads these into `components-api.json` / `registry.json` (verified locally: the gotchas now populate for both components).

## Notes for the owner — this is **not** docs-only
This changes the **`@lumeo-ui/mcp-server` npm package** content (curated examples) and the generated registry, so per the release rules it is a real library change, not a docs-only change:
- After merge, `sync-mcp-registry.yml` regenerates `components-api.json` / `registry.json` on `master` (run in CI's Linux env to avoid the CRLF/line-ending churn a local run produces).
- Publishing the refreshed MCP package (and the NuGet `registry.json` bundle) needs your explicit go-ahead per Rule #2. I have **not** bumped a version or tagged anything — just flagging that a release is required for the fix to reach MCP clients.

Local verification: `dotnet build src/Lumeo` ✅, MCP `tsc` build ✅, Combobox/Select tests 138/138 ✅, registry regen confirms clean gotchas for both components.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LJmBFYeCdQj2G2epoZaRzQ)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced documentation for the Select component, clarifying data-bound mode behavior and parameter mapping.
  * Improved guidance for the Combobox component, explaining child component requirements and non-generic item handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->