### PR TITLE
feat: finish audit backlog — Pagination/Button/Heading/Code/Filter/Sparkline/Statistic/Gauge (9 issues)

### DIFF
--- a/src/Lumeo.DataGrid/UI/Filter/FilterBar.razor
+++ b/src/Lumeo.DataGrid/UI/Filter/FilterBar.razor
@@ -2,9 +2,18 @@
 
 <div class="@($"space-y-4 {Class}".Trim())" @attributes="AdditionalAttributes">
     @ChildContent
-    @if (Pills != null)
+    @if ((Filters is not null && Filters.Count > 0) || Pills != null)
     {
         <div class="flex items-center gap-2 flex-wrap">
+            @if (Filters is not null)
+            {
+                @foreach (var f in Filters)
+                {
+                    var desc = f;
+                    <FilterPill Label="@desc.Field" Operator="@desc.Operator" Value="@(desc.Value ?? "")"
+                                OnDismiss="@(() => OnRemoveFilter.InvokeAsync(desc))" />
+                }
+            }
             @Pills
         </div>
     }
@@ -18,6 +27,20 @@
     [Parameter] public RenderFragment? ChildContent { get; set; }
     [Parameter] public RenderFragment? Pills { get; set; }
     [Parameter] public RenderFragment? Actions { get; set; }
+
+    /// <summary>
+    /// Data-driven filter model (#319): when supplied, the bar renders a dismissable
+    /// <see cref="FilterPill"/> per descriptor (Field / Operator / Value) and raises
+    /// <see cref="OnRemoveFilter"/> on dismiss. The <see cref="Pills"/> slot still
+    /// works and renders alongside, so this is purely additive.
+    /// </summary>
+    [Parameter] public IReadOnlyList<FilterDescriptor>? Filters { get; set; }
+    [Parameter] public EventCallback<FilterDescriptor> OnRemoveFilter { get; set; }
+
     [Parameter] public string? Class { get; set; }
     [Parameter(CaptureUnmatchedValues = true)] public Dictionary<string, object>? AdditionalAttributes { get; set; }
+
+    /// <summary>A single active filter: a field, an optional comparison operator
+    /// (e.g. "=", "&gt;", "contains"), and a display value.</summary>
+    public record FilterDescriptor(string Field, string? Operator = null, string? Value = null);
 }

--- a/src/Lumeo.DataGrid/UI/Filter/FilterPill.razor
+++ b/src/Lumeo.DataGrid/UI/Filter/FilterPill.razor
@@ -1,7 +1,7 @@
 @namespace Lumeo
 
 <Badge Variant="Badge.BadgeVariant.Secondary" Class="@($"flex items-center gap-1 pl-2 pr-1 {Class}".Trim())" @attributes="AdditionalAttributes">
-    @Label: @Value
+    @DisplayText
     <button type="button" class="ml-1 rounded-full hover:bg-muted p-0.5 focus-visible:outline-none focus-visible:ring-[1.5px] focus-visible:ring-ring focus-visible:ring-offset-1" aria-label="@($"Remove {Label} filter")" @onclick="OnDismiss">
         <Blazicon Svg="Lucide.X" class="h-3 w-3" />
     </button>
@@ -9,8 +9,13 @@
 
 @code {
     [Parameter] public string Label { get; set; } = "";
+    /// <summary>Optional comparison operator shown between Label and Value
+    /// (e.g. "=", "&gt;", "contains"). When null the pill reads "Label: Value". (#319)</summary>
+    [Parameter] public string? Operator { get; set; }
     [Parameter] public string Value { get; set; } = "";
     [Parameter] public EventCallback OnDismiss { get; set; }
     [Parameter] public string? Class { get; set; }
     [Parameter(CaptureUnmatchedValues = true)] public Dictionary<string, object>? AdditionalAttributes { get; set; }
+
+    private string DisplayText => string.IsNullOrEmpty(Operator) ? $"{Label}: {Value}" : $"{Label} {Operator} {Value}";
 }

--- a/src/Lumeo/UI/Button/Button.razor
+++ b/src/Lumeo/UI/Button/Button.razor
@@ -1,36 +1,55 @@
 @namespace Lumeo
 @inject Lumeo.Services.IComponentInteropService Interop
 
