### PR TITLE
fix(a11y,i18n): Result role / ButtonGroup group / BackToTop throttle / Stepper i18n (+ at-parity closes)

### DIFF
--- a/src/Lumeo/UI/ButtonGroup/ButtonGroup.razor
+++ b/src/Lumeo/UI/ButtonGroup/ButtonGroup.razor
@@ -1,6 +1,6 @@
 @namespace Lumeo
 
-<div class="@CssClass" @attributes="AdditionalAttributes">
+<div class="@CssClass" role="group" aria-label="@AriaLabel" @attributes="AdditionalAttributes">
     @ChildContent
 </div>
 
@@ -8,6 +8,13 @@
     [Parameter] public RenderFragment? ChildContent { get; set; }
     [Parameter] public string? Class { get; set; }
     [Parameter] public Lumeo.Orientation Orientation { get; set; } = Lumeo.Orientation.Horizontal;
+    /// <summary>
+    /// Accessible name for the button group (exposes it to AT as a named
+    /// <c>role="group"</c>). Roving tabindex is intentionally NOT forced here —
+    /// a ButtonGroup commonly wraps independent actions that each need their own
+    /// tab stop; use <c>Toolbar</c> for single-tab-stop/arrow-key navigation. (#270)
+    /// </summary>
+    [Parameter] public string? AriaLabel { get; set; }
     [Parameter(CaptureUnmatchedValues = true)] public Dictionary<string, object>? AdditionalAttributes { get; set; }
 
     private string CssClass => Cx.Merge(

--- a/src/Lumeo/UI/Result/Result.razor
+++ b/src/Lumeo/UI/Result/Result.razor
@@ -1,6 +1,6 @@
 @namespace Lumeo
 
-<div role="status" class="@CssClass" @attributes="AdditionalAttributes">
+<div role="@AriaRole" class="@CssClass" @attributes="AdditionalAttributes">
     <div class="flex flex-col items-center text-center">
         <div class="@IconContainerClasses">
             @if (IconContent is not null)
@@ -42,6 +42,13 @@
     [Parameter] public RenderFragment? Extra { get; set; }
     [Parameter] public string? Class { get; set; }
     [Parameter(CaptureUnmatchedValues = true)] public Dictionary<string, object>? AdditionalAttributes { get; set; }
+
+    // Error-ish outcomes are assertive (role="alert") so AT interrupts; success/
+    // info/not-found are polite (role="status"). A consumer role via attributes
+    // still wins (splatted last). (#284)
+    private string AriaRole => Status is ResultStatus.Error or ResultStatus.Forbidden or ResultStatus.ServerError
+        ? "alert"
+        : "status";
 
     private string CssClass => Cx.Merge(SizePaddingClass, "px-6", Class);
 

--- a/src/Lumeo/UI/Stepper/Stepper.razor
+++ b/src/Lumeo/UI/Stepper/Stepper.razor
@@ -153,7 +153,7 @@
                 disabled="@(ActiveStep == 0)"
                 class="@GetNavButtonClass(ActiveStep == 0)"
                 @onclick="GoBack">
-            @BackLabel
+            @(BackLabel ?? L["Stepper.Back"])
         </button>
         <div class="flex-1"></div>
         @if (ActiveStep == _steps.Count - 1)
@@ -162,7 +162,7 @@
                     disabled="@(!CanAdvance())"
                     class="@GetNavButtonClass(!CanAdvance(), primary: true)"
                     @onclick="Finish">
-                @FinishLabel
+                @(FinishLabel ?? L["Stepper.Finish"])
             </button>
         }
         else
@@ -171,7 +171,7 @@
                     disabled="@(!CanAdvance())"
                     class="@GetNavButtonClass(!CanAdvance(), primary: true)"
                     @onclick="GoNext">
-                @NextLabel
+                @(NextLabel ?? L["Stepper.Next"])
             </button>
         }
     </div>
