### PR TITLE
feat: Barcode validation hook + quiet zone (#291), Highlighter regex mode (#293)

### DIFF
--- a/src/Lumeo/UI/Barcode/Barcode.razor
+++ b/src/Lumeo/UI/Barcode/Barcode.razor
@@ -55,10 +55,19 @@
     [Parameter] public bool ShowText { get; set; } = true;
     [Parameter] public string Color { get; set; } = "foreground";
     [Parameter] public string BackgroundColor { get; set; } = "background";
+    /// <summary>
+    /// Fired after (re)encoding with the human-readable error message, or
+    /// <c>null</c> when the value encoded successfully — a validation hook so a
+    /// consumer can surface its own UI / gate a submit. (#291)
+    /// </summary>
+    [Parameter] public EventCallback<string?> OnError { get; set; }
     [Parameter] public string? Class { get; set; }
     [Parameter(CaptureUnmatchedValues = true)] public Dictionary<string, object>? AdditionalAttributes { get; set; }
 
-    private const int QuietZone = 10;
+    // Quiet zone scales with the narrow-module width (the spec mandates ~10×
+    // the narrow module, not a fixed pixel count) so a wide BarWidth keeps a
+    // scanner-readable margin. (#291)
+    private double QuietZone => 10 * BarWidth;
 
     private List<(double Width, bool IsBar)> _modules = new();
 
@@ -79,7 +88,21 @@
         ? $"Barcode: {_text}"
         : $"Barcode error: {_error}";
 
-    protected override void OnParametersSet() => Rebuild();
+    private string? _lastError;
+    private bool _reportedOnce;
+
+    protected override async Task OnParametersSetAsync()
+    {
+        Rebuild();
+        // Report the validation result once per change (including clearing to
+        // null on a successful encode) — never on every unrelated param set.
+        if (OnError.HasDelegate && (!_reportedOnce || _error != _lastError))
+        {
+            _reportedOnce = true;
+            _lastError = _error;
+            await OnError.InvokeAsync(_error);
+        }
+    }
 
     private void Rebuild()
     {

--- a/src/Lumeo/UI/Grid/Grid.razor
+++ b/src/Lumeo/UI/Grid/Grid.razor
@@ -4,12 +4,35 @@
 
 @code {
     [Parameter] public int Columns { get; set; } = 1;
+    /// <summary>
+    /// When true the grid collapses to 1 column on mobile and 2 on small screens,
+    /// expanding to <see cref="Columns"/> only at the <c>lg</c> breakpoint — so a
+    /// many-column grid stays readable on phones. Uses statically-known responsive
+    /// utility strings (purge-safe) for 1–6 columns; falls back to a fixed
+    /// <c>grid-cols-N</c> for other counts. Off by default (unchanged behavior). (#250)
+    /// </summary>
+    [Parameter] public bool Responsive { get; set; }
     [Parameter] public string? Gap { get; set; } = "4";
     [Parameter] public string? RowGap { get; set; }
     [Parameter] public string? ColGap { get; set; }
     [Parameter] public RenderFragment? ChildContent { get; set; }
     [Parameter] public string? Class { get; set; }
     [Parameter(CaptureUnmatchedValues = true)] public Dictionary<string, object>? AdditionalAttributes { get; set; }
+
+    // Static, fully-spelled responsive class strings so Tailwind's content scan
+    // compiles them (dynamic `sm:grid-cols-{n}` interpolation would be purged).
+    private string ColumnsClass => !Responsive
+        ? $"grid-cols-{Columns}"
+        : Columns switch
+        {
+            <= 1 => "grid-cols-1",
+            2 => "grid-cols-1 sm:grid-cols-2",
+            3 => "grid-cols-1 sm:grid-cols-2 lg:grid-cols-3",
+            4 => "grid-cols-1 sm:grid-cols-2 lg:grid-cols-4",
+            5 => "grid-cols-1 sm:grid-cols-2 lg:grid-cols-5",
+            6 => "grid-cols-1 sm:grid-cols-2 lg:grid-cols-6",
+            _ => $"grid-cols-{Columns}"
+        };
 
     private string CssClass
     {
@@ -18,7 +41,7 @@
             var gap = !string.IsNullOrEmpty(Gap) ? $"gap-{Gap}" : "";
             var rowGap = !string.IsNullOrEmpty(RowGap) ? $"gap-y-{RowGap}" : "";
             var colGap = !string.IsNullOrEmpty(ColGap) ? $"gap-x-{ColGap}" : "";
-            return Cx.Merge($"grid grid-cols-{Columns}", gap, rowGap, colGap, Class);
+            return Cx.Merge($"grid {ColumnsClass}", gap, rowGap, colGap, Class);
         }
     }
 }

--- a/src/Lumeo/UI/Highlighter/Highlighter.razor
+++ b/src/Lumeo/UI/Highlighter/Highlighter.razor
@@ -20,6 +20,13 @@
     [Parameter] public IEnumerable<string>? HighlightTerms { get; set; }
     [Parameter] public bool CaseSensitive { get; set; }
     [Parameter] public bool WholeWord { get; set; }
+    /// <summary>
+    /// Treat <see cref="Highlight"/> / <see cref="HighlightTerms"/> as regular-
+    /// expression patterns instead of literal text (the default). Invalid
+    /// patterns fall back to rendering the text un-highlighted. <see cref="WholeWord"/>
+    /// is ignored in this mode — express boundaries in the pattern itself. (#293)
+    /// </summary>
+    [Parameter] public bool RegexMode { get; set; }
     [Parameter] public string? HighlightClass { get; set; }
     [Parameter] public string Tag { get; set; } = "mark";
     [Parameter] public string? Class { get; set; }
@@ -72,6 +79,9 @@
         // Build a combined regex: alternate longest-first
         var escaped = terms.Select(t =>
         {
+            // RegexMode: use the term verbatim as a pattern. Otherwise escape it
+            // to a literal and optionally anchor on word boundaries.
+            if (RegexMode) return t;
             var e = System.Text.RegularExpressions.Regex.Escape(t);
             return WholeWord ? $@"\b{e}\b" : e;
         });

--- a/tests/Lumeo.Tests/Components/Features/FeatureBatchTests.cs
+++ b/tests/Lumeo.Tests/Components/Features/FeatureBatchTests.cs
@@ -1,0 +1,105 @@
+using System;
+using Bunit;
+using Microsoft.AspNetCore.Components;
+using Xunit;
+using Lumeo.Tests.Helpers;
+
+namespace Lumeo.Tests.Components.Features;
+
+/// <summary>
+/// Feature batch (3.17.0):
+///   #291 Barcode — OnError validation hook + quiet zone that scales with BarWidth.
+///   #293 Highlighter — opt-in RegexMode (patterns instead of literal terms).
+/// </summary>
+public class FeatureBatchTests
+{
+    private static BunitContext NewCtx()
+    {
+        var ctx = new BunitContext();
+        ctx.AddLumeoServices();
+        return ctx;
+    }
+
+    [Fact]
+    public void Barcode_OnError_fires_with_message_for_invalid_value()
+    {
+        using var ctx = NewCtx();
+        string? captured = "SENTINEL";
+        ctx.Render<Lumeo.Barcode>(p => p
+            .Add(x => x.Format, Lumeo.Barcode.BarcodeFormat.EAN13)
+            .Add(x => x.Value, "abc")
+            .Add(x => x.OnError, EventCallback.Factory.Create<string?>(this, v => captured = v)));
+
+        Assert.False(string.IsNullOrEmpty(captured)); // a real encoding error message
+    }
+
+    [Fact]
+    public void Barcode_OnError_fires_null_for_valid_value()
+    {
+        using var ctx = NewCtx();
+        string? captured = "SENTINEL";
+        ctx.Render<Lumeo.Barcode>(p => p
+            .Add(x => x.Value, "HELLO")
+            .Add(x => x.OnError, EventCallback.Factory.Create<string?>(this, v => captured = v)));
+
+        Assert.Null(captured); // encoded OK -> null
+    }
+
+    [Theory]
+    [InlineData(2, "20")]
+    [InlineData(3, "30")]
+    public void Barcode_quiet_zone_scales_with_bar_width(double barWidth, string expectedX)
+    {
+        using var ctx = NewCtx();
+        var cut = ctx.Render<Lumeo.Barcode>(p => p
+            .Add(x => x.Value, "A")
+            .Add(x => x.BarWidth, barWidth));
+
+        // rect[0] is the background (x=0); rect[1] is the first bar, offset by the
+        // quiet zone (= 10 × BarWidth).
+        var rects = cut.FindAll("rect");
+        Assert.True(rects.Count >= 2);
+        Assert.Equal(expectedX, rects[1].GetAttribute("x"));
+    }
+
+    [Fact]
+    public void Highlighter_regex_mode_matches_pattern()
+    {
+        using var ctx = NewCtx();
+        var cut = ctx.Render<Lumeo.Highlighter>(p => p
+            .Add(x => x.RegexMode, true)
+            .Add(x => x.Highlight, @"\d+")
+            .Add(x => x.Text, "a 12 b 34"));
+
+        var marks = cut.FindAll("mark");
+        Assert.Equal(2, marks.Count);
+        Assert.Equal("12", marks[0].TextContent);
+        Assert.Equal("34", marks[1].TextContent);
+    }
+
+    [Fact]
+    public void Highlighter_literal_mode_does_not_treat_pattern_as_regex()
+    {
+        using var ctx = NewCtx();
+        var cut = ctx.Render<Lumeo.Highlighter>(p => p
+            .Add(x => x.Highlight, @"\d+")
+            .Add(x => x.Text, "a 12 b"));
+
+        // Default literal mode: "\d+" is not present verbatim -> nothing highlighted.
+        Assert.Empty(cut.FindAll("mark"));
+        Assert.Contains("a 12 b", cut.Markup);
+    }
+
+    [Fact]
+    public void Highlighter_invalid_regex_falls_back_to_plain_text()
+    {
+        using var ctx = NewCtx();
+        var cut = ctx.Render<Lumeo.Highlighter>(p => p
+            .Add(x => x.RegexMode, true)
+            .Add(x => x.Highlight, "[")  // invalid pattern
+            .Add(x => x.Text, "hello"));
+
+        Assert.Empty(cut.FindAll("mark"));
+        Assert.Contains("hello", cut.Markup);
+    }
+}

--- a/tests/Lumeo.Tests/Components/Features/FeatureBatchTests.cs
+++ b/tests/Lumeo.Tests/Components/Features/FeatureBatchTests.cs
@@ -102,4 +102,28 @@ public class FeatureBatchTests
         Assert.Empty(cut.FindAll("mark"));
         Assert.Contains("hello", cut.Markup);
     }
