### PR TITLE
feat(combobox): chips, Clearable, MaxDisplayTags — multi-select parity with Select

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
   <!-- Lockstep version shared by all Lumeo packages.
        Update this single property to version all packages in unison. -->
   <PropertyGroup>
-    <Version>3.11.0</Version>
+    <Version>3.12.0</Version>
   </PropertyGroup>
 
   <!-- Shared NuGet README packing lives in Directory.Build.targets, NOT here.

--- a/docs/Lumeo.Docs/Pages/Components/ComboboxPage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/ComboboxPage.razor
@@ -78,6 +78,23 @@
         </Stack>
     </ComponentDemo>
 
+    <ComponentDemo Title="Clearable + MaxDisplayTags (Multiple)" Code="@_clearableMultiCode">
+        <Stack Gap="2" Class="w-full max-w-sm">
+            <Combobox Multiple="true" Clearable="true" MaxDisplayTags="2"
+                      @bind-Values="_selectedToolsClearable" @bind-Open="_isOpenClearableMulti">
+                <ComboboxInput Placeholder="Pick tools..." />
+                <ComboboxContent>
+                    <ComboboxItem Value="dotnet">.NET</ComboboxItem>
+                    <ComboboxItem Value="blazor">Blazor</ComboboxItem>
+                    <ComboboxItem Value="tailwind">Tailwind</ComboboxItem>
+                    <ComboboxItem Value="echarts">ECharts</ComboboxItem>
+                    <ComboboxItem Value="lucide">Lucide</ComboboxItem>
+                </ComboboxContent>
+            </Combobox>
+            <Lumeo.Text Size="sm" Color="muted">First 2 selections show as chips; the rest collapse to "+N more". The × button clears all.</Lumeo.Text>
+        </Stack>
+    </ComponentDemo>
+
     <ComponentDemo Title="Grouped Items" Code="@_groupedCode">
         <Stack Gap="2" Class="w-full max-w-xs">
             <Combobox @bind-Value="_selectedGroupedFramework" @bind-Open="_isOpenGrouped">
@@ -177,6 +194,8 @@
     private bool _isOpenGrouped;
     private HashSet<string> _selectedTools = new();
     private bool _isOpenGroupedAdv;
+    private HashSet<string> _selectedToolsClearable = new();
+    private bool _isOpenClearableMulti;
 
     private record ActionItem(string Id, string Label, string Hint, string IconName);
 
@@ -288,6 +307,23 @@
 
 @code {
     private HashSet<string> _selectedFrameworks = new();
+    private bool _isOpen;
+}";
+
+    private string _clearableMultiCode = @"<Combobox Multiple=""true"" Clearable=""true"" MaxDisplayTags=""2""
+          @bind-Values=""_selected"" @bind-Open=""_isOpen"">
+    <ComboboxInput Placeholder=""Pick tools..."" />
+    <ComboboxContent>
+        <ComboboxItem Value=""dotnet"">.NET</ComboboxItem>
+        <ComboboxItem Value=""blazor"">Blazor</ComboboxItem>
+        <ComboboxItem Value=""tailwind"">Tailwind</ComboboxItem>
+        <ComboboxItem Value=""echarts"">ECharts</ComboboxItem>
+        <ComboboxItem Value=""lucide"">Lucide</ComboboxItem>
+    </ComboboxContent>
+</Combobox>
+
+@code {
+    private HashSet<string> _selected = new();
     private bool _isOpen;
 }";
 
@@ -582,6 +618,18 @@
                             <td class="p-3 font-mono text-xs text-muted-foreground">HashSet&lt;string&gt;</td>
                             <td class="p-3 font-mono text-xs text-muted-foreground">new()</td>
                             <td class="p-3 text-muted-foreground">The set of selected values when Multiple is true. Use with @@bind-Values.</td>
+                        </tr>
+                        <tr>
+                            <td class="p-3 font-mono text-xs text-primary">Clearable</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">bool</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">false</td>
+                            <td class="p-3 text-muted-foreground">Shows a × button in the input that resets the selection to empty. Mirrors Select.Clearable.</td>
+                        </tr>
+                        <tr>
+                            <td class="p-3 font-mono text-xs text-primary">MaxDisplayTags</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">int</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">3</td>
+                            <td class="p-3 text-muted-foreground">In Multiple mode, caps the number of chips shown in the input — the rest collapse into a "+N more" indicator.</td>
                         </tr>
                         <tr>
                             <td class="p-3 font-mono text-xs text-primary">OnSearchAsync</td>