@@ -188,9 +188,12 @@
     [Parameter] public bool Linear { get; set; } = true;
     [Parameter] public bool AllowStepClick { get; set; }
     [Parameter] public EventCallback OnFinish { get; set; }
-    [Parameter] public string NextLabel { get; set; } = "Next";
-    [Parameter] public string BackLabel { get; set; } = "Back";
-    [Parameter] public string FinishLabel { get; set; } = "Finish";
+    /// <summary>Override the "Next" button label. When null, uses the localized <c>L["Stepper.Next"]</c>. (#245)</summary>
+    [Parameter] public string? NextLabel { get; set; }
+    /// <summary>Override the "Back" button label. When null, uses the localized <c>L["Stepper.Back"]</c>. (#245)</summary>
+    [Parameter] public string? BackLabel { get; set; }
+    /// <summary>Override the "Finish" button label. When null, uses the localized <c>L["Stepper.Finish"]</c>. (#245)</summary>
+    [Parameter] public string? FinishLabel { get; set; }
     [Parameter] public string? Class { get; set; }
     [Parameter(CaptureUnmatchedValues = true)] public Dictionary<string, object>? AdditionalAttributes { get; set; }
 

--- a/src/Lumeo/wwwroot/js/components.js
+++ b/src/Lumeo/wwwroot/js/components.js
@@ -2318,15 +2318,28 @@ export function registerBackToTop(id, dotnetRef, threshold) {
     }
 
     const effectiveThreshold = threshold || 300;