+
+    [Fact]
+    public void Grid_responsive_uses_breakpoint_columns()
+    {
+        using var ctx = NewCtx();
+        var cut = ctx.Render<Lumeo.Grid>(p => p
+            .Add(x => x.Columns, 3)
+            .Add(x => x.Responsive, true));
+
+        var cls = cut.Find("div").GetAttribute("class") ?? "";
+        Assert.Contains("sm:grid-cols-2", cls);
+        Assert.Contains("lg:grid-cols-3", cls);
+    }
+
+    [Fact]
+    public void Grid_default_stays_fixed_columns()
+    {
+        using var ctx = NewCtx();
+        var cut = ctx.Render<Lumeo.Grid>(p => p.Add(x => x.Columns, 3));
+
+        var cls = cut.Find("div").GetAttribute("class") ?? "";
+        Assert.Contains("grid-cols-3", cls);
+        Assert.DoesNotContain("sm:grid-cols", cls);
+    }
 }


### PR DESCRIPTION
Bundled "easy" feature batch for a single 3.17.0 (avoiding many small releases). All CI-verifiable with tests.

- **Barcode (#291)** — `OnError` validation hook (fires the encoding error, or `null` on success) + quiet zone scales with `BarWidth`. 1D-only stays by design.
- **Highlighter (#293)** — opt-in `RegexMode` (patterns vs literal terms); invalid patterns fall back to plain.
- **Grid (#250)** — opt-in `Responsive` breakpoint columns (1→2→`Columns` at sm/lg) using purge-safe static utility strings; off by default.

`FeatureBatchTests` (9, green) + core build ✅.

Closes #291, closes #293, closes #250.

> Bundled the easy items; the remainder (Pagination, Filter, Drawer, asChild, build-pipeline, animations) is intentionally out of scope here.