-<button @ref="_el" type="@TypeAttr" class="@CssClass" disabled="@(IsLoading || Disabled)" @attributes="AdditionalAttributes" @onclick="OnClick" @onclick:stopPropagation="StopPropagation" @onclick:preventDefault="PreventDefault">
-    @if (IsLoading)
-    {
-        <Spinner Class="h-4 w-4" />
-        @if (LoadingText != null)
+@{
+    // Shared inner content so the <button> and <a> render paths stay identical.
+    RenderFragment inner = @<text>
+        @if (IsLoading)
         {
-            <span>@LoadingText</span>
+            <Spinner Class="h-4 w-4" />
+            @if (LoadingText != null)
+            {
+                <span>@LoadingText</span>
+            }
+            else
+            {
+                @ChildContent
+            }
+            @if (RightIcon != null)
+            {
+                @RightIcon
+            }
         }
         else
         {
+            @if (LeftIcon != null)
+            {
+                @LeftIcon
+            }
             @ChildContent
+            @if (RightIcon != null)
+            {
+                @RightIcon
+            }
         }
-        @if (RightIcon != null)
-        {
-            @RightIcon
-        }
-    }
-    else
-    {
-        @if (LeftIcon != null)
-        {
-            @LeftIcon
-        }
-        @ChildContent
-        @if (RightIcon != null)
-        {
-            @RightIcon
-        }
-    }
-</button>
+    </text>;
+}
+@if (Href is not null)
+{
+    @* Link-button (#269): polymorphic render as <a> for the common "link styled
+       as a button" case. <a> can't be natively disabled, so a disabled/loading
+       link gets aria-disabled + pointer-events-none/opacity directly (the
+       `disabled:` utility variant only targets a real :disabled element). *@
+    <a @ref="_el" href="@Href" class="@LinkCssClass"
+       aria-disabled="@((IsLoading || Disabled) ? "true" : null)"
+       tabindex="@((IsLoading || Disabled) ? "-1" : null)"
+       @attributes="AdditionalAttributes" @onclick="OnClick"
+       @onclick:stopPropagation="StopPropagation" @onclick:preventDefault="PreventDefault">@inner</a>
+}
+else
+{
+    <button @ref="_el" type="@TypeAttr" class="@CssClass" disabled="@(IsLoading || Disabled)" @attributes="AdditionalAttributes" @onclick="OnClick" @onclick:stopPropagation="StopPropagation" @onclick:preventDefault="PreventDefault">@inner</button>
+}
 
 @code {
     [Parameter] public RenderFragment? ChildContent { get; set; }
@@ -51,6 +70,16 @@
     [Parameter] public bool Disabled { get; set; }
     [Parameter] public bool IsLoading { get; set; }
     [Parameter] public string? LoadingText { get; set; }
+
+    /// <summary>
+    /// When set, the button renders as an <c>&lt;a href&gt;</c> styled exactly like
+    /// a button — the Blazor-idiomatic polymorphism for the common "link that
+    /// looks like a button" case (#269). All visual props (Variant/Size/icons)
+    /// still apply; <see cref="Disabled"/>/<see cref="IsLoading"/> map to
+    /// <c>aria-disabled</c> + non-interactive styling since a link can't be
+    /// natively disabled. Leave null for a normal <c>&lt;button&gt;</c>.
+    /// </summary>
+    [Parameter] public string? Href { get; set; }
 
     /// <summary>HTML button type. Defaults to <see cref="ButtonType.Button"/>
     /// — explicitly NOT submit. The HTML spec says &lt;button&gt; inside
@@ -94,6 +123,10 @@
         Cx.When(IsLoading, "pointer-events-none opacity-70"),
         Cx.When(FullWidth, "w-full"),
         Class);
+
+    // Link variant can't use the `disabled:` utilities (no :disabled state on
+    // <a>), so fold the inactive styling in directly.
+    private string LinkCssClass => Cx.Merge(CssClass, Cx.When(IsLoading || Disabled, "pointer-events-none opacity-50"));
 
     private const string BaseClasses = "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-[1.5px] focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50";
 

--- a/src/Lumeo/UI/Code/Code.razor
+++ b/src/Lumeo/UI/Code/Code.razor
@@ -1,13 +1,50 @@
 @namespace Lumeo
 
-<code class="@CssClass" @attributes="AdditionalAttributes">@ChildContent</code>
+<code class="@CssClass" data-language="@Language" @attributes="AdditionalAttributes">@Body</code>
 
 @code {
     [Parameter] public string Variant { get; set; } = "inline";
     [Parameter] public string? Size { get; set; }
+
+    /// <summary>
+    /// Raw source to render (block variant). When set together with
+    /// <see cref="Highlighter"/> the output is syntax-highlighted; otherwise the
+    /// source is rendered as escaped plain text. Falls back to
+    /// <see cref="ChildContent"/> when null. (#196)
+    /// </summary>
+    [Parameter] public string? Source { get; set; }
+
+    /// <summary>Language hint (e.g. "csharp", "ts") — emitted as <c>data-language</c>
+    /// and passed to <see cref="Highlighter"/>.</summary>
+    [Parameter] public string? Language { get; set; }
+
+    /// <summary>
+    /// Pluggable syntax highlighter: <c>(code, language) =&gt; safe HTML</c>. Plug in
+    /// Prism / Shiki / highlight.js (or a server-side highlighter). The delegate
+    /// MUST return SAFE HTML — escape untrusted source. Core ships no built-in
+    /// highlighter on purpose (dependency-free), mirroring
+    /// <c>StreamingText.MarkdownRenderer</c>. Ignored unless <see cref="Source"/> is set.
+    /// </summary>
+    [Parameter] public Func<string, string?, MarkupString>? Highlighter { get; set; }
+
     [Parameter] public RenderFragment? ChildContent { get; set; }
     [Parameter] public string? Class { get; set; }
     [Parameter(CaptureUnmatchedValues = true)] public Dictionary<string, object>? AdditionalAttributes { get; set; }
+
+    private RenderFragment Body => builder =>
+    {
+        if (Source is not null)
+        {
+            if (Highlighter is not null)
+                builder.AddContent(0, Highlighter(Source, Language)); // consumer-sanitized HTML
+            else
+                builder.AddContent(0, Source);                        // escaped plain text
+        }
+        else
+        {
+            builder.AddContent(0, ChildContent);
+        }
+    };
 
     private string BaseClasses => Variant switch
     {

--- a/src/Lumeo/UI/Gauge/Gauge.razor
+++ b/src/Lumeo/UI/Gauge/Gauge.razor
@@ -22,7 +22,7 @@
         @if (ShowValue)
         {
             <span class="text-xs text-foreground font-medium mt-1 block text-center"
-                  style="width: @(Size)px">@DisplayValue</span>
+                  style="width: @(Size)px">@LabelBody</span>
         }
     </div>
 }
@@ -69,7 +69,7 @@ else
         @if (ShowValue)
         {
             <span class="absolute inset-0 flex items-center justify-center text-foreground font-medium pointer-events-none"
-                  style="font-size: @(LabelFontSize)px; @LabelOffset">@DisplayValue</span>
+                  style="font-size: @(LabelFontSize)px; @LabelOffset">@LabelBody</span>
         }
     </div>
 }
@@ -82,12 +82,24 @@ else
     [Parameter] public int Size { get; set; } = 120;
     [Parameter] public int StrokeWidth { get; set; } = 8;
     [Parameter] public string? Label { get; set; }
+    /// <summary>
+    /// Custom center/label content — overrides the default text. Drop in a
+    /// <c>&lt;NumberTicker&gt;</c> (Lumeo.Motion) here for an animated value, instead
+    /// of duplicating count-up animation in core. (#277)
+    /// </summary>
+    [Parameter] public RenderFragment? LabelContent { get; set; }
     [Parameter] public bool ShowValue { get; set; } = true;
     [Parameter] public string Color { get; set; } = "primary";
     [Parameter] public string TrackColor { get; set; } = "muted";
     [Parameter] public IReadOnlyList<GaugeThreshold>? Thresholds { get; set; }
     [Parameter] public string? Class { get; set; }
     [Parameter(CaptureUnmatchedValues = true)] public Dictionary<string, object>? AdditionalAttributes { get; set; }
+
+    private RenderFragment LabelBody => builder =>
+    {
+        if (LabelContent is not null) builder.AddContent(0, LabelContent);
+        else builder.AddContent(1, DisplayValue);
+    };
 
     private double Percentage => Max > Min
         ? Math.Clamp((Value - Min) / (Max - Min) * 100.0, 0.0, 100.0)

--- a/src/Lumeo/UI/Heading/Heading.razor
+++ b/src/Lumeo/UI/Heading/Heading.razor
@@ -5,30 +5,49 @@
    silently. The clamp drives both the rendered tag AND the visual size
    below, so the two stay consistent (a Level=0 input doesn't render as
    an h6 with h1 sizing). *@
-@switch (ClampedLevel)
+@if (!string.IsNullOrEmpty(As))
 {
-    case 1:
-        <h1 class="@CssClass" @attributes="AdditionalAttributes">@ChildContent</h1>
-        break;
-    case 2:
-        <h2 class="@CssClass" @attributes="AdditionalAttributes">@ChildContent</h2>
-        break;
-    case 3:
-        <h3 class="@CssClass" @attributes="AdditionalAttributes">@ChildContent</h3>
-        break;
-    case 4:
-        <h4 class="@CssClass" @attributes="AdditionalAttributes">@ChildContent</h4>
-        break;
-    case 5:
-        <h5 class="@CssClass" @attributes="AdditionalAttributes">@ChildContent</h5>
-        break;
-    default:
-        <h6 class="@CssClass" @attributes="AdditionalAttributes">@ChildContent</h6>
-        break;
+    @* asChild-style polymorphism (#295): render the heading's visual styles on a
+       caller-chosen element (e.g. a hero title that shouldn't be a document
+       heading). Visual only — add role="heading"/aria-level via attributes if you
+       want heading semantics on a non-h* element. *@
+    @RenderAs
+}
+else
+{
+    switch (ClampedLevel)
+    {
+        case 1:
+            <h1 class="@CssClass" @attributes="AdditionalAttributes">@ChildContent</h1>
+            break;
+        case 2:
+            <h2 class="@CssClass" @attributes="AdditionalAttributes">@ChildContent</h2>
+            break;
+        case 3:
+            <h3 class="@CssClass" @attributes="AdditionalAttributes">@ChildContent</h3>
+            break;
+        case 4:
+            <h4 class="@CssClass" @attributes="AdditionalAttributes">@ChildContent</h4>
+            break;
+        case 5:
+            <h5 class="@CssClass" @attributes="AdditionalAttributes">@ChildContent</h5>
+            break;
+        default:
+            <h6 class="@CssClass" @attributes="AdditionalAttributes">@ChildContent</h6>
+            break;
+    }
 }
 
 @code {
     [Parameter] public int Level { get; set; } = 2;
+    /// <summary>
+    /// Render the heading's visual styling on this element tag instead of the
+    /// semantic <c>h{Level}</c> (e.g. <c>"p"</c>, <c>"div"</c>, <c>"span"</c>) —
+    /// the asChild-style escape hatch for "looks like a heading, isn't one in the
+    /// document outline". Visual only; supply role/aria-level via attributes for
+    /// heading semantics. Null = the normal <c>h{Level}</c>. (#295)
+    /// </summary>
+    [Parameter] public string? As { get; set; }
     [Parameter] public string? Size { get; set; }
     [Parameter] public string? Weight { get; set; }
     [Parameter] public string? Tracking { get; set; }
@@ -37,6 +56,16 @@
     [Parameter(CaptureUnmatchedValues = true)] public Dictionary<string, object>? AdditionalAttributes { get; set; }
 
     private int ClampedLevel => Math.Clamp(Level, 1, 6);
+
+    private RenderFragment RenderAs => builder =>
+    {
+        builder.OpenElement(0, As!);
+        builder.AddAttribute(1, "class", CssClass);
+        if (AdditionalAttributes is not null)
+            builder.AddMultipleAttributes(2, AdditionalAttributes);
+        builder.AddContent(3, ChildContent);
+        builder.CloseElement();
+    };
 
     private string ResolvedSize => Size ?? ClampedLevel switch
     {

--- a/src/Lumeo/UI/Pagination/Pagination.razor
+++ b/src/Lumeo/UI/Pagination/Pagination.razor
@@ -1,13 +1,114 @@
 @namespace Lumeo
 
 <nav role="navigation" aria-label="pagination" class="@CssClass" @attributes="AdditionalAttributes">
-    @ChildContent
+    @if (IsDataDriven)
+    {
+        <ul class="flex flex-row items-center gap-1">
+            <li>
+                <button type="button" class="@NavButtonClass" aria-label="Go to previous page"
+                        disabled="@(CurrentPage <= 1)" @onclick="() => GoTo(CurrentPage - 1)">
+                    <Blazicon Svg="Lucide.ChevronLeft" class="h-4 w-4" />
+                </button>
+            </li>
+            @foreach (var item in PageSequence)
+            {
+                @if (item == EllipsisMarker)
+                {
+                    <PaginationEllipsis />
+                }
+                else
+                {
+                    var page = item;
+                    var pageLabel = $"Go to page {page}";
+                    <PaginationItem IsActive="@(page == CurrentPage)"
+                                    aria-label="@pageLabel"
+                                    OnClick="@(() => GoTo(page))">@(page)</PaginationItem>
+                }
+            }
+            <li>
+                <button type="button" class="@NavButtonClass" aria-label="Go to next page"
+                        disabled="@(CurrentPage >= EffectiveTotalPages)" @onclick="() => GoTo(CurrentPage + 1)">
+                    <Blazicon Svg="Lucide.ChevronRight" class="h-4 w-4" />
+                </button>
+            </li>
+        </ul>
+    }
+    else
+    {
+        @ChildContent
+    }
 </nav>
 
 @code {
     [Parameter] public RenderFragment? ChildContent { get; set; }
+
+    // --- Data-driven mode (#210) — opt-in. Supply Page plus either TotalPages
+    // or TotalItems (+ PageSize); the pager then renders prev/next, boundary and
+    // sibling page buttons with ellipsis automatically. When ChildContent is set
+    // the component stays fully compositional (unchanged). ---
+    [Parameter] public int? Page { get; set; }
+    [Parameter] public EventCallback<int> PageChanged { get; set; }
+    [Parameter] public int? TotalPages { get; set; }
+    [Parameter] public int? TotalItems { get; set; }
+    [Parameter] public int PageSize { get; set; } = 10;
+    /// <summary>Pages shown on each side of the current page (default 1).</summary>
+    [Parameter] public int SiblingCount { get; set; } = 1;
+    /// <summary>Pages always shown at the very start/end (default 1).</summary>
+    [Parameter] public int BoundaryCount { get; set; } = 1;
+
     [Parameter] public string? Class { get; set; }
     [Parameter(CaptureUnmatchedValues = true)] public Dictionary<string, object>? AdditionalAttributes { get; set; }
 
+    private const int EllipsisMarker = -1;
+
     private string CssClass => Cx.Merge("mx-auto flex w-full justify-center", Class);
+
+    private int EffectiveTotalPages =>
+        TotalPages ?? (TotalItems is int t && PageSize > 0 ? Math.Max(1, (int)Math.Ceiling(t / (double)PageSize)) : 0);
+
+    private bool IsDataDriven => ChildContent is null && Page is not null && EffectiveTotalPages > 0;
+
+    private int CurrentPage => Math.Clamp(Page ?? 1, 1, Math.Max(1, EffectiveTotalPages));
+
+    private string NavButtonClass =>
+        "inline-flex h-11 w-11 sm:h-9 sm:w-9 items-center justify-center rounded-md text-sm font-medium cursor-pointer transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50";
+
+    private async Task GoTo(int page)
+    {
+        var clamped = Math.Clamp(page, 1, EffectiveTotalPages);
+        if (clamped != CurrentPage)
+            await PageChanged.InvokeAsync(clamped);
+    }
+
+    // Page sequence with ellipsis markers (-1). Always shows first/last + the
+    // boundary band + a sibling band around the current page; gaps collapse to
+    // a single ellipsis.
+    private IReadOnlyList<int> PageSequence
+    {
+        get
+        {
+            int total = EffectiveTotalPages;
+            var result = new List<int>();
+            if (total <= 0) return result;
+
+            int current = CurrentPage;
+            int boundary = Math.Max(0, BoundaryCount);
+            int sibling = Math.Max(0, SiblingCount);
+
+            var pages = new SortedSet<int> { 1, total, current };
+            for (int i = 1; i <= Math.Min(boundary, total); i++) pages.Add(i);
+            for (int i = Math.Max(total - boundary + 1, 1); i <= total; i++) pages.Add(i);
+            for (int i = current - sibling; i <= current + sibling; i++)
+                if (i >= 1 && i <= total) pages.Add(i);
+
+            int prev = 0;
+            foreach (var p in pages)
+            {
+                if (prev != 0 && p - prev > 1) result.Add(EllipsisMarker);
+                result.Add(p);
+                prev = p;
+            }
+            return result;
+        }
+    }
 }

--- a/src/Lumeo/UI/SparkCard/SparkCard.razor
+++ b/src/Lumeo/UI/SparkCard/SparkCard.razor
@@ -19,12 +19,14 @@
         {
             @ChildContent
         }
-        else if (Data is not null)
+        else if (_chartValues is not null)
         {
             @* #276: delegate to the full Sparkline so the inline chart is as
                capable (Type / Area / per-point tooltips) as the standalone
-               component, instead of a hardcoded less-capable polyline. *@
-            <Sparkline Values="@Data" Type="@Type" ShowArea="@ShowArea" ShowLast="@ShowLast"
+               component, instead of a hardcoded less-capable polyline. A single
+               data point can't form a line, so the chart is only rendered for
+               two or more points (matching the pre-#276 contract). *@
+            <Sparkline Values="@_chartValues" Type="@Type" ShowArea="@ShowArea" ShowLast="@ShowLast"
                        ShowTooltips="@ShowTooltips" Color="@SparkColor" Height="@SparkHeight"
                        Class="h-full w-full" aria-hidden="true" />
         }
@@ -52,6 +54,16 @@
 
     [Parameter] public string? Class { get; set; }
     [Parameter(CaptureUnmatchedValues = true)] public Dictionary<string, object>? AdditionalAttributes { get; set; }
+
+    // Materialized once per parameter set: the inline chart needs at least two
+    // points to draw a line, so anything shorter renders nothing (no stray svg).
+    private IReadOnlyList<double>? _chartValues;
+
+    protected override void OnParametersSet()
+    {
+        var list = Data as IReadOnlyList<double> ?? Data?.ToList();
+        _chartValues = list is { Count: >= 2 } ? list : null;
+    }
 
     private int SparkHeight => Size switch
     {

--- a/src/Lumeo/UI/SparkCard/SparkCard.razor
+++ b/src/Lumeo/UI/SparkCard/SparkCard.razor
@@ -19,17 +19,14 @@
         {
             @ChildContent
         }
-        else if (Data is not null && _points is not null)
+        else if (Data is not null)
         {
-            <svg viewBox="0 0 100 30" preserveAspectRatio="none" class="h-full w-full overflow-visible" aria-hidden="true">
-                <polyline points="@_points"
-                          fill="none"
-                          stroke="var(--color-primary, currentColor)"
-                          stroke-width="1.5"
-                          stroke-linecap="round"
-                          stroke-linejoin="round"
-                          vector-effect="non-scaling-stroke" />
-            </svg>
+            @* #276: delegate to the full Sparkline so the inline chart is as
+               capable (Type / Area / per-point tooltips) as the standalone
+               component, instead of a hardcoded less-capable polyline. *@
+            <Sparkline Values="@Data" Type="@Type" ShowArea="@ShowArea" ShowLast="@ShowLast"
+                       ShowTooltips="@ShowTooltips" Color="@SparkColor" Height="@SparkHeight"
+                       Class="h-full w-full" aria-hidden="true" />
         }
     </div>
 </div>
@@ -41,42 +38,27 @@
     [Parameter] public RenderFragment? ChildContent { get; set; }
     [Parameter] public Lumeo.Size Size { get; set; } = Lumeo.Size.Md;
     [Parameter] public SparkCardVariant Variant { get; set; } = SparkCardVariant.Default;
+
+    /// <summary>Inline sparkline shape (Line / Area / Bars). (#276)</summary>
+    [Parameter] public Sparkline.SparkType Type { get; set; } = Sparkline.SparkType.Line;
+    /// <summary>Fill the area under a line sparkline. (#276)</summary>
+    [Parameter] public bool ShowArea { get; set; }
+    /// <summary>Mark the most recent point. (#276)</summary>
+    [Parameter] public bool ShowLast { get; set; }
+    /// <summary>Per-point markers + hover tooltips on the inline sparkline. (#276)</summary>
+    [Parameter] public bool ShowTooltips { get; set; }
+    /// <summary>Override the sparkline color (CSS color / var). (#276)</summary>
+    [Parameter] public string? SparkColor { get; set; }
+
     [Parameter] public string? Class { get; set; }
     [Parameter(CaptureUnmatchedValues = true)] public Dictionary<string, object>? AdditionalAttributes { get; set; }
 
-    private string? _points;
-
-    protected override void OnParametersSet()
+    private int SparkHeight => Size switch
     {
-        _points = ComputePoints(Data);
-    }
-
-    private static string? ComputePoints(IEnumerable<double>? data)
-    {
-        if (data is null) return null;
-        var list = data.ToList();
-        if (list.Count < 2) return null;
-
-        var min = list.Min();
-        var max = list.Max();
-        var range = max - min;
-        if (range == 0) range = 1;
-
-        var sb = new System.Text.StringBuilder();
-        var n = list.Count;
-        for (int i = 0; i < n; i++)
-        {
-            var x = (double)i / (n - 1) * 100.0;
-            // Invert Y so higher values are visually higher (SVG y goes down)
-            var yNorm = (list[i] - min) / range;
-            var y = 28.0 - yNorm * 26.0 + 1.0; // padding 1 top/bottom, area height 26
-            if (i > 0) sb.Append(' ');
-            sb.Append(x.ToString("0.##", System.Globalization.CultureInfo.InvariantCulture));
-            sb.Append(',');
-            sb.Append(y.ToString("0.##", System.Globalization.CultureInfo.InvariantCulture));
-        }
-        return sb.ToString();
-    }
+        Lumeo.Size.Sm => 32,
+        Lumeo.Size.Lg => 56,
+        _ => 40
+    };
 
     private string SizePadding => Size switch
     {

--- a/src/Lumeo/UI/Sparkline/Sparkline.razor
+++ b/src/Lumeo/UI/Sparkline/Sparkline.razor
@@ -19,6 +19,12 @@
     [Parameter] public SparkType Type { get; set; } = SparkType.Line;
     [Parameter] public bool ShowArea { get; set; }
     [Parameter] public bool ShowLast { get; set; }
+    /// <summary>
+    /// Render a marker dot at every data point with a native SVG <c>&lt;title&gt;</c>
+    /// (hover tooltip showing the value) — point highlight + tooltips with no JS.
+    /// Off by default. (#275)
+    /// </summary>
+    [Parameter] public bool ShowTooltips { get; set; }
     [Parameter] public double StrokeWidth { get; set; } = 1.5;
     [Parameter] public string? AriaLabel { get; set; } = "Trend";
     [Parameter] public string? Class { get; set; }
@@ -127,6 +133,21 @@
             }
             var r = (Type == SparkType.Area || ShowArea) ? 2.75 : 2.25;
             sb.Append($"<circle cx=\"{F(lx)}\" cy=\"{F(ly)}\" r=\"{F(r)}\" fill=\"{color}\" />");
+        }
+
+        // Per-point markers + native <title> hover tooltips (#275). Opt-in.
+        if (ShowTooltips)
+        {
+            var n = list.Count;
+            var slot = 100.0 / n;
+            for (int i = 0; i < n; i++)
+            {
+                var cx = Type == SparkType.Bars
+                    ? i * slot + slot / 2.0
+                    : (n == 1 ? 50.0 : (double)i / (n - 1) * 100.0);
+                var cy = ScaleY(list[i]);
+                sb.Append($"<circle cx=\"{F(cx)}\" cy=\"{F(cy)}\" r=\"1.75\" fill=\"{color}\"><title>{F(list[i])}</title></circle>");
+            }
         }
 
         return sb.ToString();

--- a/src/Lumeo/UI/Statistic/Statistic.razor
+++ b/src/Lumeo/UI/Statistic/Statistic.razor
@@ -10,7 +10,7 @@
         {
             <span class="@ValueClass">@Prefix</span>
         }
-        <span class="@ValueClass">@FormattedValue</span>
+        <span class="@ValueClass">@ValueBody</span>
         @if (Suffix is not null)
         {
             <span class="@SuffixClass">@Suffix</span>
@@ -38,6 +38,12 @@
 @code {
     [Parameter] public string? Title { get; set; }
     [Parameter] public string? Value { get; set; }
+    /// <summary>
+    /// Custom value content — overrides <see cref="Value"/>. Drop in a
+    /// <c>&lt;NumberTicker&gt;</c> (Lumeo.Motion) here for an animated count-up,
+    /// rather than duplicating animation logic in core. (#273)
+    /// </summary>
+    [Parameter] public RenderFragment? ValueContent { get; set; }
     [Parameter] public RenderFragment? Prefix { get; set; }
     [Parameter] public RenderFragment? Suffix { get; set; }
     [Parameter] public int? Precision { get; set; }
@@ -57,6 +63,12 @@
     [Parameter] public StatisticVariant Variant { get; set; } = StatisticVariant.Default;
     [Parameter] public string? Class { get; set; }
     [Parameter(CaptureUnmatchedValues = true)] public Dictionary<string, object>? AdditionalAttributes { get; set; }
+
+    private RenderFragment ValueBody => builder =>
+    {
+        if (ValueContent is not null) builder.AddContent(0, ValueContent);
+        else builder.AddContent(1, FormattedValue);
+    };
 
     private string CssClass => Cx.Merge(VariantClass, Class);
 

--- a/tests/Lumeo.Tests/Components/Features/FilterModelTests.cs
+++ b/tests/Lumeo.Tests/Components/Features/FilterModelTests.cs
@@ -1,0 +1,56 @@
+using System.Collections.Generic;
+using Bunit;
+using Microsoft.AspNetCore.Components;
+using Xunit;
+using Lumeo.Tests.Helpers;
+
+namespace Lumeo.Tests.Components.Features;
+
+/// <summary>
+/// #319 — FilterBar/FilterPill gain a data-driven operator/value model
+/// (FilterDescriptor: Field / Operator / Value) with auto-rendered, dismissable pills.
+/// </summary>
+public class FilterModelTests
+{
+    private static BunitContext NewCtx()
+    {
+        var ctx = new BunitContext();
+        ctx.AddLumeoServices();
+        return ctx;
+    }
+
+    [Fact]
+    public void FilterBar_renders_descriptors_and_raises_remove()
+    {
+        using var ctx = NewCtx();
+        Lumeo.FilterBar.FilterDescriptor? removed = null;
+        var filters = new List<Lumeo.FilterBar.FilterDescriptor>
+        {
+            new("Status", "=", "Active"),
+            new("Type", "=", "User"),
+        };
+
+        var cut = ctx.Render<Lumeo.FilterBar>(p => p
+            .Add(x => x.Filters, filters)
+            .Add(x => x.OnRemoveFilter,
+                EventCallback.Factory.Create<Lumeo.FilterBar.FilterDescriptor>(this, d => removed = d)));
+
+        Assert.Contains("Status = Active", cut.Markup);
+        Assert.Contains("Type = User", cut.Markup);
+
+        // Each pill has a single dismiss button; removing the first raises the descriptor.
+        cut.FindAll("button")[0].Click();
+        Assert.Equal("Status", removed?.Field);
+    }
+
+    [Fact]
+    public void FilterPill_without_operator_uses_label_colon_value()
+    {
+        using var ctx = NewCtx();
+        var cut = ctx.Render<Lumeo.FilterPill>(p => p
+            .Add(x => x.Label, "Tag")
+            .Add(x => x.Value, "urgent"));
+
+        Assert.Contains("Tag: urgent", cut.Markup);
+    }
+}

--- a/tests/Lumeo.Tests/Components/Features/GoalBatch2Tests.cs
+++ b/tests/Lumeo.Tests/Components/Features/GoalBatch2Tests.cs
@@ -1,0 +1,81 @@
+using System;
+using Bunit;
+using Microsoft.AspNetCore.Components;
+using Xunit;
+using Lumeo.Tests.Helpers;
+
+namespace Lumeo.Tests.Components.Features;
+
+/// <summary>
+/// Goal batch 2:
+///   #196 Code — pluggable Highlighter + Source/Language (syntax-highlighting support).
+///   #275 Sparkline — opt-in per-point markers with native &lt;title&gt; tooltips.
+///   #276 SparkCard — inline chart delegates to the full Sparkline.
+/// </summary>
+public class GoalBatch2Tests
+{
+    private static BunitContext NewCtx()
+    {
+        var ctx = new BunitContext();
+        ctx.AddLumeoServices();
+        return ctx;
+    }
+
+    [Fact]
+    public void Code_uses_highlighter_hook_for_source()
+    {
+        using var ctx = NewCtx();
+        var cut = ctx.Render<Lumeo.Code>(p => p
+            .Add(x => x.Source, "let x = 1;")
+            .Add(x => x.Language, "ts")
+            .Add(x => x.Highlighter, (Func<string, string?, MarkupString>)((c, l) => (MarkupString)$"<span class=\"kw\">{c}</span>")));
+
+        Assert.Contains("<span class=\"kw\">let x = 1;</span>", cut.Markup);
+        Assert.Equal("ts", cut.Find("code").GetAttribute("data-language"));
+    }
+
+    [Fact]
+    public void Code_without_highlighter_escapes_source()
+    {
+        using var ctx = NewCtx();
+        var cut = ctx.Render<Lumeo.Code>(p => p.Add(x => x.Source, "<script>alert(1)</script>"));
+
+        Assert.DoesNotContain("<script>", cut.Markup); // escaped, not injected
+        Assert.Contains("alert(1)", cut.Markup);
+    }
+
+    [Fact]
+    public void Sparkline_tooltips_emit_titles_per_point()
+    {
+        using var ctx = NewCtx();
+        var cut = ctx.Render<Lumeo.Sparkline>(p => p
+            .Add(x => x.Values, new double[] { 3, 1, 4 })
+            .Add(x => x.ShowTooltips, true));
+
+        Assert.Contains("<title>", cut.Markup);
+        Assert.Contains("<title>3</title>", cut.Markup);
+        Assert.Contains("<title>4</title>", cut.Markup);
+    }
+
+    [Fact]
+    public void Sparkline_no_tooltips_by_default()
+    {
+        using var ctx = NewCtx();
+        var cut = ctx.Render<Lumeo.Sparkline>(p => p.Add(x => x.Values, new double[] { 3, 1, 4 }));
+        Assert.DoesNotContain("<title>", cut.Markup);
+    }
+
+    [Fact]
+    public void SparkCard_renders_delegated_sparkline()
+    {
+        using var ctx = NewCtx();
+        var cut = ctx.Render<Lumeo.SparkCard>(p => p
+            .Add(x => x.Label, "Revenue")
+            .Add(x => x.Data, new double[] { 1, 2, 3, 2, 5 })
+            .Add(x => x.ShowTooltips, true));
+
+        // Delegated <Sparkline> renders an svg; tooltips flow through.
+        Assert.NotEmpty(cut.FindAll("svg"));
+        Assert.Contains("<title>", cut.Markup);
+    }
+}

--- a/tests/Lumeo.Tests/Components/Features/GoalBatch3Tests.cs
+++ b/tests/Lumeo.Tests/Components/Features/GoalBatch3Tests.cs
@@ -1,0 +1,59 @@
+using Bunit;
+using Xunit;
+using Lumeo.Tests.Helpers;
+
+namespace Lumeo.Tests.Components.Features;
+
+/// <summary>
+/// Goal batch 3 — composable value/label slots so animated counts (e.g. a
+/// NumberTicker from Lumeo.Motion) drop in without duplicating animation in core:
+///   #273 Statistic.ValueContent · #277 Gauge.LabelContent.
+/// </summary>
+public class GoalBatch3Tests
+{
+    private static BunitContext NewCtx()
+    {
+        var ctx = new BunitContext();
+        ctx.AddLumeoServices();
+        return ctx;
+    }
+
+    [Fact]
+    public void Statistic_value_content_overrides_value()
+    {
+        using var ctx = NewCtx();
+        var cut = ctx.Render<Lumeo.Statistic>(p => p
+            .Add(x => x.Value, "999")
+            .Add(x => x.ValueContent, b => b.AddContent(0, "CUSTOM")));
+
+        Assert.Contains("CUSTOM", cut.Markup);
+        Assert.DoesNotContain("999", cut.Markup);
+    }
+
+    [Fact]
+    public void Statistic_falls_back_to_value()
+    {
+        using var ctx = NewCtx();
+        var cut = ctx.Render<Lumeo.Statistic>(p => p.Add(x => x.Value, "42"));
+        Assert.Contains("42", cut.Markup);
+    }
+
+    [Fact]
+    public void Gauge_label_content_overrides_default()
+    {
+        using var ctx = NewCtx();
+        var cut = ctx.Render<Lumeo.Gauge>(p => p
+            .Add(x => x.Value, 50)
+            .Add(x => x.LabelContent, b => b.AddContent(0, "TICK")));
+
+        Assert.Contains("TICK", cut.Markup);
+    }
+
+    [Fact]
+    public void Gauge_default_shows_percentage_label()
+    {
+        using var ctx = NewCtx();
+        var cut = ctx.Render<Lumeo.Gauge>(p => p.Add(x => x.Value, 50));
+        Assert.Contains("50%", cut.Markup);
+    }
+}

--- a/tests/Lumeo.Tests/Components/Features/GoalBatchTests.cs
+++ b/tests/Lumeo.Tests/Components/Features/GoalBatchTests.cs
@@ -1,0 +1,124 @@
+using System;
+using System.Linq;
+using Bunit;
+using Microsoft.AspNetCore.Components;
+using Xunit;
+using Lumeo.Tests.Helpers;
+
+namespace Lumeo.Tests.Components.Features;
+
+/// <summary>
+/// Goal batch:
+///   #210 Pagination — data-driven pager mode (Page/TotalPages, ellipsis, prev/next).
+///   #269 Button — Href renders a link styled as a button.
+///   #295 Heading — As renders the heading styling on a chosen element.
+/// </summary>
+public class GoalBatchTests
+{
+    private static BunitContext NewCtx()
+    {
+        var ctx = new BunitContext();
+        ctx.AddLumeoServices();
+        return ctx;
+    }
+
+    [Fact]
+    public void Pagination_data_driven_renders_pages_with_active_and_ellipsis()
+    {
+        using var ctx = NewCtx();
+        var cut = ctx.Render<Lumeo.Pagination>(p => p
+            .Add(x => x.Page, 5)
+            .Add(x => x.TotalPages, 10));
+
+        string[] pageTexts = cut.FindAll("button")
+            .Select(b => b.TextContent.Trim())
+            .Where(t => t.Length > 0)
+            .ToArray();
+
+        // boundary=1, sibling=1 around page 5 -> 1, 4, 5, 6, 10
+        Assert.Contains("1", pageTexts);
+        Assert.Contains("4", pageTexts);
+        Assert.Contains("5", pageTexts);
+        Assert.Contains("6", pageTexts);
+        Assert.Contains("10", pageTexts);
+        Assert.DoesNotContain("2", pageTexts); // collapsed into an ellipsis
+
+        // current page is marked
+        Assert.Equal("5", cut.Find("[aria-current='page']").TextContent.Trim());
+    }
+
+    [Fact]
+    public void Pagination_computes_total_from_items_and_fires_page_changed()
+    {
+        using var ctx = NewCtx();
+        int? changed = null;
+        var cut = ctx.Render<Lumeo.Pagination>(p => p
+            .Add(x => x.Page, 1)
+            .Add(x => x.TotalItems, 95)   // /10 => 10 pages
+            .Add(x => x.PageSize, 10)
+            .Add(x => x.PageChanged, EventCallback.Factory.Create<int>(this, v => changed = v)));
+
+        var pageTen = cut.FindAll("button").First(b => b.TextContent.Trim() == "10");
+        pageTen.Click();
+        Assert.Equal(10, changed);
+    }
+
+    [Fact]
+    public void Button_with_href_renders_anchor_styled_as_button()
+    {
+        using var ctx = NewCtx();
+        var cut = ctx.Render<Lumeo.Button>(p => p
+            .Add(x => x.Href, "/go")
+            .AddChildContent("Link"));
+
+        var a = cut.Find("a");
+        Assert.Equal("/go", a.GetAttribute("href"));
+        Assert.Contains("bg-primary", a.GetAttribute("class")); // default variant styling
+        Assert.Empty(cut.FindAll("button"));
+    }
+
+    [Fact]
+    public void Button_without_href_stays_a_button()
+    {
+        using var ctx = NewCtx();
+        var cut = ctx.Render<Lumeo.Button>(p => p.AddChildContent("Click"));
+        Assert.NotNull(cut.Find("button"));
+        Assert.Empty(cut.FindAll("a"));
+    }
+
+    [Fact]
+    public void Button_disabled_href_is_aria_disabled_and_inert()
+    {
+        using var ctx = NewCtx();
+        var cut = ctx.Render<Lumeo.Button>(p => p
+            .Add(x => x.Href, "/go")
+            .Add(x => x.Disabled, true)
+            .AddChildContent("Link"));
+
+        var a = cut.Find("a");
+        Assert.Equal("true", a.GetAttribute("aria-disabled"));
+        Assert.Contains("pointer-events-none", a.GetAttribute("class"));
+    }
+
+    [Fact]
+    public void Heading_as_renders_chosen_element_with_heading_styles()
+    {
+        using var ctx = NewCtx();
+        var cut = ctx.Render<Lumeo.Heading>(p => p
+            .Add(x => x.As, "div")
+            .Add(x => x.Level, 2)
+            .AddChildContent("Title"));
+
+        var div = cut.Find("div");
+        Assert.Contains("text-3xl", div.GetAttribute("class")); // Level 2 size
+        Assert.Empty(cut.FindAll("h2"));
+    }
+
+    [Fact]
+    public void Heading_default_renders_semantic_heading()
+    {
+        using var ctx = NewCtx();
+        var cut = ctx.Render<Lumeo.Heading>(p => p.Add(x => x.Level, 2).AddChildContent("Title"));
+        Assert.NotNull(cut.Find("h2"));
+    }
+}


### PR DESCRIPTION
Finishes the remaining audit backlog the best way, bundled into **one** release (3.18.0). Resolves **9** issues — all additive/opt-in, 27 feature tests green.

**Features / modes**
- **#210 Pagination** — data-driven pager (Page/TotalPages or TotalItems+PageSize, sibling/boundary, ellipsis, prev/next) alongside the compositional API.
- **#269 Button** — `Href` renders a link styled as a button (Blazor-idiomatic asChild).
- **#295 Heading** — `As` renders heading styling on a chosen element.
- **#196 Code** — `Source`/`Language` + pluggable `Highlighter` hook (Prism/Shiki/highlight.js); no heavy built-in (mirrors `StreamingText.MarkdownRenderer`).
- **#319 FilterBar/FilterPill** — `FilterDescriptor` operator/value model + auto-rendered dismissable pills.
- **#275 Sparkline** — opt-in `ShowTooltips` (per-point markers + native `<title>`, no JS).
- **#276 SparkCard** — inline chart delegates to the full `<Sparkline>`.
- **#273 Statistic** / **#277 Gauge** — `ValueContent`/`LabelContent` slots so a `NumberTicker` composes in for animation (no core duplication).

Closes #210, closes #269, closes #295, closes #196, closes #319, closes #275, closes #276, closes #273, closes #277.

## Deliberately deferred (rushing them blind isn't "the best way")
- **#320** RichTextEditor TipTap extensions + **#218** Drawer snap-points — substantial JS/gesture work in satellites (need an npm/TipTap build + real-device testing).
- **#171** docs icon-pack lazy-load — docs-only reflection refactor.
- **#337** audit index tracks these.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Button component now supports rendering as hyperlinks with optional `Href` parameter
  * Pagination component adds data-driven mode with automatic page generation
  * Heading component introduces `As` parameter for flexible semantic element rendering
  * Code component now supports source code input with optional syntax highlighting
  * Gauge and Statistic components support custom label and value content
  * Sparkline adds tooltip support for data point hover information
  * FilterBar introduces data-driven filter model with dismissable filter pills

* **Tests**
  * Added comprehensive test coverage for new component features

<!-- end of auto-generated comment: release notes by coderabbit.ai -->