### PR TITLE
fix(docs): Icon page crash — lazy-load Blazicons packs instead of eager reflection

### DIFF
--- a/docs/Lumeo.Docs/Pages/Components/IconPage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/IconPage.razor
@@ -102,7 +102,14 @@
                  id="@_gridId"
                  class="flex-1 p-3 min-w-0 overflow-y-auto"
                  style="max-height: 600px">
-                @if (Filtered.Count == 0)
+                @if (!CatalogReady)
+                {
+                    <div class="flex flex-col items-center gap-2 py-16 text-muted-foreground">
+                        <DynamicIcon Name="Loader" Class="h-8 w-8 animate-spin text-muted-foreground/40" />
+                        <Lumeo.Text Size="sm">Loading @LibraryDisplayName(IconService.ActiveLibrary) icons…</Lumeo.Text>
+                    </div>
+                }
+                else if (Filtered.Count == 0)
                 {
                     <div class="flex flex-col items-center gap-2 py-16 text-muted-foreground">
                         <DynamicIcon Name="SearchX" Class="h-10 w-10 text-muted-foreground/40" />
@@ -390,12 +397,20 @@
     // changes, so scrollTop resets to 0 and the first row is never cut off.
     private string GridKey => $"grid-{IconService.ActiveLibrary}-{_query}";
 
-    // Cached catalog for the active library; falls back to Lucide while a pack
-    // is still loading (EnsureCatalogAsync repopulates + re-renders when done).
+    // Cached catalog for the active library, or empty while its pack is still
+    // loading. Deliberately NOT a Lucide fallback: returning Lucide's icons
+    // under e.g. the "Bootstrap Icons" label briefly showed mislabeled icons
+    // and let a click select the wrong library's entry before the load
+    // finished (Codex #170). The grid shows a loading state instead — see
+    // CatalogReady. EnsureCatalogAsync repopulates + re-renders when done.
     private IReadOnlyList<IconEntry> ActiveCatalog =>
         _catalogs.TryGetValue(IconService.ActiveLibrary, out var list)
             ? list
-            : (_catalogs.TryGetValue("lucide", out var lucide) ? lucide : Array.Empty<IconEntry>());
+            : Array.Empty<IconEntry>();
+
+    // False while the active (non-Lucide) library's pack is still loading.
+    // Lucide is built in OnInitialized so it is always ready (no flash).
+    private bool CatalogReady => _catalogs.ContainsKey(IconService.ActiveLibrary);
 
     private List<IconEntry> Filtered => string.IsNullOrWhiteSpace(_query)
         ? ActiveCatalog.ToList()

--- a/docs/Lumeo.Docs/Pages/Components/IconPage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/IconPage.razor
@@ -1,6 +1,7 @@
 @page "/components/icon"
 @inject Lumeo.Docs.Services.IconService IconService
 @inject IJSRuntime JS
+@inject Microsoft.AspNetCore.Components.WebAssembly.Services.LazyAssemblyLoader LazyLoader
 @implements IDisposable
 @using Lumeo.Docs.Shared
 @using Blazicons
@@ -362,34 +363,65 @@
     // Name is the Blazicons property name (e.g. "Search", "ChevronDown").
     private record IconEntry(string Name, SvgIcon Svg);
 
-    // Full catalog per library — enumerated via reflection over the Blazicons
-    // static classes so every available icon is shown automatically. No manual
-    // list to keep in sync when Blazicons adds more.
-    private static readonly Dictionary<string, IReadOnlyList<IconEntry>> _catalogsByLibrary = BuildCatalogs();
+    // Per-library catalogs, built ON DEMAND. The non-Lucide Blazicons packs are
+    // <BlazorWebAssemblyLazyLoad> assemblies. Reflecting over their types
+    // (typeof(FluentUiIcon), …) eagerly in a static initializer forced the WASM
+    // runtime to resolve those assemblies through the reflection path, which
+    // raced CustomizerSidebar's LazyAssemblyLoader fetch of the same DLLs and
+    // double-read the DLL Response ("Failed to execute 'arrayBuffer' … body
+    // stream already read"), crashing the page on load. We now load each pack
+    // via LazyAssemblyLoader BEFORE reflecting over it and cache the result.
+    // Lucide is eager (in the boot manifest), so it is safe to build up front.
+    private readonly Dictionary<string, IReadOnlyList<IconEntry>> _catalogs = new();
+    private readonly HashSet<string> _loadingLibs = new();
+
+    // library key -> (lazy-loaded DLL file, fully-qualified Blazicons container type)
+    private static readonly Dictionary<string, (string Dll, string TypeName)> _lazyLibs = new()
+    {
+        ["bootstrap"]       = ("Blazicons.Bootstrap.dll", "Blazicons.BootstrapIcon"),
+        ["fluentui"]        = ("Blazicons.FluentUI.dll", "Blazicons.FluentUiIcon"),
+        ["google-material"] = ("Blazicons.GoogleMaterialDesign.dll", "Blazicons.GoogleMaterialOutlinedIcon"),
+        ["font-awesome"]    = ("Blazicons.FontAwesome.dll", "Blazicons.FontAwesomeSolidIcon"),
+        ["ionicons"]        = ("Blazicons.Ionicons.dll", "Blazicons.Ionicon"),
+        ["material-design"] = ("Blazicons.MaterialDesignIcons.dll", "Blazicons.MdiIcon"),
+    };
 
     // Key that re-mounts the grid scroll container whenever the filter/library
     // changes, so scrollTop resets to 0 and the first row is never cut off.
     private string GridKey => $"grid-{IconService.ActiveLibrary}-{_query}";
 
+    // Cached catalog for the active library; falls back to Lucide while a pack
+    // is still loading (EnsureCatalogAsync repopulates + re-renders when done).
     private IReadOnlyList<IconEntry> ActiveCatalog =>
-        _catalogsByLibrary.TryGetValue(IconService.ActiveLibrary, out var list)
+        _catalogs.TryGetValue(IconService.ActiveLibrary, out var list)
             ? list
-            : _catalogsByLibrary["lucide"];
+            : (_catalogs.TryGetValue("lucide", out var lucide) ? lucide : Array.Empty<IconEntry>());
 
     private List<IconEntry> Filtered => string.IsNullOrWhiteSpace(_query)
         ? ActiveCatalog.ToList()
         : ActiveCatalog.Where(e => e.Name.Contains(_query, StringComparison.OrdinalIgnoreCase)).ToList();
 
-    private static Dictionary<string, IReadOnlyList<IconEntry>> BuildCatalogs() => new()
+    // Loads the active library's lazy assembly (no-op if already loaded — e.g.
+    // CustomizerSidebar preloaded it) and only then reflects over its icon type.
+    private async Task EnsureCatalogAsync(string lib)
     {
-        ["lucide"]          = EnumerateIcons(typeof(Lucide)),
-        ["bootstrap"]       = EnumerateIcons(typeof(BootstrapIcon)),
-        ["fluentui"]        = EnumerateIcons(typeof(FluentUiIcon)),
-        ["google-material"] = EnumerateIcons(typeof(GoogleMaterialOutlinedIcon)),
-        ["font-awesome"]    = EnumerateIcons(typeof(FontAwesomeSolidIcon)),
-        ["ionicons"]        = EnumerateIcons(typeof(Ionicon)),
-        ["material-design"] = EnumerateIcons(typeof(MdiIcon)),
-    };
+        if (_catalogs.ContainsKey(lib)) return;
+        if (!_lazyLibs.TryGetValue(lib, out var meta)) return; // unknown key → Lucide fallback
+        if (!_loadingLibs.Add(lib)) return;                    // de-dupe concurrent loads of this pack
+        try
+        {
+            await LazyLoader.LoadAssembliesAsync(new[] { meta.Dll });
+            var asmName = System.IO.Path.GetFileNameWithoutExtension(meta.Dll);
+            var type = Type.GetType($"{meta.TypeName}, {asmName}");
+            if (type is not null)
+                _catalogs[lib] = EnumerateIcons(type);
+        }
+        catch (Microsoft.JSInterop.JSDisconnectedException) { }
+        finally
+        {
+            _loadingLibs.Remove(lib);
+        }
+    }
 
     private static IReadOnlyList<IconEntry> EnumerateIcons(Type svgIconContainer)
     {
@@ -478,9 +510,25 @@
     protected override void OnInitialized()
     {
         IconService.OnChange += OnLibChanged;
+        // Lucide is eager (boot manifest) — safe to reflect immediately.
+        _catalogs["lucide"] = EnumerateIcons(typeof(Lucide));
     }
 
-    private void OnLibChanged() => InvokeAsync(StateHasChanged);
+    // Covers the initial render and direct navigation: ensure the (possibly
+    // non-Lucide) active library's catalog is built before the grid renders.
+    protected override async Task OnParametersSetAsync()
+        => await EnsureCatalogAsync(IconService.ActiveLibrary);
+
+    // Library switched (page Select or the global CustomizerSidebar picker):
+    // load its pack on demand, then re-render. Fire-and-forget is fine — the
+    // load is guarded and idempotent.
+    private void OnLibChanged() => _ = OnLibChangedAsync();
+
+    private async Task OnLibChangedAsync()
+    {
+        await EnsureCatalogAsync(IconService.ActiveLibrary);
+        await InvokeAsync(StateHasChanged);
+    }
 
     // Browsers restore scrollTop of inner scroll containers across reloads and
     // re-renders. @key alone doesn't reliably clear it. Resolve the element by


### PR DESCRIPTION
## Symptom
Auf `/components/icon` (Docs-Site, Blazor WASM) crasht das Rendern:
```
TypeError: Failed to execute 'arrayBuffer' on 'Response': body stream already read
System.ArgumentException: There is no tracked object with id '12'.
Perhaps the DotNetObjectReference instance was already disposed.
```

## Root cause
Die Seite baute ihre Per-Library-Kataloge in einem **statischen Initializer** (`_catalogsByLibrary = BuildCatalogs()`), der eager über `typeof(FluentUiIcon)`, `typeof(Devicon)` … reflektierte — alles `<BlazorWebAssemblyLazyLoad>`-Assemblies. Das Auflösen dieser Typ-Tokens zwang die WASM-Runtime, die DLLs über den **Reflection-Pfad** zu laden, der mit dem `LazyAssemblyLoader`-Fetch derselben Packs in `CustomizerSidebar` kollidierte → der **Response-Body wurde doppelt gelesen** (`arrayBuffer … body stream already read`). Der zweite Fehler (disposed `DotNetObjectReference`) ist die Kaskade, als das Rendern abbrach. Nebeneffekt: Lazy-Loading war komplett ausgehebelt — alle sechs Packs luden selbst bei einem reinen Lucide-Besuch.

## Fix
Kataloge werden **on demand** gebaut:
- **Lucide** (eager, im Boot-Manifest) vorab in `OnInitialized`.
- Jedes Lazy-Pack wird via `LazyAssemblyLoader.LoadAssembliesAsync(...)` geladen **bevor** über seinen Typ reflektiert wird (Typ per String-Name aufgelöst → kein eager `typeof`-Binding bleibt übrig), dann gecacht.
- `OnParametersSetAsync` deckt die initiale/aktive Library ab; der `IconService.OnChange`-Handler lädt-dann-rendert beim Library-Wechsel.
- Konkurrierende Loads desselben Packs werden de-dupliziert (`_loadingLibs`).

Folgt dem App-eigenen Lazy-Load-Muster (`App.razor` `OnNavigateAsync`, `CustomizerSidebar`).

## Tests / Verifikation
- Docs-Build grün, Docs-Tests **22/22**.
- ⚠️ **Runtime-Fix — bitte am Preview-Deploy verifizieren**: `/components/icon` öffnen, zwischen Libraries (Lucide → FluentUI → Devicon …) wechseln, Konsole sauber? Die Beispiel-Icons im Tab „Other libraries" mitprüfen (rendern erst bei Klick; Packs sind dann durch die CustomizerSidebar-Vorladung da — sollte ok sein, aber im Preview gegenchecken).

---
_Generated by [Claude Code](https://claude.ai/code/session_01XPntycNyvABSR9U5ZKRBoU)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Icon library catalogs now load on-demand rather than all at once, improving initial page load performance while maintaining full filtering and browsing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->