-    const handler = () => {
+    // Throttle to one check per animation frame — a raw scroll handler fires
+    // dozens of times per gesture and each call crosses the JS<->.NET interop
+    // boundary. We also only invoke when the visibility actually flips. (#247)
+    let rafPending = false;
+    let lastVisible = null;
+    const compute = () => {
+        rafPending = false;
         const scrollY = window.scrollY || document.documentElement.scrollTop;
         const visible = scrollY > effectiveThreshold;
+        if (visible === lastVisible) return;
+        lastVisible = visible;
         dotnetRef.invokeMethodAsync('OnScrollVisibilityChanged', id, visible);
+    };
+    const handler = () => {
+        if (rafPending) return;
+        rafPending = true;
+        requestAnimationFrame(compute);
     };
 
     window.addEventListener('scroll', handler, { passive: true });
     backToTopHandlers.set(id, { handler, dotnetRef });
-    handler(); // initial check
+    compute(); // initial check (synchronous)
 }
 
 export function unregisterBackToTop(id) {

--- a/tests/Lumeo.Tests/Components/A11yPolish/PolishWave2Tests.cs
+++ b/tests/Lumeo.Tests/Components/A11yPolish/PolishWave2Tests.cs
@@ -1,0 +1,76 @@
+using Bunit;
+using Xunit;
+using Lumeo.Tests.Helpers;
+
+namespace Lumeo.Tests.Components.A11yPolish;
+
+/// <summary>
+/// Polish wave 2:
+///   #284 Result — role is "alert" for error-ish statuses, "status" otherwise.
+///   #270 ButtonGroup — exposes role="group" + optional AriaLabel.
+///   #245 Stepper — nav button labels come from the localizer when not overridden.
+/// (#247 BackToTop scroll-throttle is JS-only — covered by e2e/manual, not bUnit.)
+/// </summary>
+public class PolishWave2Tests
+{
+    private static BunitContext NewCtx()
+    {
+        var ctx = new BunitContext();
+        ctx.AddLumeoServices();
+        return ctx;
+    }
+
+    [Theory]
+    [InlineData(Lumeo.Result.ResultStatus.Error, "alert")]
+    [InlineData(Lumeo.Result.ResultStatus.Forbidden, "alert")]
+    [InlineData(Lumeo.Result.ResultStatus.ServerError, "alert")]
+    [InlineData(Lumeo.Result.ResultStatus.Success, "status")]
+    [InlineData(Lumeo.Result.ResultStatus.Info, "status")]
+    [InlineData(Lumeo.Result.ResultStatus.NotFound, "status")]
+    public void Result_role_tracks_status(Lumeo.Result.ResultStatus status, string expectedRole)
+    {
+        using var ctx = NewCtx();
+        var cut = ctx.Render<Lumeo.Result>(p => p
+            .Add(x => x.Status, status)
+            .Add(x => x.Title, "Outcome"));
+
+        Assert.NotNull(cut.Find($"[role='{expectedRole}']"));
+    }
+
+    [Fact]
+    public void ButtonGroup_exposes_group_role_and_label()
+    {
+        using var ctx = NewCtx();
+        var cut = ctx.Render<Lumeo.ButtonGroup>(p => p
+            .Add(x => x.AriaLabel, "Text alignment"));
+
+        var group = cut.Find("[role='group']");
+        Assert.Equal("Text alignment", group.GetAttribute("aria-label"));
+    }
+
+    [Fact]
+    public void Stepper_nav_labels_default_to_localized_strings()
+    {
+        using var ctx = NewCtx();
+        var cut = ctx.Render<Lumeo.Stepper>();
+
+        var buttons = cut.FindAll("button");
+        // No steps registered -> the only buttons are the footer Back + Next.
+        Assert.Equal(2, buttons.Count);
+        Assert.Equal("Back", buttons[0].TextContent.Trim());
+        Assert.Equal("Next", buttons[1].TextContent.Trim());
+    }
+
+    [Fact]
+    public void Stepper_nav_labels_respect_explicit_overrides()
+    {
+        using var ctx = NewCtx();
+        var cut = ctx.Render<Lumeo.Stepper>(p => p
+            .Add(x => x.BackLabel, "Zurück")
+            .Add(x => x.NextLabel, "Weiter"));
+
+        var buttons = cut.FindAll("button");
+        Assert.Equal("Zurück", buttons[0].TextContent.Trim());
+        Assert.Equal("Weiter", buttons[1].TextContent.Trim());
+    }
+}


### PR DESCRIPTION
Polish wave 2 — 4 genuine a11y/i18n fixes (bUnit-tested), plus 7 at-parity audit notes closed alongside.

## Fixes
- **Result (#284)** — `role` tracks status: `alert` (assertive) for Error/Forbidden/ServerError, `status` (polite) otherwise; a consumer `role` via attributes still wins.
- **ButtonGroup (#270)** — exposes `role="group"` + optional `AriaLabel`. Roving tabindex intentionally NOT forced (independent-action groups need per-button tab stops; `Toolbar` is the arrow-key pattern, already shipped).
- **BackToTop (#247)** — scroll handler throttled to one check per animation frame, and only crosses the JS↔.NET interop boundary on a visibility flip.
- **Stepper (#245)** — Next/Back/Finish labels fall back to `L["Stepper.*"]` (keys already shipped for every locale); explicit `*Label` params still override.

Tests: `PolishWave2Tests` (9, green) + core build ✅.

Closes #284, closes #270, closes #247, closes #245.

## Also closed alongside (at-parity / scope / cosmetic — no code change)
#174 (Input — minor parity only), #242 (AppBar — intentionally a thin primitive vs MudBlazor), #283 (EmptyState — `role="status"` is the right default for the empty-after-filter live region; overridable), #272 (KpiCard — reads correctly, no concrete defect), #264 (Descriptions — `<dl>` already fixed; remaining notes are cosmetic), #267 (Chip — minor color-token), #301 (Bento — grid is solid; heading semantics are tile/content-level).

> Version bump / tag / release stays owner-gated (Rule #2).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * ButtonGroup component now supports custom accessible labels via a new parameter for improved assistive technology support.
  * Result component dynamically adjusts ARIA roles based on status for enhanced accessibility.

* **Improvements**
  * Stepper navigation buttons now display localized text by default when not explicitly overridden.
  * Optimized scroll event handling for back-to-top functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->