### PR TITLE
fix(a11y,i18n): Splash-Kit landmark names + localizable spinner/skeleton labels + RingProgress valuenow clamp

### DIFF
--- a/src/Lumeo/UI/CTASection/CTASection.razor
+++ b/src/Lumeo/UI/CTASection/CTASection.razor
@@ -6,11 +6,11 @@
     slot for primary / secondary buttons.
 *@
 
-<section class="@CssClass" @attributes="AdditionalAttributes">
+<section class="@CssClass" aria-labelledby="@TitleId" @attributes="AdditionalAttributes">
     <div class="mx-auto max-w-4xl px-6 py-16 sm:py-20 text-center">
         @if (!string.IsNullOrEmpty(Title))
         {
-            <h2 class="text-3xl sm:text-4xl font-bold tracking-tight text-foreground">@Title</h2>
+            <h2 id="@TitleId" class="text-3xl sm:text-4xl font-bold tracking-tight text-foreground">@Title</h2>
         }
         @TitleSlot
         @if (!string.IsNullOrEmpty(Subtitle))
@@ -35,4 +35,10 @@
     [Parameter(CaptureUnmatchedValues = true)] public Dictionary<string, object>? AdditionalAttributes { get; set; }
 
     private string CssClass => Cx.Merge("w-full bg-muted/40 border-y border-border/40", Class);
+
+    // Name the <section> landmark via its heading so AT exposes it as a region
+    // with an accessible name (#298). Null when there's no Title — a TitleSlot-
+    // only consumer can still supply aria-label/aria-labelledby via attributes.
+    private readonly string _titleId = $"cta-title-{Guid.NewGuid():N}";
+    private string? TitleId => string.IsNullOrEmpty(Title) ? null : _titleId;
 }

--- a/src/Lumeo/UI/FeatureGrid/FeatureGrid.razor
+++ b/src/Lumeo/UI/FeatureGrid/FeatureGrid.razor
@@ -6,11 +6,11 @@
     or pass raw ChildContent for full control.
 *@
 
-<section class="@CssClass" @attributes="AdditionalAttributes">
+<section class="@CssClass" aria-labelledby="@TitleId" @attributes="AdditionalAttributes">
     <div class="mx-auto max-w-6xl px-6 py-16">
         @if (!string.IsNullOrEmpty(Title))
         {
-            <h2 class="text-3xl font-bold tracking-tight text-foreground text-center">@Title</h2>
+            <h2 id="@TitleId" class="text-3xl font-bold tracking-tight text-foreground text-center">@Title</h2>
         }
         @if (!string.IsNullOrEmpty(Subtitle))
         {
@@ -31,6 +31,11 @@
     [Parameter(CaptureUnmatchedValues = true)] public Dictionary<string, object>? AdditionalAttributes { get; set; }
 
     private string CssClass => Cx.Merge("w-full", Class);
+
+    // Name the <section> landmark via its heading so AT exposes it as a region
+    // with an accessible name (#299). Null when there's no Title.
+    private readonly string _titleId = $"featuregrid-title-{Guid.NewGuid():N}";
+    private string? TitleId => string.IsNullOrEmpty(Title) ? null : _titleId;
 
     private string ColumnsClass => Columns switch
     {

--- a/src/Lumeo/UI/Hero/Hero.razor
+++ b/src/Lumeo/UI/Hero/Hero.razor
@@ -7,7 +7,7 @@
     illustration. Layout collapses to a single column under sm:.
 *@
 
-<section class="@CssClass" @attributes="AdditionalAttributes">
+<section class="@CssClass" aria-labelledby="@TitleId" @attributes="AdditionalAttributes">
     <div class="@($"mx-auto max-w-6xl px-6 py-16 sm:py-24 {GridClass}")">
         <div class="@($"flex flex-col {AlignClass}")">
             @if (Eyebrow is not null)
@@ -18,7 +18,7 @@
             }
             @if (!string.IsNullOrEmpty(Title))
             {
-                <h1 class="text-4xl sm:text-5xl lg:text-6xl font-bold tracking-tight text-foreground">@Title</h1>
+                <h1 id="@TitleId" class="text-4xl sm:text-5xl lg:text-6xl font-bold tracking-tight text-foreground">@Title</h1>
             }
             @TitleSlot
             @if (!string.IsNullOrEmpty(Subtitle))
@@ -55,6 +55,12 @@
     [Parameter(CaptureUnmatchedValues = true)] public Dictionary<string, object>? AdditionalAttributes { get; set; }
 
     private string CssClass => Cx.Merge("w-full", Class);
+
+    // Name the <section> landmark via its heading so AT exposes it as a region
+    // with an accessible name (#297). Null when there's no Title — a TitleSlot-
+    // only consumer can still supply aria-label/aria-labelledby via attributes.
+    private readonly string _titleId = $"hero-title-{Guid.NewGuid():N}";
+    private string? TitleId => string.IsNullOrEmpty(Title) ? null : _titleId;
 
     private string GridClass => Media is not null
         ? "grid gap-10 lg:grid-cols-2 items-center"

--- a/src/Lumeo/UI/RingProgress/RingProgress.razor
+++ b/src/Lumeo/UI/RingProgress/RingProgress.razor
@@ -2,7 +2,7 @@
 
 <div class="@ContainerClass"
      role="progressbar"
-     aria-valuenow="@Value.ToString(System.Globalization.CultureInfo.InvariantCulture)"
+     aria-valuenow="@((int)Math.Round(ClampedValue))"
      aria-valuemin="0"
      aria-valuemax="100"
      @attributes="AdditionalAttributes"

--- a/src/Lumeo/UI/Skeleton/Skeleton.razor
+++ b/src/Lumeo/UI/Skeleton/Skeleton.razor
@@ -8,21 +8,29 @@
             100% { background-position: 200% 0; }
         }
     </style>
