### PR TITLE
fix: Collapsible controlled-state gate (#238) + ReasoningDisplay markdown (#305)

### DIFF
--- a/src/Lumeo/UI/Collapsible/Collapsible.razor
+++ b/src/Lumeo/UI/Collapsible/Collapsible.razor
@@ -34,8 +34,19 @@
 
     private async Task Toggle()
     {
-        Open = !Open;
-        await OpenChanged.InvokeAsync(Open);
+        var next = !Open;
+        // Controlled (Open is bound via OpenChanged): let the parent own state —
+        // fire the callback and render from the parent's next value instead of
+        // mutating our own [Parameter], which desyncs if the parent rejects or
+        // ignores the change. Uncontrolled: self-manage. (#238)
+        if (OpenChanged.HasDelegate)
+        {
+            await OpenChanged.InvokeAsync(next);
+        }
+        else
+        {
+            Open = next;
+        }
     }
 
     public record CollapsibleContext(bool IsOpen, EventCallback Toggle, string TriggerId, string ContentId);

--- a/src/Lumeo/UI/ReasoningDisplay/ReasoningDisplay.razor
+++ b/src/Lumeo/UI/ReasoningDisplay/ReasoningDisplay.razor
@@ -19,7 +19,14 @@
     </summary>
 
     <div class="@BodyClass">
-        <p class="m-0 whitespace-pre-wrap break-words">@Text</p>
+        @if (Markdown)
+        {
+            <div class="prose prose-sm max-w-none break-words">@RenderedMarkdown</div>
+        }
+        else
+        {
+            <p class="m-0 whitespace-pre-wrap break-words">@Text</p>
+        }
     </div>
 </details>
 
@@ -31,6 +38,24 @@
     [Parameter] public bool DefaultOpen { get; set; }
     [Parameter] public Lumeo.Size Size { get; set; } = Lumeo.Size.Md;
     [Parameter] public ReasoningVariant Variant { get; set; } = ReasoningVariant.Default;
+
+    /// <summary>
+    /// Renders <see cref="Text"/> as markdown instead of plain text — reasoning
+    /// traces from models are usually markdown (lists, bold, code). Uses
+    /// <see cref="MarkdownRenderer"/> when supplied, otherwise the built-in
+    /// dependency-free CommonMark subset. Pairs naturally with
+    /// <see cref="ReasoningVariant.Detailed"/>. (#305)
+    /// </summary>
+    [Parameter] public bool Markdown { get; set; }
+
+    /// <summary>
+    /// Optional render hook converting the raw markdown <see cref="Text"/> into a
+    /// <see cref="MarkupString"/> (plug in Markdig etc.). The delegate must return
+    /// SAFE HTML — sanitise untrusted input. Ignored unless <see cref="Markdown"/>
+    /// is <c>true</c>.
+    /// </summary>
+    [Parameter] public Func<string, MarkupString>? MarkdownRenderer { get; set; }
+
     [Parameter] public string? Class { get; set; }
     [Parameter(CaptureUnmatchedValues = true)] public Dictionary<string, object>? AdditionalAttributes { get; set; }
 
@@ -84,6 +109,20 @@
             if (!string.IsNullOrEmpty(Summary)) return Summary!;
             if (DurationMs is long ms) return $"Reasoned for {ms / 1000.0:0.#}s";
             return IsStreaming ? "Thinking…" : "Reasoning";
+        }
+    }
+
+    // Mirrors StreamingText: HTML-escape-first allow-list renderer by default,
+    // or a consumer-supplied renderer. LumeoMarkdown output is XSS-safe. (#305)
+    private MarkupString RenderedMarkdown
+    {
+        get
+        {
+            var text = Text ?? string.Empty;
+            if (text.Length == 0) return default;
+            return MarkdownRenderer is not null
+                ? MarkdownRenderer(text)
+                : (MarkupString)Lumeo.Internal.LumeoMarkdown.ToHtml(text);
         }
     }
 

--- a/tests/Lumeo.Tests/Components/A11yPolish/PolishWave3Tests.cs
+++ b/tests/Lumeo.Tests/Components/A11yPolish/PolishWave3Tests.cs
@@ -1,0 +1,58 @@
+using Bunit;
+using Microsoft.AspNetCore.Components;
+using Xunit;
+using Lumeo.Tests.Helpers;
+
+namespace Lumeo.Tests.Components.A11yPolish;
+
+/// <summary>
+/// Polish wave 3:
+///   #305 ReasoningDisplay — opt-in markdown rendering (safe built-in renderer
+///        or a consumer MarkdownRenderer hook); plain-text default unchanged.
+/// (#238 Collapsible controlled-state gate is a small logic-only change.)
+/// </summary>
+public class PolishWave3Tests
+{
+    private static BunitContext NewCtx()
+    {
+        var ctx = new BunitContext();
+        ctx.AddLumeoServices();
+        return ctx;
+    }
+
+    [Fact]
+    public void ReasoningDisplay_renders_markdown_when_enabled()
+    {
+        using var ctx = NewCtx();
+        var cut = ctx.Render<Lumeo.ReasoningDisplay>(p => p
+            .Add(x => x.Markdown, true)
+            .Add(x => x.Text, "**bold** and `code`"));
+
+        Assert.Contains("<strong>bold</strong>", cut.Markup);
+        Assert.Contains("<code>code</code>", cut.Markup);
+    }
+
+    [Fact]
+    public void ReasoningDisplay_keeps_plain_text_by_default()
+    {
+        using var ctx = NewCtx();
+        var cut = ctx.Render<Lumeo.ReasoningDisplay>(p => p
+            .Add(x => x.Text, "**bold**"));
+
+        // No markdown pass -> the asterisks survive as literal text, no <strong>.
+        Assert.DoesNotContain("<strong>", cut.Markup);
+        Assert.Contains("**bold**", cut.Markup);
+    }
+
+    [Fact]
+    public void ReasoningDisplay_uses_custom_markdown_renderer_hook()
+    {
+        using var ctx = NewCtx();
+        var cut = ctx.Render<Lumeo.ReasoningDisplay>(p => p
+            .Add(x => x.Markdown, true)
+            .Add(x => x.MarkdownRenderer, (Func<string, MarkupString>)(t => (MarkupString)$"<span class=\"custom\">{t}</span>"))
+            .Add(x => x.Text, "hi"));
+
+        Assert.Contains("<span class=\"custom\">hi</span>", cut.Markup);
+    }
+}


### PR DESCRIPTION
Polish wave 3 — 2 fixes (3 tests).

- **Collapsible (#238)** — `Toggle` only mutates its own `Open` when uncontrolled (no `OpenChanged` delegate); when controlled it fires `OpenChanged` and renders from the parent's value, instead of eagerly flipping `Open` locally (which desynced if the parent rejected/ignored the change).
- **ReasoningDisplay (#305)** — opt-in `Markdown` rendering (+ `MarkdownRenderer` hook), mirroring `StreamingText`. Reasoning traces are usually markdown; uses the XSS-safe built-in `LumeoMarkdown` renderer by default. Plain-text default unchanged.

`PolishWave3Tests` (3, green) + core build ✅.

Closes #238, closes #305.

> Version/tag/release owner-gated (Rule #2). Intended to ship together with #341 as 3.16.0.