--- a/docs/Lumeo.Docs/Pages/Docs/Changelog.razor
+++ b/docs/Lumeo.Docs/Pages/Docs/Changelog.razor
@@ -15,6 +15,30 @@
 
     <Separator Class="my-4" />
 
+    <!-- v3.12.0 -->
+    <Stack Gap="4">
+        <div class="flex items-center gap-3">
+            <Badge>v3.12.0</Badge>
+            <Lumeo.Text Size="sm" Color="muted">June 2026</Lumeo.Text>
+        </div>
+
+        <Lumeo.Text Size="base" Color="muted" Leading="relaxed">
+            Minor: <Lumeo.Link Href="components/combobox">Combobox</Lumeo.Link> reaches full multi-select parity
+            with <Lumeo.Link Href="components/select">Select</Lumeo.Link> — chips in the input, a clear
+            affordance, and a configurable overflow indicator.
+        </Lumeo.Text>
+
+        <Stack Gap="3">
+            <Heading Level="3" Size="sm" Class="font-semibold">Added</Heading>
+            <ul class="space-y-1.5 text-sm list-disc list-inside text-muted-foreground">
+                <li><strong>Combobox multi-select now renders selected values as chips inside the input (closes #162).</strong> Previously <code class="rounded bg-muted px-1 text-xs">Multiple="true"</code> updated the bound <code class="rounded bg-muted px-1 text-xs">Values</code> correctly but gave no visual feedback — the input stayed blank. Selected values now show as removable chips alongside the search field (tag-input style), with <kbd>Backspace</kbd> on the empty input removing the last chip.</li>
+                <li><strong>Combobox gains <code class="rounded bg-muted px-1 text-xs">Clearable</code> and <code class="rounded bg-muted px-1 text-xs">MaxDisplayTags</code>.</strong> <code class="rounded bg-muted px-1 text-xs">Clearable</code> renders an × button that resets <code class="rounded bg-muted px-1 text-xs">Value</code> / <code class="rounded bg-muted px-1 text-xs">Values</code> to empty; <code class="rounded bg-muted px-1 text-xs">MaxDisplayTags</code> (default 3) caps visible chips and collapses the rest into a <em>+N more</em> indicator. Both mirror the existing Select API exactly.</li>
+            </ul>
+        </Stack>
+    </Stack>
+
+    <Separator Class="my-4" />
+
     <!-- v3.11.0 -->
     <Stack Gap="4">
         <div class="flex items-center gap-3">

--- a/src/Lumeo/UI/Combobox/Combobox.razor
+++ b/src/Lumeo/UI/Combobox/Combobox.razor
@@ -18,6 +18,9 @@
         Items, ItemValue, ItemText, ItemGroup, ItemDisabled, ItemDescription, ItemIcon, ItemTemplate, Virtualize, ItemSize)
     {
         Placeholder = Placeholder,
+        Clearable = Clearable,
+        MaxDisplayTags = MaxDisplayTags,
+        OnClear = EventCallback.Factory.Create(this, OnClearSelection),
     };
 }
 
@@ -79,6 +82,14 @@
     [Parameter] public bool Multiple { get; set; }
     [Parameter] public HashSet<string>? Values { get; set; }
     [Parameter] public EventCallback<HashSet<string>> ValuesChanged { get; set; }
+    /// <summary>Cap on the number of selected-value chips rendered by
+    /// <see cref="ComboboxInput"/> in <see cref="Multiple"/> mode; the rest collapse into a
+    /// "+N more" indicator. Mirrors <c>Select.MaxDisplayTags</c>.</summary>
+    [Parameter] public int MaxDisplayTags { get; set; } = 3;
+    /// <summary>When <c>true</c>, the input shows a clear (×) affordance that resets
+    /// <see cref="Value"/> (or <see cref="Values"/> in <see cref="Multiple"/> mode) to its empty
+    /// state. Mirrors <c>Select.Clearable</c>.</summary>
+    [Parameter] public bool Clearable { get; set; }
 
     // Creatable
     [Parameter] public bool Creatable { get; set; }