-    <div role="status" aria-busy="true" aria-label="Loading"
+    <div role="status" aria-busy="true" aria-label="@AriaLabelOrDefault"
          class="@(Cx.Merge("rounded-md bg-gradient-to-r from-primary/10 via-primary/5 to-primary/10 bg-[length:200%_100%]", Class))"
          style="animation: skeleton-wave 1.5s ease-in-out infinite"
          @attributes="AdditionalAttributes"></div>
 }
 else
 {
-    <div role="status" aria-busy="true" aria-label="Loading"
+    <div role="status" aria-busy="true" aria-label="@AriaLabelOrDefault"
          class="@(Cx.Merge(AnimationClass, "rounded-md bg-primary/10", Class))" @attributes="AdditionalAttributes"></div>
 }
 
 @code {
     [Parameter] public SkeletonAnimation Animation { get; set; } = SkeletonAnimation.Pulse;
+    /// <summary>
+    /// Screen-reader name for the loading placeholder. Defaults to "Loading";
+    /// set a localized string (or pass <c>aria-label</c> directly) so it
+    /// announces in the app's language.
+    /// </summary>
+    [Parameter] public string? AriaLabel { get; set; }
     [Parameter] public string? Class { get; set; }
     [Parameter(CaptureUnmatchedValues = true)] public Dictionary<string, object>? AdditionalAttributes { get; set; }
+
+    private string AriaLabelOrDefault => string.IsNullOrEmpty(AriaLabel) ? "Loading" : AriaLabel!;
 
     private string AnimationClass => Animation switch
     {

--- a/src/Lumeo/UI/Spinner/Spinner.razor
+++ b/src/Lumeo/UI/Spinner/Spinner.razor
@@ -46,17 +46,26 @@ else if (Variant == SpinnerVariant.Bars)
     [Parameter] public Lumeo.Size Size { get; set; } = Lumeo.Size.Md;
     [Parameter] public SpinnerVariant Variant { get; set; } = SpinnerVariant.Ring;
     [Parameter] public string? Label { get; set; }
+    /// <summary>
+    /// Screen-reader name when there is no visible <see cref="Label"/>. Defaults
+    /// to "Loading"; set it to a localized string (or pass <c>aria-label</c>
+    /// directly) so the spinner announces in the app's language.
+    /// </summary>
+    [Parameter] public string? AriaLabel { get; set; }
     [Parameter] public string? Color { get; set; }
     [Parameter] public string? Class { get; set; }
     [Parameter(CaptureUnmatchedValues = true)] public Dictionary<string, object>? AdditionalAttributes { get; set; }
 
     private string WrapperClass => Cx.Merge("inline-flex items-center gap-2", Color, Class);
 
-    // Always advertise an accessible name to AT. Falls back to the visible
-    // Label when present, otherwise "Loading" — the SVG/Dots/Bars are marked
-    // aria-hidden because their shapes carry no semantic meaning by
-    // themselves, so without this the spinner is invisible to screen readers.
-    private string AriaLabelOrDefault => string.IsNullOrEmpty(Label) ? "Loading" : Label!;
+    // Always advertise an accessible name to AT. Prefers an explicit AriaLabel
+    // (localizable), then the visible Label, then "Loading" — the SVG/Dots/Bars
+    // are aria-hidden because their shapes carry no semantic meaning, so without
+    // this the spinner is invisible to screen readers. A consumer-supplied
+    // aria-label via attributes still wins (splatted last).
+    private string AriaLabelOrDefault =>
+        !string.IsNullOrEmpty(AriaLabel) ? AriaLabel! :
+        !string.IsNullOrEmpty(Label) ? Label! : "Loading";
 
     private string RingCssClass => Cx.Join("animate-spin", SizeClasses);
 

--- a/tests/Lumeo.Tests/Components/A11yPolish/A11yPolishTests.cs
+++ b/tests/Lumeo.Tests/Components/A11yPolish/A11yPolishTests.cs
@@ -1,0 +1,114 @@
+using Bunit;
+using Xunit;
+using Lumeo.Tests.Helpers;
+
+namespace Lumeo.Tests.Components.A11yPolish;
+
+/// <summary>
+/// Covers the a11y/i18n polish batch:
+///   #297 Hero / #298 CTASection / #299 FeatureGrid — the &lt;section&gt; landmark
+///     gains an accessible name via aria-labelledby -> its heading.
+///   #281 Skeleton / #282 Spinner — the screen-reader label is localizable.
+///   #278 RingProgress — aria-valuenow is clamped to [valuemin, valuemax].
+/// </summary>
+public class A11yPolishTests
+{
+    private static BunitContext NewCtx()
+    {
+        var ctx = new BunitContext();
+        ctx.AddLumeoServices();
+        return ctx;
+    }
+
+    [Fact]
+    public void CTASection_section_is_labelled_by_its_heading()
+    {
+        using var ctx = NewCtx();
+        var cut = ctx.Render<Lumeo.CTASection>(p => p.Add(x => x.Title, "Get started"));
+
+        var section = cut.Find("section");
+        var h2 = cut.Find("h2");
+        var labelledBy = section.GetAttribute("aria-labelledby");
+
+        Assert.False(string.IsNullOrEmpty(labelledBy));
+        Assert.Equal(h2.Id, labelledBy);
+    }
+
+    [Fact]
+    public void FeatureGrid_section_is_labelled_by_its_heading()
+    {
+        using var ctx = NewCtx();
+        var cut = ctx.Render<Lumeo.FeatureGrid>(p => p.Add(x => x.Title, "Features"));
+
+        var section = cut.Find("section");
+        var h2 = cut.Find("h2");
+
+        Assert.Equal(h2.Id, section.GetAttribute("aria-labelledby"));
+        Assert.False(string.IsNullOrEmpty(h2.Id));
+    }
+
+    [Fact]
+    public void Hero_section_is_labelled_by_its_heading()
+    {
+        using var ctx = NewCtx();
+        var cut = ctx.Render<Lumeo.Hero>(p => p.Add(x => x.Title, "Build faster"));
+
+        var section = cut.Find("section");
+        var h1 = cut.Find("h1");
+
+        Assert.Equal(h1.Id, section.GetAttribute("aria-labelledby"));
+        Assert.False(string.IsNullOrEmpty(h1.Id));
+    }
+
+    [Fact]
+    public void CTASection_without_title_has_no_dangling_labelledby()
+    {
+        using var ctx = NewCtx();
+        var cut = ctx.Render<Lumeo.CTASection>();
+
+        // No heading id to point at -> attribute must be absent, not "".
+        Assert.False(cut.Find("section").HasAttribute("aria-labelledby"));
+    }
+
+    [Fact]
+    public void Spinner_uses_localizable_aria_label()
+    {
+        using var ctx = NewCtx();
+        var cut = ctx.Render<Lumeo.Spinner>(p => p.Add(x => x.AriaLabel, "Lädt"));
+
+        Assert.Equal("Lädt", cut.Find("[role='status']").GetAttribute("aria-label"));
+    }
+
+    [Fact]
+    public void Spinner_defaults_aria_label_to_loading()
+    {
+        using var ctx = NewCtx();
+        var cut = ctx.Render<Lumeo.Spinner>();
+
+        Assert.Equal("Loading", cut.Find("[role='status']").GetAttribute("aria-label"));
+    }
+
+    [Fact]
+    public void Skeleton_uses_localizable_aria_label()
+    {
+        using var ctx = NewCtx();
+        var cut = ctx.Render<Lumeo.Skeleton>(p => p.Add(x => x.AriaLabel, "Lädt"));
+
+        Assert.Equal("Lädt", cut.Find("[role='status']").GetAttribute("aria-label"));
+    }
+
+    [Theory]
+    [InlineData(150, "100")]
+    [InlineData(-10, "0")]
+    [InlineData(42.6, "43")]
+    public void RingProgress_clamps_and_rounds_aria_valuenow(double value, string expected)
+    {
+        using var ctx = NewCtx();
+        var cut = ctx.Render<Lumeo.RingProgress>(p => p.Add(x => x.Value, value));
+
+        var bar = cut.Find("[role='progressbar']");
+        Assert.Equal(expected, bar.GetAttribute("aria-valuenow"));
+        Assert.Equal("0", bar.GetAttribute("aria-valuemin"));
+        Assert.Equal("100", bar.GetAttribute("aria-valuemax"));
+    }
+}


### PR DESCRIPTION
Tractable a11y / i18n polish batch from the audit backlog. Unlike the P0 PR (#339), these are **bUnit-verifiable** and ship with tests — no browser verification needed.

## Landmarks gain accessible names
`Hero` (#297), `CTASection` (#298), `FeatureGrid` (#299) render a `<section>` (a landmark) but had **no accessible name**, so AT exposed them as anonymous regions. They now set `aria-labelledby` -> their heading's id when a `Title` is present (omitted otherwise; a consumer `aria-label`/`aria-labelledby` via attributes still wins).

## Localizable loading labels
`Spinner` (#282) and `Skeleton` (#281) hardcoded `aria-label="Loading"`. Both now take an `AriaLabel` parameter (defaults to `"Loading"`) so the screen-reader name is localizable without a visible label; a splatted `aria-label` still wins.

## RingProgress valuenow clamp
`RingProgress` (#278) already had `role="progressbar"` + `aria-value*` (from the 3.14.0 pass — the issue title is stale). `aria-valuenow` now clamps/rounds into `[valuemin, valuemax]` so an out-of-range `Value` can't report an invalid value.

## Tests
New `A11yPolishTests` (10, all green locally): landmark names match their headings (and are absent without a title), localizable + default labels, and the valuenow clamp (`150 -> 100`, `-10 -> 0`, `42.6 -> 43`).

`dotnet build src/Lumeo` ✅ · `dotnet test --filter A11yPolish` ✅ 10/10.

Closes #278, closes #281, closes #282, closes #297, closes #298, closes #299 (on merge).

> Per Rule #2 the version bump / tag / release stays owner-gated — this PR is the reviewable change set.
