### PR TITLE
feat(combobox): chip for single-select + clear-emits-empty-set

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
   <!-- Lockstep version shared by all Lumeo packages.
        Update this single property to version all packages in unison. -->
   <PropertyGroup>
-    <Version>3.12.0</Version>
+    <Version>3.12.1</Version>
   </PropertyGroup>
 
   <!-- Shared NuGet README packing lives in Directory.Build.targets, NOT here.

--- a/docs/Lumeo.Docs/Pages/Docs/Changelog.razor
+++ b/docs/Lumeo.Docs/Pages/Docs/Changelog.razor
@@ -15,6 +15,36 @@
 
     <Separator Class="my-4" />
 
+    <!-- v3.12.1 -->
+    <Stack Gap="4">
+        <div class="flex items-center gap-3">
+            <Badge>v3.12.1</Badge>
+            <Lumeo.Text Size="sm" Color="muted">June 2026</Lumeo.Text>
+        </div>
+
+        <Lumeo.Text Size="base" Color="muted" Leading="relaxed">
+            Patch: <Lumeo.Link Href="components/combobox">Combobox</Lumeo.Link> single-select now also shows the
+            selected value as a chip (parity with the v3.12.0 multi-select work), plus a small Codex-flagged
+            fix to the Clearable-multi clear semantics.
+        </Lumeo.Text>
+
+        <Stack Gap="3">
+            <Heading Level="3" Size="sm" Class="font-semibold">Improved</Heading>
+            <ul class="space-y-1.5 text-sm list-disc list-inside text-muted-foreground">
+                <li><strong>Combobox single-select renders a chip when a value is set (closes #164).</strong> Before the input went blank after selection, leaving no visual confirmation; now it shows a chip alongside the search input so the user always sees what's picked. With <code class="rounded bg-muted px-1 text-xs">Clearable</code>, the chip carries an × that resets the selection.</li>
+            </ul>
+        </Stack>
+
+        <Stack Gap="3">
+            <Heading Level="3" Size="sm" Class="font-semibold">Fixed</Heading>
+            <ul class="space-y-1.5 text-sm list-disc list-inside text-muted-foreground">
+                <li><strong>Combobox.Clearable multi-mode now emits an empty <code class="rounded bg-muted px-1 text-xs">HashSet&lt;string&gt;</code> instead of <code class="rounded bg-muted px-1 text-xs">null</code>.</strong> <code class="rounded bg-muted px-1 text-xs">ValuesChanged</code> is typed as the non-nullable <code class="rounded bg-muted px-1 text-xs">EventCallback&lt;HashSet&lt;string&gt;&gt;</code>; consumers that bind to a non-null <code class="rounded bg-muted px-1 text-xs">HashSet&lt;string&gt; _selected = new()</code> and read <code class="rounded bg-muted px-1 text-xs">_selected.Count</code> during render would NRE after the × button fired. Surfaced by Codex review on PR #163.</li>
+            </ul>
+        </Stack>
+    </Stack>
+
+    <Separator Class="my-4" />
+
     <!-- v3.12.0 -->
     <Stack Gap="4">
         <div class="flex items-center gap-3">

--- a/src/Lumeo/UI/Combobox/Combobox.razor
+++ b/src/Lumeo/UI/Combobox/Combobox.razor
@@ -258,8 +258,13 @@
     {
         if (Multiple)
         {
-            Values = null;
-            await ValuesChanged.InvokeAsync(null);
+            // Emit an empty set rather than null: ValuesChanged is typed as the
+            // non-nullable EventCallback<HashSet<string>>, and consumers commonly
+            // bind to a non-null `HashSet<string> _selected = new()` and read
+            // `_selected.Count` during render — a null roundtrip via @bind-Values
+            // would NRE there (Codex P2, PR #163).
+            Values = new HashSet<string>();
+            await ValuesChanged.InvokeAsync(Values);
         }
         else
         {

--- a/src/Lumeo/UI/Combobox/Combobox.razor
+++ b/src/Lumeo/UI/Combobox/Combobox.razor
@@ -262,8 +262,12 @@
             // non-nullable EventCallback<HashSet<string>>, and consumers commonly
             // bind to a non-null `HashSet<string> _selected = new()` and read
             // `_selected.Count` during render — a null roundtrip via @bind-Values
-            // would NRE there (Codex P2, PR #163).
-            Values = new HashSet<string>();
+            // would NRE there (Codex P2, PR #163). Preserve the bound set's
+            // comparer (e.g. StringComparer.OrdinalIgnoreCase) when present,
+            // otherwise the consumer loses case-insensitive equality semantics
+            // after a Clear (Codex P2, PR #165).
+            var comparer = Values?.Comparer ?? EqualityComparer<string>.Default;
+            Values = new HashSet<string>(comparer);
             await ValuesChanged.InvokeAsync(Values);
         }
         else

--- a/src/Lumeo/UI/Combobox/ComboboxInput.razor
+++ b/src/Lumeo/UI/Combobox/ComboboxInput.razor
@@ -1,23 +1,27 @@
 @namespace Lumeo
 @inject Lumeo.Services.Localization.ILumeoLocalizer L
+@inject IComponentInteropService Interop
 
 @if (HasChips)
 {
     @* Tag-input layout for Multiple mode with selections: chips, then a flex-1
        inline input that keeps search working alongside the chips. Border lives
-       on the wrapper so the field reads as a single control. *@
-    <div class="@WrapperCssClass">
+       on the wrapper so the field reads as a single control. Clicking anywhere
+       on the wrapper (between chips, on the chip text) focuses the input and
+       opens the dropdown — Codex P2 (PR #165). *@
+    <div class="@WrapperCssClass" @onclick="OpenAndFocus">
         @{
             var displayed = Context.Values!.Take(Context.MaxDisplayTags).ToList();
             var remaining = Context.Values!.Count - Context.MaxDisplayTags;
         }
         @foreach (var val in displayed)
         {
+            var label = ItemDisplay(val);
             <span class="inline-flex items-center gap-1 rounded-md border border-border/40 bg-secondary px-1.5 py-0.5 text-xs font-medium text-secondary-foreground">
-                @val
+                @label
                 <button type="button"
                         class="cursor-pointer rounded-full hover:bg-foreground/20 focus-visible:outline-none focus-visible:ring-[1.5px] focus-visible:ring-ring focus-visible:ring-offset-1"
-                        aria-label="@($"Remove {val}")"
+                        aria-label="@($"Remove {label}")"
                         @onclick="() => RemoveValue(val)"
                         @onclick:stopPropagation="true">
                     <Blazicon Svg="Lucide.X" class="h-3 w-3" />
@@ -61,15 +65,18 @@ else if (HasSingleChip)
        search input. Without this the input goes blank after selection and there's
        no visual confirmation of what was picked. The chip is removable when
        Clearable; otherwise it's a static indicator. Selecting a different item
-       replaces the chip via the existing Value flow. *@
-    <div class="@WrapperCssClass">
+       replaces the chip via the existing Value flow. Wrapper-level @onclick keeps
+       a click on the chip text from being a dead zone — opens the dropdown and
+       focuses the input (Codex P2, PR #165). *@
+    var singleLabel = ItemDisplay(Context.Value!);
+    <div class="@WrapperCssClass" @onclick="OpenAndFocus">
         <span class="inline-flex items-center gap-1 rounded-md border border-border/40 bg-secondary px-1.5 py-0.5 text-xs font-medium text-secondary-foreground">
-            @Context.Value
+            @singleLabel
             @if (Context.Clearable)
             {
                 <button type="button"
                         class="cursor-pointer rounded-full hover:bg-foreground/20 focus-visible:outline-none focus-visible:ring-[1.5px] focus-visible:ring-ring focus-visible:ring-offset-1"
-                        aria-label="@($"Remove {Context.Value}")"
+                        aria-label="@($"Remove {singleLabel}")"
                         @onclick="HandleClear"
                         @onclick:stopPropagation="true">
                     <Blazicon Svg="Lucide.X" class="h-3 w-3" />
@@ -172,6 +179,34 @@ else
     private async Task RemoveValue(string value) => await Context.OnSelect.InvokeAsync(value);
 
     private async Task HandleClear() => await Context.OnClear.InvokeAsync();
+
+    // Wrapper click handler for chip-mode layouts: opens the dropdown and focuses
+    // the inline search input so clicks on chip text or empty space inside the
+    // wrapper aren't dead zones (Codex P2, PR #165).
+    private async Task OpenAndFocus()
+    {
+        if (!Context.IsOpen)
+            await Context.SetOpen.InvokeAsync(true);
+        try { await Interop.FocusElement(Context.InputId); }
+        catch (Microsoft.JSInterop.JSDisconnectedException) { }
+    }
+
+    // Resolve a stored value to its human-friendly display label. Data-bound
+    // mode: look up the item via ItemValue and use ItemText. Composition mode
+    // (Items==null) has no value→label registry, so the raw value is the best
+    // we can do — same as v3.12.0 multi-chip behavior (Codex P2, PR #165).
+    private string ItemDisplay(string val)
+    {
+        if (Context.Items != null)
+        {
+            foreach (var item in Context.Items)
+            {
+                if (Context.ItemValue(item) == val)
+                    return Context.ItemText?.Invoke(item) ?? Context.ItemValue(item);
+            }
+        }
+        return val;
+    }
 
     private async Task HandleKeyDown(KeyboardEventArgs e)
     {

--- a/src/Lumeo/UI/Combobox/ComboboxInput.razor
+++ b/src/Lumeo/UI/Combobox/ComboboxInput.razor
@@ -55,6 +55,44 @@
         }
     </div>
 }
+else if (HasSingleChip)
+{
+    @* #164: single-select also renders the current value as a chip alongside the
+       search input. Without this the input goes blank after selection and there's
+       no visual confirmation of what was picked. The chip is removable when
+       Clearable; otherwise it's a static indicator. Selecting a different item
+       replaces the chip via the existing Value flow. *@
+    <div class="@WrapperCssClass">
+        <span class="inline-flex items-center gap-1 rounded-md border border-border/40 bg-secondary px-1.5 py-0.5 text-xs font-medium text-secondary-foreground">
+            @Context.Value
+            @if (Context.Clearable)
+            {
+                <button type="button"
+                        class="cursor-pointer rounded-full hover:bg-foreground/20 focus-visible:outline-none focus-visible:ring-[1.5px] focus-visible:ring-ring focus-visible:ring-offset-1"
+                        aria-label="@($"Remove {Context.Value}")"
+                        @onclick="HandleClear"
+                        @onclick:stopPropagation="true">
+                    <Blazicon Svg="Lucide.X" class="h-3 w-3" />
+                </button>
+            }
+        </span>
+        <input id="@Context.InputId"
+               type="text"
+               role="combobox"
+               aria-haspopup="listbox"
+               aria-expanded="@Context.IsOpen.ToString().ToLower()"
+               aria-controls="@Context.ContentId"
+               aria-autocomplete="list"
+               aria-activedescendant="@(Context.IsOpen ? Context.FocusedItemId : null)"
+               class="flex-1 min-w-[80px] bg-transparent text-sm placeholder:text-muted-foreground focus:outline-none"
+               placeholder="@EffectivePlaceholder"
+               value="@Context.SearchText"
+               @oninput="HandleInput"
+               @onfocus="Open"
+               @onkeydown="HandleKeyDown"
+               @attributes="AdditionalAttributes" />
+    </div>
+}
 else
 {
     <div class="relative">
@@ -77,16 +115,6 @@ else
                @onfocus="Open"
                @onkeydown="HandleKeyDown"
                @attributes="AdditionalAttributes" />
-        @if (Context.Clearable && HasSingleValue)
-        {
-            <button type="button"
-                    class="absolute end-2.5 top-1/2 -translate-y-1/2 cursor-pointer hover:text-foreground focus-visible:outline-none focus-visible:ring-[1.5px] focus-visible:ring-ring focus-visible:ring-offset-1 rounded"
-                    aria-label="@L["Select.ClearSelection"]"
-                    @onclick="HandleClear"
-                    @onclick:stopPropagation="true">
-                <Blazicon Svg="Lucide.X" class="h-3.5 w-3.5 opacity-50 hover:opacity-100" />
-            </button>
-        }
     </div>
 }
 
@@ -116,10 +144,10 @@ else
     };
 
     private bool HasChips => Context.Multiple && Context.Values != null && Context.Values.Count > 0;
-    private bool HasSingleValue => !Context.Multiple && !string.IsNullOrEmpty(Context.Value);
+    private bool HasSingleChip => !Context.Multiple && !string.IsNullOrEmpty(Context.Value);
     private string? EffectivePlaceholder => Placeholder ?? Context.Placeholder ?? L["Combobox.SearchPlaceholder"];
 
-    private string CssClass => Cx.Merge("flex", SizeClasses, "w-full rounded-md border", (Context.Invalid ? "border-destructive" : "border-input"), "bg-transparent ps-8", (Context.Clearable && HasSingleValue ? "pe-8" : "pe-3"), "text-sm placeholder:text-muted-foreground focus-visible:outline-none", (Context.Invalid ? "focus-visible:ring-[1.5px] focus-visible:ring-destructive/20" : ""), Class);
+    private string CssClass => Cx.Merge("flex", SizeClasses, "w-full rounded-md border", (Context.Invalid ? "border-destructive" : "border-input"), "bg-transparent ps-8 pe-3 text-sm placeholder:text-muted-foreground focus-visible:outline-none", (Context.Invalid ? "focus-visible:ring-[1.5px] focus-visible:ring-destructive/20" : ""), Class);
 
     private string WrapperCssClass => Cx.Merge("flex flex-wrap items-center gap-1", ChipWrapperSizeClasses, "w-full rounded-md border", (Context.Invalid ? "border-destructive" : "border-input"), "bg-transparent text-sm focus-within:outline-none", (Context.Invalid ? "focus-within:ring-[1.5px] focus-within:ring-destructive/20" : ""), Class);
 

--- a/tests/Lumeo.Tests/Components/Combobox/ComboboxTests.cs
+++ b/tests/Lumeo.Tests/Components/Combobox/ComboboxTests.cs
@@ -519,4 +519,110 @@ public class ComboboxTests : IAsyncLifetime
 
         Assert.Null(captured);
     }
+
+    // --- PR #165 review fixes: Codex P2 (label lookup, chip click, comparer) ---
+
+    [Fact]
+    public void Clear_Preserves_HashSet_Comparer()
+    {
+        HashSet<string>? captured = null;
+        var callback = EventCallback.Factory.Create<HashSet<string>>(_ctx, (HashSet<string> v) => captured = v);
+
+        var seed = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "React", "Vue" };
+        var cut = RenderMultiCombobox(values: seed, clearable: true, valuesChanged: callback);
+
+        var clearBtn = cut.Find("button[aria-label='Clear selection']");
+        try { clearBtn.Click(); } catch (ArgumentException) { }
+
+        Assert.NotNull(captured);
+        Assert.Empty(captured!);
+        // Comparer must survive the clear — otherwise downstream Contains/Add
+        // changes equality semantics silently (Codex P2, PR #165).
+        Assert.Same(StringComparer.OrdinalIgnoreCase, captured!.Comparer);
+    }
+
+    private IRenderedComponent<IComponent> RenderDataBoundSingleCombobox(
+        string? value,
+        IEnumerable<object> items,
+        Func<object, string> itemValue,
+        Func<object, string> itemText,
+        bool clearable = false)
+    {
+        return _ctx.Render(builder =>
+        {
+            builder.OpenComponent<L.Combobox>(0);
+            if (value != null) builder.AddAttribute(1, "Value", value);
+            builder.AddAttribute(2, "Items", items);
+            builder.AddAttribute(3, "ItemValue", itemValue);
+            builder.AddAttribute(4, "ItemText", itemText);
+            if (clearable) builder.AddAttribute(5, "Clearable", true);
+            builder.AddAttribute(6, "ChildContent", (RenderFragment)(b =>
+            {
+                b.OpenComponent<L.ComboboxInput>(0);
+                b.CloseComponent();
+            }));
+            builder.CloseComponent();
+        });
+    }
+
+    [Fact]
+    public void Single_Chip_Shows_ItemText_Not_Raw_Value_When_Data_Bound()
+    {
+        // Data-bound: stored value "dotnet" should display as ".NET" in the chip.
+        var items = new object[]
+        {
+            new { Id = "dotnet", Label = ".NET" },
+            new { Id = "blazor", Label = "Blazor" },
+        };
+        var cut = RenderDataBoundSingleCombobox(
+            value: "dotnet",
+            items: items,
+            itemValue: o => ((dynamic)o).Id,
+            itemText: o => ((dynamic)o).Label);
+
+        // The chip wrapper span must contain the label, not the id.
+        var chipSpans = cut.FindAll("span.bg-secondary");
+        Assert.NotEmpty(chipSpans);
+        var chipText = chipSpans[0].TextContent;
+        Assert.Contains(".NET", chipText);
+        Assert.DoesNotContain("dotnet", chipText);
+    }
+
+    [Fact]
+    public void Single_Chip_Falls_Back_To_Raw_Value_In_Composition_Mode()
+    {
+        // Composition mode (no Items): no value→label registry, so the raw
+        // value is the best we can do. Matches v3.12.0 multi-chip behavior.
+        var cut = RenderSingleCombobox(value: "react");
+        var chipSpans = cut.FindAll("span.bg-secondary");
+        Assert.NotEmpty(chipSpans);
+        Assert.Contains("react", chipSpans[0].TextContent);
+    }
+
+    [Fact]
+    public void Clicking_Single_Chip_Wrapper_Opens_Combobox()
+    {
+        bool? opened = null;
+        var callback = EventCallback.Factory.Create<bool>(_ctx, (bool v) => opened = v);
+
+        var cut = _ctx.Render(builder =>
+        {
+            builder.OpenComponent<L.Combobox>(0);
+            builder.AddAttribute(1, "Value", "react");
+            builder.AddAttribute(2, "IsOpen", false);
+            builder.AddAttribute(3, "IsOpenChanged", callback);
+            builder.AddAttribute(4, "ChildContent", (RenderFragment)(b =>
+            {
+                b.OpenComponent<L.ComboboxInput>(0);
+                b.CloseComponent();
+            }));
+            builder.CloseComponent();
+        });
+
+        // Click the wrapper div (chip layout). The wrapper carries @onclick=OpenAndFocus.
+        var wrapper = cut.Find("div.flex.flex-wrap");
+        try { wrapper.Click(); } catch (ArgumentException) { }
+
+        Assert.True(opened);
+    }
 }

--- a/tests/Lumeo.Tests/Components/Combobox/ComboboxTests.cs
+++ b/tests/Lumeo.Tests/Components/Combobox/ComboboxTests.cs
@@ -434,7 +434,7 @@ public class ComboboxTests : IAsyncLifetime
     [Fact]
     public void Clear_Button_Clears_All_Values_In_Multiple_Mode()
     {
-        HashSet<string>? captured = new HashSet<string> { "still-here" };
+        HashSet<string>? captured = null;
         var callback = EventCallback.Factory.Create<HashSet<string>>(_ctx, (HashSet<string> v) => captured = v);
         var cut = RenderMultiCombobox(
             values: new HashSet<string> { "react", "vue" },
@@ -444,43 +444,79 @@ public class ComboboxTests : IAsyncLifetime
         var clearBtn = cut.Find("button[aria-label='Clear selection']");
         try { clearBtn.Click(); } catch (ArgumentException) { }
 
+        // Codex P2 (#163 review): emit empty set rather than null so consumers
+        // binding to a non-null HashSet<string> don't NRE on _selected.Count.
+        Assert.NotNull(captured);
+        Assert.Empty(captured!);
+    }
+
+    // --- #164: single-select chip parity with multi ---
+
+    private IRenderedComponent<IComponent> RenderSingleCombobox(
+        string? value = null,
+        bool clearable = false,
+        EventCallback<string>? valueChanged = null)
+    {
+        return _ctx.Render(builder =>
+        {
+            builder.OpenComponent<L.Combobox>(0);
+            if (value != null)
+                builder.AddAttribute(1, "Value", value);
+            if (valueChanged.HasValue)
+                builder.AddAttribute(2, "ValueChanged", valueChanged.Value);
+            if (clearable)
+                builder.AddAttribute(3, "Clearable", true);
+            builder.AddAttribute(4, "ChildContent", (RenderFragment)(b =>
+            {
+                b.OpenComponent<L.ComboboxInput>(0);
+                b.CloseComponent();
+            }));
+            builder.CloseComponent();
+        });
+    }
+
+    [Fact]
+    public void Single_Select_With_Value_Renders_Chip_In_Input()
+    {
+        var cut = RenderSingleCombobox(value: "react");
+        Assert.Contains("react", cut.Markup);
+        // Chip wrapper marks the tag-input layout (border-border/40 + bg-secondary on the span).
+        Assert.NotEmpty(cut.FindAll("span.bg-secondary"));
+    }
+
+    [Fact]
+    public void Single_Select_With_No_Value_Renders_Empty_Search_Input()
+    {
+        var cut = RenderSingleCombobox(value: null);
+        Assert.Empty(cut.FindAll("span.bg-secondary"));
+        Assert.NotNull(cut.Find("input[type='text']"));
+    }
+
+    [Fact]
+    public void Single_Select_Chip_Has_No_Remove_Button_When_Not_Clearable()
+    {
+        var cut = RenderSingleCombobox(value: "react", clearable: false);
+        // The chip is shown, but with no X button — pure visual indicator.
+        Assert.Empty(cut.FindAll("button[aria-label^='Remove ']"));
+    }
+
+    [Fact]
+    public void Single_Select_Clearable_Chip_Shows_Remove_Button()
+    {
+        var cut = RenderSingleCombobox(value: "react", clearable: true);
+        Assert.NotEmpty(cut.FindAll("button[aria-label='Remove react']"));
+    }
+
+    [Fact]
+    public void Single_Select_Clearable_Chip_Click_Clears_Value()
+    {
+        string? captured = "react";
+        var callback = EventCallback.Factory.Create<string>(_ctx, (string v) => captured = v);
+        var cut = RenderSingleCombobox(value: "react", clearable: true, valueChanged: callback);
+
+        var removeBtn = cut.Find("button[aria-label='Remove react']");
+        try { removeBtn.Click(); } catch (ArgumentException) { }
+
         Assert.Null(captured);
-    }
-
-    [Fact]
-    public void Clearable_Single_Mode_Shows_Clear_Button_When_Value_Present()
-    {
-        var cut = _ctx.Render(builder =>
-        {
-            builder.OpenComponent<L.Combobox>(0);
-            builder.AddAttribute(1, "Value", "react");
-            builder.AddAttribute(2, "Clearable", true);
-            builder.AddAttribute(3, "ChildContent", (RenderFragment)(b =>
-            {
-                b.OpenComponent<L.ComboboxInput>(0);
-                b.CloseComponent();
-            }));
-            builder.CloseComponent();
-        });
-
-        Assert.NotEmpty(cut.FindAll("button[aria-label='Clear selection']"));
-    }
-
-    [Fact]
-    public void Clearable_Single_Mode_Hides_Clear_Button_When_Empty()
-    {
-        var cut = _ctx.Render(builder =>
-        {
-            builder.OpenComponent<L.Combobox>(0);
-            builder.AddAttribute(1, "Clearable", true);
-            builder.AddAttribute(2, "ChildContent", (RenderFragment)(b =>
-            {
-                b.OpenComponent<L.ComboboxInput>(0);
-                b.CloseComponent();
-            }));
-            builder.CloseComponent();
-        });
-
-        Assert.Empty(cut.FindAll("button[aria-label='Clear selection']"));
     }
 }


### PR DESCRIPTION
Two related Combobox patches in one PR — both touch the same files.

## 1. Single-select chip parity (closes #164)

After v3.12.0 the multi-select Combobox showed chips for selections, but single-select still went **blank** after picking an item — no visual confirmation of what was picked. `ComboboxInput` now renders a chip when `Value` is set, mirroring the multi-select layout:

- Chip shows the selected value alongside the still-functional search input (tag-input layout).
- With `Clearable`, the chip carries an × that resets `Value` to null.
- Without `Clearable`, the chip is a pure visual indicator.
- Selecting a different item replaces the chip through the existing `Value` flow — no separate logic.

## 2. Codex P2 fix: clear emits empty set, not null

[Codex P2 on PR #163](https://github.com/Brain2k-0005/Lumeo/pull/163#discussion_r3357590766):

> When `Clearable` is used with `Multiple="true"` and the consumer follows the documented/common pattern of binding to a non-null `HashSet<string>` (for example then reading `_selected.Count` during render), this invokes `ValuesChanged` with `null` even though the callback is typed as `EventCallback<HashSet<string>>`. Blazor's generated `@bind-Values` setter can assign that null to the caller's set, causing the next render or mutation to throw.

**Real bug** — verified. `OnClearSelection` now emits `new HashSet<string>()` instead of `null` for the multi path, which keeps the non-nullable callback type honest and protects consumers reading `.Count` during render.

## Tests
- 5 new bUnit tests: single-select chip renders only when `Value` set, no remove button without `Clearable`, remove button present + functional with `Clearable`, click clears the value.
- 1 existing test updated: `Clear_Button_Clears_All_Values_In_Multiple_Mode` now asserts an **empty set** is emitted (not null).
- Full suite: **2844/2844 ✅**.

## Version
`3.12.0` → `3.12.1`. Patch — purely additive UX + bug fix; no breaking changes.

## Owner notes
Per Rule #2, tag/publish for v3.12.1 still needs your explicit go-ahead. Local build + docs build green.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LJmBFYeCdQj2G2epoZaRzQ)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Single-select Combobox mode now renders selected values as removable chips, replacing the previous clear button pattern for a more intuitive user experience and improved visual consistency.

* **Bug Fixes**
  * Fixed Combobox multi-select clearable mode to properly emit an empty collection instead of null when cleared, eliminating potential rendering errors occurring during component updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->