@@ -243,6 +254,21 @@
         await Task.CompletedTask;
     }
 
+    private async Task OnClearSelection()
+    {
+        if (Multiple)
+        {
+            Values = null;
+            await ValuesChanged.InvokeAsync(null);
+        }
+        else
+        {
+            Value = null;
+            await ValueChanged.InvokeAsync(null);
+        }
+        SearchText = "";
+    }
+
     private async Task OnCreateItem(string value)
     {
         await OnCreate.InvokeAsync(value);
@@ -287,5 +313,8 @@
         /// as a fallback when its own Placeholder is unset. Init-only so the positional
         /// constructor above stays source-compatible.</summary>
         public string? Placeholder { get; init; }
+        public bool Clearable { get; init; }
+        public int MaxDisplayTags { get; init; } = 3;
+        public EventCallback OnClear { get; init; }
     }
 }

--- a/src/Lumeo/UI/Combobox/Combobox.razor
+++ b/src/Lumeo/UI/Combobox/Combobox.razor
@@ -2,6 +2,8 @@
 @implements IDisposable
 @inject IComponentInteropService Interop
 
+@* <gotcha>Data-bound mode (the Items parameter) still requires <ComboboxInput /> and <ComboboxContent /> children — a bare <Combobox Items="..." /> with no children renders only an empty wrapper. Map items with ItemValue/ItemText (there is no ItemLabel parameter); items are typed as object, so the Combobox is not generic (no TItem).</gotcha> *@
+
 @{
     var focusedItemId = _focusedIndex >= 0 && _focusedIndex < _items.Count ? _items[_focusedIndex].Id : null;
     var focusedItemValue = _focusedIndex >= 0 && _focusedIndex < _items.Count ? _items[_focusedIndex].Value : null;

--- a/src/Lumeo/UI/Combobox/ComboboxInput.razor
+++ b/src/Lumeo/UI/Combobox/ComboboxInput.razor
@@ -1,27 +1,94 @@
 @namespace Lumeo
 @inject Lumeo.Services.Localization.ILumeoLocalizer L
 
-<div class="relative">
-    @* top-1/2 + -translate-y-1/2 keeps the icon centred across all density
-       heights (h-8 / h-9 / h-10) instead of the fixed top-2.5 that only
-       centred the historical 36px comfortable input. *@
-    <Blazicon Svg="Lucide.Search" class="absolute start-2.5 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
-    <input id="@Context.InputId"
-           type="text"
-           role="combobox"
-           aria-haspopup="listbox"
-           aria-expanded="@Context.IsOpen.ToString().ToLower()"
-           aria-controls="@Context.ContentId"
-           aria-autocomplete="list"
-           aria-activedescendant="@(Context.IsOpen ? Context.FocusedItemId : null)"
-           class="@CssClass"
-           placeholder="@(Placeholder ?? Context.Placeholder ?? L["Combobox.SearchPlaceholder"])"
-           value="@Context.SearchText"
-           @oninput="HandleInput"
-           @onfocus="Open"
-           @onkeydown="HandleKeyDown"
-           @attributes="AdditionalAttributes" />
-</div>
+@if (HasChips)
+{
+    @* Tag-input layout for Multiple mode with selections: chips, then a flex-1
+       inline input that keeps search working alongside the chips. Border lives
+       on the wrapper so the field reads as a single control. *@
+    <div class="@WrapperCssClass">
+        @{
+            var displayed = Context.Values!.Take(Context.MaxDisplayTags).ToList();
+            var remaining = Context.Values!.Count - Context.MaxDisplayTags;
+        }
+        @foreach (var val in displayed)
+        {
+            <span class="inline-flex items-center gap-1 rounded-md border border-border/40 bg-secondary px-1.5 py-0.5 text-xs font-medium text-secondary-foreground">
+                @val
+                <button type="button"
+                        class="cursor-pointer rounded-full hover:bg-foreground/20 focus-visible:outline-none focus-visible:ring-[1.5px] focus-visible:ring-ring focus-visible:ring-offset-1"
+                        aria-label="@($"Remove {val}")"
+                        @onclick="() => RemoveValue(val)"
+                        @onclick:stopPropagation="true">
+                    <Blazicon Svg="Lucide.X" class="h-3 w-3" />
+                </button>
+            </span>
+        }
+        @if (remaining > 0)
+        {
+            <span class="text-xs text-muted-foreground">+@remaining more</span>
+        }
+        <input id="@Context.InputId"
+               type="text"
+               role="combobox"
+               aria-haspopup="listbox"
+               aria-expanded="@Context.IsOpen.ToString().ToLower()"
+               aria-controls="@Context.ContentId"
+               aria-autocomplete="list"
+               aria-activedescendant="@(Context.IsOpen ? Context.FocusedItemId : null)"
+               class="flex-1 min-w-[80px] bg-transparent text-sm placeholder:text-muted-foreground focus:outline-none"
+               placeholder="@EffectivePlaceholder"
+               value="@Context.SearchText"
+               @oninput="HandleInput"
+               @onfocus="Open"
+               @onkeydown="HandleKeyDown"
+               @attributes="AdditionalAttributes" />
+        @if (Context.Clearable)
+        {
+            <button type="button"
+                    class="cursor-pointer hover:text-foreground focus-visible:outline-none focus-visible:ring-[1.5px] focus-visible:ring-ring focus-visible:ring-offset-1 rounded ms-auto shrink-0"
+                    aria-label="@L["Select.ClearSelection"]"
+                    @onclick="HandleClear"
+                    @onclick:stopPropagation="true">
+                <Blazicon Svg="Lucide.X" class="h-3.5 w-3.5 opacity-50 hover:opacity-100" />
+            </button>
+        }
+    </div>
+}
+else
+{
+    <div class="relative">
+        @* top-1/2 + -translate-y-1/2 keeps the icon centred across all density
+           heights (h-8 / h-9 / h-10) instead of the fixed top-2.5 that only
+           centred the historical 36px comfortable input. *@
+        <Blazicon Svg="Lucide.Search" class="absolute start-2.5 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+        <input id="@Context.InputId"
+               type="text"
+               role="combobox"
+               aria-haspopup="listbox"
+               aria-expanded="@Context.IsOpen.ToString().ToLower()"
+               aria-controls="@Context.ContentId"
+               aria-autocomplete="list"
+               aria-activedescendant="@(Context.IsOpen ? Context.FocusedItemId : null)"
+               class="@CssClass"
+               placeholder="@EffectivePlaceholder"
+               value="@Context.SearchText"
+               @oninput="HandleInput"
+               @onfocus="Open"
+               @onkeydown="HandleKeyDown"
+               @attributes="AdditionalAttributes" />
+        @if (Context.Clearable && HasSingleValue)
+        {
+            <button type="button"
+                    class="absolute end-2.5 top-1/2 -translate-y-1/2 cursor-pointer hover:text-foreground focus-visible:outline-none focus-visible:ring-[1.5px] focus-visible:ring-ring focus-visible:ring-offset-1 rounded"
+                    aria-label="@L["Select.ClearSelection"]"
+                    @onclick="HandleClear"
+                    @onclick:stopPropagation="true">
+                <Blazicon Svg="Lucide.X" class="h-3.5 w-3.5 opacity-50 hover:opacity-100" />
+            </button>
+        }
+    </div>
+}
 
 @code {
     [CascadingParameter] public Combobox.ComboboxContext Context { get; set; } = default!;
@@ -39,7 +106,22 @@
         _ => "h-9 py-2"
     };
 
-    private string CssClass => Cx.Merge("flex", SizeClasses, "w-full rounded-md border", (Context.Invalid ? "border-destructive" : "border-input"), "bg-transparent ps-8 pe-3 text-sm placeholder:text-muted-foreground focus-visible:outline-none", (Context.Invalid ? "focus-visible:ring-[1.5px] focus-visible:ring-destructive/20" : ""), Class);
+    // Tag-input wrapper height is min- not fixed (chips can wrap to a second row),
+    // keeping the Comfortable visual default at h-9 minimum.
+    private string ChipWrapperSizeClasses => Density switch
+    {
+        Lumeo.Density.Compact => "min-h-8 px-2 py-1",
+        Lumeo.Density.Spacious => "min-h-10 px-3 py-1.5",
+        _ => "min-h-9 px-2.5 py-1"
+    };
+
+    private bool HasChips => Context.Multiple && Context.Values != null && Context.Values.Count > 0;
+    private bool HasSingleValue => !Context.Multiple && !string.IsNullOrEmpty(Context.Value);
+    private string? EffectivePlaceholder => Placeholder ?? Context.Placeholder ?? L["Combobox.SearchPlaceholder"];
+
+    private string CssClass => Cx.Merge("flex", SizeClasses, "w-full rounded-md border", (Context.Invalid ? "border-destructive" : "border-input"), "bg-transparent ps-8", (Context.Clearable && HasSingleValue ? "pe-8" : "pe-3"), "text-sm placeholder:text-muted-foreground focus-visible:outline-none", (Context.Invalid ? "focus-visible:ring-[1.5px] focus-visible:ring-destructive/20" : ""), Class);
+
+    private string WrapperCssClass => Cx.Merge("flex flex-wrap items-center gap-1", ChipWrapperSizeClasses, "w-full rounded-md border", (Context.Invalid ? "border-destructive" : "border-input"), "bg-transparent text-sm focus-within:outline-none", (Context.Invalid ? "focus-within:ring-[1.5px] focus-within:ring-destructive/20" : ""), Class);
 
     private async Task HandleInput(ChangeEventArgs e)
     {
@@ -58,6 +140,10 @@
             await Context.SetOpen.InvokeAsync(true);
         }
     }
