### PR TITLE
fix(overlay,icon): transform-free positioner (#172) + TW-v4 icon-size reset (#173) — needs preview verification

### DIFF
--- a/docs/Lumeo.Docs/Pages/E2E/P0Harness.razor
+++ b/docs/Lumeo.Docs/Pages/E2E/P0Harness.razor
@@ -1,0 +1,45 @@
+@page "/e2e/p0-harness"
+
+@* E2E-only harness for the #172 / #173 P0 regression checks (Lumeo.Tests.E2E).
+   Deliberately minimal, deterministic and NOT linked in navigation. These two
+   bugs are real-browser cascade/layout effects that bUnit cannot see (it has no
+   layout engine), so the assertions run in Playwright against this page.
+
+   #172 — a center-aligned DropdownMenu makes the parent content use
+   translateX(-50%). Before the transform-free positionFixed fix that transform
+   established a containing block, so the nested fixed sub-content resolved
+   against the transformed parent instead of the viewport and opened off-target.
+   #173 — icons sit in a text-sm context so the bug (every icon collapsing to
+   1em = 14px because Blazicons' unlayered svg rule beat the @layer utilities)
+   is distinguishable from the correct rem-based utility sizes (16/20/24px). *@
+
+<PageTitle>P0 harness</PageTitle>
+
+<div class="p-10 space-y-12">
+    <h1 class="text-xl font-bold">P0 regression harness (#172 / #173)</h1>
+
+    <section class="flex justify-center">
+        <DropdownMenu>
+            <DropdownMenuTrigger>
+                <Button data-testid="p0-dd-trigger" Variant="Button.ButtonVariant.Outline">Open menu</Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent Align="Lumeo.Align.Center">
+                <DropdownMenuItem>Item one</DropdownMenuItem>
+                <DropdownMenuSub>
+                    <DropdownMenuSubTrigger data-testid="p0-sub-trigger">Open submenu</DropdownMenuSubTrigger>
+                    <DropdownMenuSubContent data-testid="p0-sub-content">
+                        <DropdownMenuItem>Sub item A</DropdownMenuItem>
+                        <DropdownMenuItem>Sub item B</DropdownMenuItem>
+                    </DropdownMenuSubContent>
+                </DropdownMenuSub>
+                <DropdownMenuItem>Item two</DropdownMenuItem>
+            </DropdownMenuContent>
+        </DropdownMenu>
+    </section>
+
+    <section class="text-sm">
+        <span data-testid="p0-icon-md" class="inline-flex align-middle"><Icon Name="Search" Size="Lumeo.Size.Md" /></span>
+        <span data-testid="p0-icon-lg" class="inline-flex align-middle"><Icon Name="Search" Size="Lumeo.Size.Lg" /></span>
+        <span data-testid="p0-icon-xl" class="inline-flex align-middle"><Icon Name="Search" Size="Lumeo.Size.Xl" /></span>
+    </section>
+</div>

--- a/src/Lumeo/wwwroot/css/lumeo.css
+++ b/src/Lumeo/wwwroot/css/lumeo.css
@@ -1736,3 +1736,33 @@ input[type="range"]::-moz-range-thumb {
   background-color: var(--color-border);
 }
 
+/* =====================================================================
+   Icon sizing under Tailwind v4 (#173)
+   =====================================================================
+   Blazicons injects an UNLAYERED runtime rule `svg[blazicon]{width:1em;
+   height:1em}`. Under Tailwind v4 an unlayered rule beats anything in
+   `@layer utilities`, so Lumeo's size utilities (h-4 w-4 … h-6 w-6, size-*)
+   — which live in @layer utilities — silently lose and every icon collapses
+   to the 1em font size (e.g. `<Icon Size="Lg">` renders 14px at text-sm
+   instead of 20px). Project-wide: Lumeo's own components render
+   `<Blazicon class="h-4 w-4">` directly.
+
+   Fix: an unlayered rule of HIGHER specificity than `svg[blazicon]` (the
+   attribute is repeated -> (0,3,1) > (0,1,1)) that matches only icons
+   carrying a width/height/size utility and uses `revert-layer` to defer the
+   value back to the utilities layer. Net: the size utility wins over the 1em
+   rule, while a consumer's own `Class="h-8 w-8"` override (also a utility)
+   still wins over the preset. Decorative icons with no size utility keep
+   Blazicons' 1em default untouched.
+
+   LOAD ORDER: this neutralizes the 1em rule only when lumeo.css is loaded
+   UNLAYERED (the default `<link rel="stylesheet">` path — e.g. the docs
+   site). Consumers who instead `@import ".../lumeo.css" layer(base)` place
+   these rules in @layer base, which cannot outrank an unlayered rule — they
+   must add the same reset unlayered in their own entry CSS (see icon docs).
+   Cascade outcome is browser-verified on the Cloudflare preview / e2e (#173). */
+svg[blazicon][blazicon][class*="w-"],
+svg[blazicon][blazicon][class*="size-"] { width: revert-layer; }
+svg[blazicon][blazicon][class*="h-"],
+svg[blazicon][blazicon][class*="size-"] { height: revert-layer; }
+

--- a/src/Lumeo/wwwroot/js/components.js
+++ b/src/Lumeo/wwwroot/js/components.js
@@ -383,93 +383,64 @@ export function positionFixed(contentId, referenceId, align, matchWidth, side, o
             content.style.width = `${refRect.width}px`;
         }
 
-        // Calculate preferred position
-        let top, left, right;
-        let transform = '';
+        // --- Transform-free positioning (#172) ---------------------------------
+        // Position with explicit top/left ONLY; never set a CSS `transform` on
+        // overlay content. A transformed ancestor establishes a containing block
+        // for its `position:fixed` descendants — which is exactly why a nested
+        // overlay (DropdownMenuSubContent, popover-in-popover, ContextMenu/Menubar
+        // sub-content) positioned via this same function resolved against the
+        // transformed parent instead of the viewport and rendered off-screen.
+        // Folding the former translateX/Y(-50%/-100%) offsets into the computed
+        // coordinates keeps the visual result identical while leaving the overlay
+        // transform-free, so nested fixed overlays resolve against the viewport.
+        content.style.transform = '';
 
-        if (resolvedSide === 'top') {
-            top = refRect.top - gap;
-            switch (align) {
-                case 'center':
-                    left = refRect.left + refRect.width / 2;
-                    transform = 'translateX(-50%) translateY(-100%)';
-                    break;
-                case 'end':
-                    left = refRect.right;
-                    transform = 'translateX(-100%) translateY(-100%)';
-                    break;
-                default:
-                    left = refRect.left;
-                    transform = 'translateY(-100%)';
-                    break;
-            }
-        } else if (resolvedSide === 'left') {
-            left = refRect.left - gap;
-            transform = 'translateX(-100%)';
-            switch (align) {
-                case 'center':
-                    top = refRect.top + refRect.height / 2;
-                    transform = 'translateX(-100%) translateY(-50%)';
-                    break;
-                case 'end':
-                    top = refRect.bottom;
-                    transform = 'translateX(-100%) translateY(-100%)';
-                    break;
-                default:
-                    top = refRect.top;
-                    break;
-            }
-        } else if (resolvedSide === 'right') {
-            left = refRect.right + gap;
-            switch (align) {
-                case 'center':
-                    top = refRect.top + refRect.height / 2;
-                    transform = 'translateY(-50%)';
-                    break;
-                case 'end':
-                    top = refRect.bottom;
-                    transform = 'translateY(-100%)';
-                    break;
-                default:
-                    top = refRect.top;
-                    break;
-            }
-        } else {
-            // bottom (default)
-            top = refRect.bottom + gap;
-            switch (align) {
-                case 'center':
-                    left = refRect.left + refRect.width / 2;
-                    transform = 'translateX(-50%)';
-                    break;
-                case 'end':
-                    left = refRect.right;
-                    transform = 'translateX(-100%)';
-                    break;
-                default:
-                    left = refRect.left;
-                    break;
-            }
-        }
-
-        // Apply initial position
-        content.style.top = `${top}px`;
-        content.style.left = left != null ? `${left}px` : '';
-        content.style.right = right != null ? `${right}px` : '';
-        content.style.transform = transform;
-
-        // Viewport bounds check (synchronous — no rAF to avoid stale refs).
-        // Reset any prior maxHeight so we measure the natural content size
-        // (otherwise a previous tight clamp would stick across reopens).
+        // Reset any prior clamp so we measure the natural content size first
+        // (otherwise a previous tight maxHeight would skew the measurement).
         content.style.maxHeight = '';
         content.style.overflow = '';
 
-        // Force a synchronous layout BEFORE measuring. Without this, an
-        // in-flight animation scale-up or a Blazor render that hasn't
-        // committed yet can return stale / pre-final dimensions —
-        // empirically observed: cr.height = 1574 when the popover's
-        // settled height was 310. Reading offsetHeight forces the
-        // browser to flush layout.
+        // Measure the natural box. matchWidth was already applied above, so width
+        // (and therefore wrap-dependent height) is final. offsetWidth/Height force
+        // a synchronous layout flush — without it an in-flight animation scale or
+        // an uncommitted Blazor render can report stale dimensions (empirically
+        // cr.height = 1574 when the settled height was 310).
+        void content.offsetHeight;
+        let cw = content.offsetWidth;
+        let ch = content.offsetHeight;
+
+        // Compute explicit top/left for the requested side + align. The size
+        // shifts replace the former transforms: translateX(-50%) -> -cw/2,
+        // translateX(-100%) -> -cw, translateY(-50%) -> -ch/2,
+        // translateY(-100%) -> -ch.
+        let top, left;
+        if (resolvedSide === 'top') {
+            top = refRect.top - gap - ch;
+            if (align === 'center') left = refRect.left + refRect.width / 2 - cw / 2;
+            else if (align === 'end') left = refRect.right - cw;
+            else left = refRect.left;
+        } else if (resolvedSide === 'left') {
+            left = refRect.left - gap - cw;
+            if (align === 'center') top = refRect.top + refRect.height / 2 - ch / 2;
+            else if (align === 'end') top = refRect.bottom - ch;
+            else top = refRect.top;
+        } else if (resolvedSide === 'right') {
+            left = refRect.right + gap;
+            if (align === 'center') top = refRect.top + refRect.height / 2 - ch / 2;
+            else if (align === 'end') top = refRect.bottom - ch;
+            else top = refRect.top;
+        } else {
+            // bottom (default)
+            top = refRect.bottom + gap;
+            if (align === 'center') left = refRect.left + refRect.width / 2 - cw / 2;
+            else if (align === 'end') left = refRect.right - cw;
+            else left = refRect.left;
+        }
+
+        // Apply, then re-measure for the flip/clamp guards below.
+        content.style.top = `${top}px`;
+        content.style.left = `${left}px`;
+        content.style.right = '';
         void content.offsetHeight;
         const cr = content.getBoundingClientRect();
 
@@ -479,6 +450,8 @@ export function positionFixed(contentId, referenceId, align, matchWidth, side, o
         // parent flex container — observed at ~1574px inside a Sheet) ends
         // up with `top: triggerTop - contentHeight - gap` going far negative,
         // rendering off-screen at the top. Clamp to viewport with maxHeight.
+        // (Transform-free: recompute `top` directly instead of stripping a
+        // translateY from a transform string.)
         if (resolvedSide === 'bottom' && cr.bottom > window.innerHeight) {
             const newRefRect = reference.getBoundingClientRect();
             const spaceAbove = newRefRect.top - 8;        // 8px breathing room
@@ -486,13 +459,11 @@ export function positionFixed(contentId, referenceId, align, matchWidth, side, o
             if (spaceAbove >= cr.height + gap) {
                 // Flip up — fits naturally
                 content.style.top = `${newRefRect.top - cr.height - gap}px`;
-                content.style.transform = transform.replace('translateY(-100%)', '').trim() || '';
             } else if (spaceAbove > spaceBelow) {
                 // More room above than below — flip up and cap height
                 content.style.top = `8px`;
                 content.style.maxHeight = `${spaceAbove - gap}px`;
                 content.style.overflow = 'auto';
-                content.style.transform = transform.replace('translateY(-100%)', '').trim() || '';
             } else {
                 // Stick below the trigger and cap height to viewport
                 content.style.top = `${newRefRect.bottom + gap}px`;
@@ -507,12 +478,10 @@ export function positionFixed(contentId, referenceId, align, matchWidth, side, o
             const spaceBelow = window.innerHeight - newRefRect.bottom - 8;
             if (spaceBelow >= cr.height + gap) {
                 content.style.top = `${newRefRect.bottom + gap}px`;
-                content.style.transform = transform.replace('translateY(-100%)', '').replace('translateX(-50%) translateY(-100%)', 'translateX(-50%)').trim() || '';
             } else if (spaceBelow > spaceAbove) {
                 content.style.top = `${newRefRect.bottom + gap}px`;
                 content.style.maxHeight = `${spaceBelow}px`;
                 content.style.overflow = 'auto';
-                content.style.transform = transform.replace('translateY(-100%)', '').replace('translateX(-50%) translateY(-100%)', 'translateX(-50%)').trim() || '';
             } else {
                 content.style.top = `8px`;
                 content.style.maxHeight = `${spaceAbove - gap}px`;
@@ -521,12 +490,10 @@ export function positionFixed(contentId, referenceId, align, matchWidth, side, o
         }
         // Clamp horizontal
         if (cr.right > window.innerWidth) {
-            content.style.left = `${window.innerWidth - cr.width - 8}px`;
-            content.style.transform = '';
+            content.style.left = `${Math.max(8, window.innerWidth - cr.width - 8)}px`;
         }
         if (cr.left < 0) {
             content.style.left = '8px';
-            content.style.transform = '';
         }
 
         // Universal final guard: ensure the popover (a) never exceeds the

--- a/tests/Lumeo.Tests.E2E/Smokes/P0OverlayIconTests.cs
+++ b/tests/Lumeo.Tests.E2E/Smokes/P0OverlayIconTests.cs
@@ -1,0 +1,108 @@
+using System;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Microsoft.Playwright;
+using Xunit;
+
+namespace Lumeo.Tests.E2E.Smokes;
+
+/// <summary>
+/// Real-browser regression coverage for the two P0 cascade/layout bugs that
+/// bUnit cannot reproduce (it has no layout engine — it sees classes, not
+/// computed geometry):
+///
+///   #172 — a nested overlay (DropdownMenuSubContent) was positioned relative to
+///          a transformed parent (the CSS `transform` used for align/flip created
+///          a containing block for the `position:fixed` sub-content), so it opened
+///          off its trigger / off-viewport. Fixed by making positionFixed
+///          transform-free.
+///   #173 — Blazicons injects an unlayered `svg[blazicon]{width:1em}` rule that, in
+///          Tailwind v4, beats the size utilities in `@layer utilities`, collapsing
+///          every icon to the font size. Fixed by an unlayered revert-layer reset.
+///
+/// Targets the deterministic <c>/e2e/p0-harness</c> page. Requires the docs
+/// dev-server (see project README.md).
+/// </summary>
+public class P0OverlayIconTests : PlaywrightTestBase
+{
+    private async Task OpenMenuAndSubmenuAsync()
+    {
+        await Goto("/e2e/p0-harness");
+        await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+        await Page.Locator("[data-testid='p0-dd-trigger']").ClickAsync();
+
+        var subTrigger = Page.Locator("[data-testid='p0-sub-trigger']");
+        await subTrigger.WaitForAsync(new() { State = WaitForSelectorState.Visible, Timeout = 5000 });
+
+        // Submenus open on mouseenter (DropdownMenuSubTrigger.HandleMouseEnter).
+        await subTrigger.HoverAsync();
+
+        var subContent = Page.Locator("[data-testid='p0-sub-content']");
+        await subContent.WaitForAsync(new() { State = WaitForSelectorState.Visible, Timeout = 5000 });
+    }
+
+    [Fact]
+    public async Task Submenu_opens_within_viewport_adjacent_to_its_trigger()
+    {
+        await OpenMenuAndSubmenuAsync();
+
+        var geom = await Page.EvaluateAsync<JsonElement>(@"() => {
+            const sub = document.querySelector(""[data-testid='p0-sub-content']"");
+            const trg = document.querySelector(""[data-testid='p0-sub-trigger']"");
+            const s = sub.getBoundingClientRect();
+            const t = trg.getBoundingClientRect();
+            return {
+                left: s.left, right: s.right, top: s.top, bottom: s.bottom, width: s.width,
+                vw: window.innerWidth, vh: window.innerHeight,
+                trgLeft: t.left, trgRight: t.right
+            };
+        }");
+
+        double left = geom.GetProperty("left").GetDouble();
+        double right = geom.GetProperty("right").GetDouble();
+        double top = geom.GetProperty("top").GetDouble();
+        double bottom = geom.GetProperty("bottom").GetDouble();
+        double width = geom.GetProperty("width").GetDouble();
+        double vw = geom.GetProperty("vw").GetDouble();
+        double vh = geom.GetProperty("vh").GetDouble();
+        double trgLeft = geom.GetProperty("trgLeft").GetDouble();
+        double trgRight = geom.GetProperty("trgRight").GetDouble();
+
+        Assert.True(width > 0, "Sub-content has zero width — it did not render.");
+
+        // (a) Fully within the viewport. The #172 failure pushed it far off-screen.
+        Assert.True(left >= -1 && top >= -1 && right <= vw + 1 && bottom <= vh + 1,
+            $"Sub-content outside viewport: left={left} top={top} right={right} bottom={bottom} vw={vw} vh={vh}");
+
+        // (b) Horizontally adjacent to its trigger — opening to the right (left edge
+        //     ~ trigger's right edge) or flipped to the left (right edge ~ trigger's
+        //     left edge). Pre-fix the transform containing block offset it by ~half
+        //     the parent content's width, so neither edge lined up.
+        bool opensRight = Math.Abs(left - trgRight) <= 24;
+        bool opensLeft = Math.Abs(right - trgLeft) <= 24;
+        Assert.True(opensRight || opensLeft,
+            $"Sub-content not adjacent to its trigger: subLeft={left} subRight={right} trgLeft={trgLeft} trgRight={trgRight}");
+    }
+
+    [Theory]
+    [InlineData("p0-icon-md", 16)]
+    [InlineData("p0-icon-lg", 20)]
+    [InlineData("p0-icon-xl", 24)]
+    public async Task Icon_size_utility_wins_over_blazicon_1em(string testid, int expectedPx)
+    {
+        await Goto("/e2e/p0-harness");
+        await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+        var width = await Page.EvaluateAsync<double>(
+            $@"() => {{
+                const svg = document.querySelector(""[data-testid='{testid}'] svg"");
+                return svg ? parseFloat(getComputedStyle(svg).width) : -1;
+            }}");
+
+        // 1.5px tolerance for sub-pixel rounding. Pre-fix every icon measured
+        // ~14px (1em at text-sm) regardless of its h-/w- utility.
+        Assert.True(Math.Abs(width - expectedPx) <= 1.5,
+            $"Icon '{testid}' computed width {width}px, expected ~{expectedPx}px — Blazicons' 1em rule is likely still winning the cascade.");
+    }
+}


### PR DESCRIPTION
## ⚠️ Do not merge until browser-verified

Both fixes target **real-browser cascade/layout effects that bUnit cannot observe**. They build clean and ship with an automated Playwright harness, but the cascade/layout outcome must be confirmed on the **Cloudflare preview** (and the **e2e** job green) before merge. Per Rule #2 the tag/release stays owner-gated.

Closes #172, closes #173 (on merge, once verified).

## #172 — transform-free overlay positioner
`positionFixed` (the shared positioner for Popover, Select, DropdownMenu, ContextMenu, Menubar, Tooltip) previously set a CSS `transform` for align/flip. A transformed element is a **containing block for its `position:fixed` descendants**, so a nested overlay (`DropdownMenuSubContent`, popover-in-popover, ContextMenu/Menubar submenu) resolved against the transformed parent instead of the viewport and opened off-target / off-screen.

**Fix:** position with **explicit top/left only**, folding the former `translateX/Y(-50%/-100%)` offsets into the computed coordinates. Visually identical for the existing cases (math verified for bottom/top/left/right × start/center/end); all viewport flip/clamp guards preserved. Completes a pattern the codebase already follows — `positionAtPoint` is already transform-free and `zoom-in`/Sheet/Drawer already strip their transforms to dodge the same containing-block trap.

## #173 — Tailwind-v4 icon-size cascade
Blazicons injects an **unlayered** `svg[blazicon]{width:1em;height:1em}`. In Tailwind v4 unlayered rules beat `@layer utilities`, so `h-/w-/size-` utilities silently lost and every icon collapsed to the font size (`Size="Lg"` rendered 14px at `text-sm` instead of 20px).

**Fix:** an unlayered, higher-specificity (`svg[blazicon][blazicon][class*="…"]` → (0,3,1) > (0,1,1)) `revert-layer` reset that defers sizing back to the utilities layer — the utility wins over `1em`, while a consumer's own `Class="h-8 w-8"` (also a utility) still wins over the preset. Decorative icons with no size utility keep the `1em` default.
**Consumer note:** effective on the unlayered `<link>` path (docs site / default). Consumers who `@import "...lumeo.css" layer(base)` must add the same reset unlayered themselves (documented inline).

## Automated harness (the safety net)
- New deterministic docs page `/e2e/p0-harness` (not in nav).
- New `tests/Lumeo.Tests.E2E/Smokes/P0OverlayIconTests.cs`:
  - **#172:** opens a **center-aligned** dropdown (forces the parent transform pre-fix) → submenu → asserts sub-content is **within the viewport** and **adjacent to its sub-trigger**.
  - **#173:** asserts computed `svg` widths are **16 / 20 / 24px** for `Md / Lg / Xl` in a `text-sm` context (pre-fix all ~14px).

Runs in the existing `e2e.yml` (real headless Chromium vs the docs server) — turning "can't verify in CI" into a CI gate.

## Build status
`dotnet build docs/Lumeo.Docs` ✅ 0 errors · `dotnet build tests/Lumeo.Tests.E2E` ✅ 0 errors · JS syntax ✅. No library C# changes (JS + CSS + docs harness + e2e test only).

## Verification checklist (confirm on the preview)
**#172**
- [ ] Bottom-anchored DropdownMenu (e.g. sidebar footer) → open submenu → sub-content visible within the viewport.
- [ ] Submenu in a top-opening menu; Popover-in-Popover; ContextMenu sub-content.
- [ ] Collision/flip still correct for parent content (Select/Popover/DatePicker, incl. inside a Dialog/Sheet).

**#173**
- [ ] `<Icon Size="Lg">` computes 20px, `Xl` 24px, default 16px in a TW-v4 build.
- [ ] Lumeo's own component icons (Button left-icon, Select chevron) correct at `text-sm`.
- [ ] Consumer `Class="h-8 w-8"` still overrides the preset.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed icon sizing behavior to display correctly with Tailwind CSS v4, preventing icons from collapsing to unintended sizes.
  * Improved dropdown and overlay positioning logic for more accurate viewport alignment and edge clamping.

* **Tests**
  * Added E2E regression test suite validating overlay positioning within viewport bounds and icon size utilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->