+
+    private async Task RemoveValue(string value) => await Context.OnSelect.InvokeAsync(value);
+
+    private async Task HandleClear() => await Context.OnClear.InvokeAsync();
 
     private async Task HandleKeyDown(KeyboardEventArgs e)
     {
@@ -87,6 +173,15 @@
                 break;
             case "Escape":
                 await Context.SetOpen.InvokeAsync(false);
+                break;
+            case "Backspace":
+                // Tag-input convention: when the search field is empty and Multiple has
+                // selections, Backspace removes the last chip. Single mode is unchanged.
+                if (Context.Multiple && string.IsNullOrEmpty(Context.SearchText) && Context.Values is { Count: > 0 })
+                {
+                    var last = Context.Values.Last();
+                    await Context.OnSelect.InvokeAsync(last);
+                }
                 break;
         }
     }

--- a/src/Lumeo/UI/Select/Select.razor
+++ b/src/Lumeo/UI/Select/Select.razor
@@ -1,6 +1,8 @@
 @namespace Lumeo
 @inject IComponentInteropService Interop
 
+@* <gotcha>Data-bound mode (the Items parameter) still requires <SelectTrigger /> and <SelectContent /> children — a bare <Select Items="..." /> with no children shows only an empty field. Map items with ItemValue/ItemText; items are typed as object, so the data-bound Select is not generic.</gotcha> *@
+
 @{
     var focusedItemId = _focusedIndex >= 0 && _focusedIndex < _items.Count ? _items[_focusedIndex].Id : null;
     var focusedItemValue = _focusedIndex >= 0 && _focusedIndex < _items.Count ? _items[_focusedIndex].Value : null;

--- a/tests/Lumeo.Tests/Components/Combobox/ComboboxTests.cs
+++ b/tests/Lumeo.Tests/Components/Combobox/ComboboxTests.cs
@@ -324,4 +324,163 @@ public class ComboboxTests : IAsyncLifetime
 
         Assert.Equal("input-level", cut.Find("input").GetAttribute("placeholder"));
     }
+
+    // --- #162: Multi-select chips + Clearable + MaxDisplayTags parity with Select ---
+
+    private IRenderedComponent<IComponent> RenderMultiCombobox(
+        HashSet<string>? values = null,
+        bool clearable = false,
+        int? maxDisplayTags = null,
+        EventCallback<HashSet<string>>? valuesChanged = null)
+    {
+        return _ctx.Render(builder =>
+        {
+            builder.OpenComponent<L.Combobox>(0);
+            builder.AddAttribute(1, "Multiple", true);
+            if (values != null)
+                builder.AddAttribute(2, "Values", values);
+            if (valuesChanged.HasValue)
+                builder.AddAttribute(3, "ValuesChanged", valuesChanged.Value);
+            if (clearable)
+                builder.AddAttribute(4, "Clearable", true);
+            if (maxDisplayTags.HasValue)
+                builder.AddAttribute(5, "MaxDisplayTags", maxDisplayTags.Value);
+            builder.AddAttribute(6, "ChildContent", (RenderFragment)(b =>
+            {
+                b.OpenComponent<L.ComboboxInput>(0);
+                b.CloseComponent();
+            }));
+            builder.CloseComponent();
+        });
+    }
+
+    [Fact]
+    public void Multiple_With_No_Values_Renders_Plain_Input()
+    {
+        var cut = RenderMultiCombobox(values: null);
+        Assert.Empty(cut.FindAll("button[aria-label^='Remove ']"));
+        Assert.NotNull(cut.Find("input[type='text']"));
+    }
+
+    [Fact]
+    public void Multiple_With_Values_Renders_Chip_Per_Value()
+    {
+        var cut = RenderMultiCombobox(values: new HashSet<string> { "react", "vue", "angular" });
+        var chips = cut.FindAll("button[aria-label^='Remove ']");
+        Assert.Equal(3, chips.Count);
+        Assert.Contains("react", cut.Markup);
+        Assert.Contains("vue", cut.Markup);
+        Assert.Contains("angular", cut.Markup);
+    }
+
+    [Fact]
+    public void Multiple_With_Values_Renders_Input_Alongside_Chips()
+    {
+        var cut = RenderMultiCombobox(values: new HashSet<string> { "react" });
+        Assert.NotNull(cut.Find("input[type='text']"));
+    }
+
+    [Fact]
+    public void Chip_Remove_Click_Toggles_Value_Off()
+    {
+        HashSet<string>? captured = null;
+        var callback = EventCallback.Factory.Create<HashSet<string>>(_ctx, (HashSet<string> v) => captured = v);
+        var cut = RenderMultiCombobox(
+            values: new HashSet<string> { "react", "vue" },
+            valuesChanged: callback);
+
+        var removeReact = cut.Find("button[aria-label='Remove react']");
+        try { removeReact.Click(); } catch (ArgumentException) { }
+
+        Assert.NotNull(captured);
+        Assert.DoesNotContain("react", captured!);
+        Assert.Contains("vue", captured!);
+    }
+
+    [Fact]
+    public void MaxDisplayTags_Caps_Visible_Chips_And_Shows_Remainder()
+    {
+        var values = new HashSet<string> { "a", "b", "c", "d", "e" };
+        var cut = RenderMultiCombobox(values: values, maxDisplayTags: 2);
+
+        Assert.Equal(2, cut.FindAll("button[aria-label^='Remove ']").Count);
+        Assert.Contains("+3 more", cut.Markup);
+    }
+
+    [Fact]
+    public void MaxDisplayTags_Default_Is_3()
+    {
+        var values = new HashSet<string> { "a", "b", "c", "d" };
+        var cut = RenderMultiCombobox(values: values);
+
+        Assert.Equal(3, cut.FindAll("button[aria-label^='Remove ']").Count);
+        Assert.Contains("+1 more", cut.Markup);
+    }
+
+    [Fact]
+    public void Clearable_Multiple_Shows_Clear_Button_When_Values_Present()
+    {
+        var cut = RenderMultiCombobox(values: new HashSet<string> { "react" }, clearable: true);
+        Assert.NotEmpty(cut.FindAll("button[aria-label='Clear selection']"));
+    }
+
+    [Fact]
+    public void Clearable_False_Hides_Clear_Button()
+    {
+        var cut = RenderMultiCombobox(values: new HashSet<string> { "react" }, clearable: false);
+        Assert.Empty(cut.FindAll("button[aria-label='Clear selection']"));
+    }
+
+    [Fact]
+    public void Clear_Button_Clears_All_Values_In_Multiple_Mode()
+    {
+        HashSet<string>? captured = new HashSet<string> { "still-here" };
+        var callback = EventCallback.Factory.Create<HashSet<string>>(_ctx, (HashSet<string> v) => captured = v);
+        var cut = RenderMultiCombobox(
+            values: new HashSet<string> { "react", "vue" },
+            clearable: true,
+            valuesChanged: callback);
+
+        var clearBtn = cut.Find("button[aria-label='Clear selection']");
+        try { clearBtn.Click(); } catch (ArgumentException) { }
+
+        Assert.Null(captured);
+    }
+
+    [Fact]
+    public void Clearable_Single_Mode_Shows_Clear_Button_When_Value_Present()
+    {
+        var cut = _ctx.Render(builder =>
+        {
+            builder.OpenComponent<L.Combobox>(0);
+            builder.AddAttribute(1, "Value", "react");
+            builder.AddAttribute(2, "Clearable", true);
+            builder.AddAttribute(3, "ChildContent", (RenderFragment)(b =>
+            {
+                b.OpenComponent<L.ComboboxInput>(0);
+                b.CloseComponent();
+            }));
+            builder.CloseComponent();
+        });
+
+        Assert.NotEmpty(cut.FindAll("button[aria-label='Clear selection']"));
+    }
+
+    [Fact]
+    public void Clearable_Single_Mode_Hides_Clear_Button_When_Empty()
+    {
+        var cut = _ctx.Render(builder =>
+        {
+            builder.OpenComponent<L.Combobox>(0);
+            builder.AddAttribute(1, "Clearable", true);
+            builder.AddAttribute(2, "ChildContent", (RenderFragment)(b =>
+            {
+                b.OpenComponent<L.ComboboxInput>(0);
+                b.CloseComponent();
+            }));
+            builder.CloseComponent();
+        });
+
+        Assert.Empty(cut.FindAll("button[aria-label='Clear selection']"));
+    }
 }

--- a/tools/lumeo-mcp/src/components.ts
+++ b/tools/lumeo-mcp/src/components.ts
@@ -142,16 +142,19 @@ export const components: ComponentDoc[] = [
   {
     name: "Select",
     category: "Forms",
-    description: "Dropdown select with options.",
+    description: "Dropdown select with options. Value is a string; use SelectItem children for static options or the Items parameter for data binding.",
     params: p([
-      { name: "Value", type: "TValue?", default: "default", description: "Current selection (two-way bindable)." },
-      { name: "ValueChanged", type: "EventCallback<TValue?>", default: "—", description: "Raised on selection." },
+      { name: "Value", type: "string?", default: "null", description: "Current selection value (two-way bindable)." },
+      { name: "ValueChanged", type: "EventCallback<string?>", default: "—", description: "Raised on selection." },
       { name: "Placeholder", type: "string?", default: "null", description: "Placeholder when no value selected." },
+      { name: "Items", type: "IEnumerable<object>?", default: "null", description: "Data source for data-bound mode. Rendered by the child SelectContent." },
+      { name: "ItemValue", type: "Func<object, string>", default: "ToString()", description: "Maps an item to its string value (data-bound mode)." },
+      { name: "ItemText", type: "Func<object, string>?", default: "ItemValue", description: "Maps an item to its display label (data-bound mode)." },
     ]),
     slots: [
-      { name: "ChildContent", description: "One or more <SelectItem Value=\"...\">…</SelectItem> entries." },
+      { name: "ChildContent", description: "Static mode: one or more <SelectItem Value=\"...\">…</SelectItem> entries. Data-bound mode (Items): still requires <SelectTrigger /> and <SelectContent /> children — a bare <Select Items=\"...\" /> renders an empty field." },
     ],
-    example: `<Select TValue="string" @bind-Value="_country" Placeholder="Select a country">
+    example: `<Select @bind-Value="_country" Placeholder="Select a country">
     <SelectItem Value="@("us")">United States</SelectItem>
     <SelectItem Value="@("de")">Germany</SelectItem>
     <SelectItem Value="@("fr")">France</SelectItem>
@@ -161,18 +164,26 @@ export const components: ComponentDoc[] = [
   {
     name: "Combobox",
     category: "Forms",
-    description: "Searchable dropdown select, supports async data and custom item templates.",
+    description: "Searchable dropdown select, supports async data and custom item templates. Not generic — items are typed as object.",
     params: p([
-      { name: "Items", type: "IEnumerable<TItem>", default: "[]", description: "Source list." },
-      { name: "Value", type: "TItem?", default: "default", description: "Current selection (two-way bindable)." },
-      { name: "ValueChanged", type: "EventCallback<TItem?>", default: "—", description: "Raised on selection." },
-      { name: "ItemLabel", type: "Func<TItem, string>", default: "—", description: "Maps item to display label." },
-      { name: "Placeholder", type: "string?", default: "null", description: "Placeholder text." },
+      { name: "Items", type: "IEnumerable<object>?", default: "null", description: "Data source for data-bound mode. Rendered by the child ComboboxContent." },
+      { name: "Value", type: "string?", default: "null", description: "Current selection value (two-way bindable)." },
+      { name: "ValueChanged", type: "EventCallback<string>", default: "—", description: "Raised on selection." },
+      { name: "ItemValue", type: "Func<object, string>", default: "ToString()", description: "Maps an item to its string value." },
+      { name: "ItemText", type: "Func<object, string>?", default: "ItemValue", description: "Maps an item to its display label. Defaults to ItemValue when null." },
+      { name: "Placeholder", type: "string?", default: "null", description: "Placeholder shown by the child ComboboxInput when it has none of its own." },
     ]),
     slots: [
-      { name: "ItemTemplate", description: "Custom template per item (RenderFragment<TItem>)." },
+      { name: "ChildContent", description: "Required. Must contain <ComboboxInput /> and <ComboboxContent /> — even in data-bound (Items) mode, a Combobox with no children renders nothing." },
+      { name: "ItemTemplate", description: "Custom template per item (RenderFragment<object>)." },
     ],
-    example: `<Combobox TItem="string" Items="_countries" @bind-Value="_country" ItemLabel="c => c" Placeholder="Search country..." />`,
+    example: `<Combobox Items="_frameworks" @bind-Value="_selected"
+          ItemValue="@(o => ((Framework)o).Id)"
+          ItemText="@(o => ((Framework)o).Name)"
+          Placeholder="Search frameworks...">
+    <ComboboxInput />
+    <ComboboxContent />
+</Combobox>`,
     cssVars: ["--color-popover", "--color-accent"],
   },
   {


### PR DESCRIPTION
Closes #162.

## Problem
`Combobox` with `Multiple="true"` already updated the bound `Values` correctly, but:
- The input area showed **no visual feedback** for selections — no chips, no tags, no indication of what was selected.
- There was **no `Clearable`** affordance.
- There was **no `MaxDisplayTags`** overflow control.

`Select` has had all three for releases. This brings Combobox to parity.

## Changes

### Component
- **`ComboboxInput`**: when `Multiple` has selections, renders a tag-input layout — selected values as removable chips alongside the search input, all sharing one bordered control. `MaxDisplayTags` (default 3) caps visible chips and collapses the rest into a `+N more` indicator. `Backspace` on an empty search field removes the last chip (standard tag-input convention).
- **`Combobox`**: new `Clearable` and `MaxDisplayTags` parameters; new private `OnClearSelection` handler that resets `Value` (single) or `Values` (multiple) to empty and clears the search text.
- **`Combobox.ComboboxContext`**: extended via init-only properties (same source-compat pattern as the existing `Placeholder`) so the positional constructor isn't broken.

### Tests — 11 new bUnit tests
Chip rendering per value, chip remove via X-button, `MaxDisplayTags` cap + overflow indicator (default 3 + explicit value), Clearable button visibility in both single + multiple modes (with and without selection), and end-to-end clear flow. Full suite: **2841/2841 passing**.

### Docs
- New `Clearable + MaxDisplayTags (Multiple)` demo on the Combobox page (live, runnable).
- API reference table gains rows for `Clearable` and `MaxDisplayTags`.
- Changelog entry under v3.12.0.

### Version
`Directory.Build.props`: `3.11.0` → `3.12.0`. Purely additive — no source breaks; existing demos automatically benefit from chip rendering with no changes.

## Notes for the owner
Per Rule #2, this is a real lib change with a new public API surface. **Tag/release pending your go-ahead** — I have not tagged or triggered the publish workflow.

Local verification: `dotnet build src/Lumeo` ✅, `dotnet build docs/Lumeo.Docs` ✅, `dotnet test` 2841/2841 ✅.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LJmBFYeCdQj2G2epoZaRzQ)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Combobox multi-select now displays selected values as removable chips.
  * Added clearable functionality to reset selections.
  * Added configurable max display tags to limit visible chips with a "+N more" indicator.

* **Documentation**
  * Updated Combobox and Select component documentation with usage examples and API reference updates.
  * Released v3.12.0 changelog with feature highlights.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->