### PR TITLE
feat: Drawer snap points + velocity dismiss (#218) · RichTextEditor a11y (#320)

### DIFF
--- a/docs/Lumeo.Docs/Pages/Components/DrawerPage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/DrawerPage.razor
@@ -140,6 +140,41 @@
         </Drawer>
     </ComponentDemo>
 
+    <ComponentDemo Title="Snap points (touch)" Code="@_snapCode">
+        <Stack Gap="3">
+            <Lumeo.Text Size="sm" Color="muted">
+                Bottom drawer with snap points at 40% / 75% / 100%. On a touch device (or DevTools device emulation),
+                drag the handle to move between snaps; a quick flick down dismisses. On desktop it opens at the active
+                snap so you can still see the resting position. Active snap: <strong>@((int)(_snapPoints[_snapIndex] * 100))%</strong> (index @_snapIndex).
+            </Lumeo.Text>
+            <div>
+                <Drawer @bind-Open="_snapOpen">
+                    <DrawerTrigger>
+                        <Button Variant="Button.ButtonVariant.Outline">Open Snap Drawer</Button>
+                    </DrawerTrigger>
+                    <DrawerContent SnapPoints="_snapPoints" @bind-ActiveSnapPoint="_snapIndex">
+                        <DrawerHeader>
+                            <DrawerTitle>Snap Drawer</DrawerTitle>
+                            <DrawerDescription>Drag the handle to snap between 40%, 75%, and full height.</DrawerDescription>
+                        </DrawerHeader>
+                        <Stack Gap="2" Class="p-4">
+                            @foreach (var i in Enumerable.Range(1, 8))
+                            {
+                                <Flex Justify="between" Class="text-sm border-b border-border/40 pb-2">
+                                    <Lumeo.Text As="span" Size="sm" Color="muted">Row @i</Lumeo.Text>
+                                    <Lumeo.Text As="span" Size="sm" Weight="medium">Detail @i</Lumeo.Text>
+                                </Flex>
+                            }
+                        </Stack>
+                        <DrawerFooter>
+                            <DrawerClose><Button Class="w-full">Close</Button></DrawerClose>
+                        </DrawerFooter>
+                    </DrawerContent>
+                </Drawer>
+            </div>
+        </Stack>
+    </ComponentDemo>
+
     <ComponentDemo Title="Side — interactive" Code="@_sideInteractiveCode">
         <Stack Gap="4">
             <Lumeo.Text Size="sm" Color="muted">Pick a value to see it applied live.</Lumeo.Text>
@@ -339,6 +374,24 @@
                             <td class="p-3 font-mono text-xs text-muted-foreground">Bottom</td>
                             <td class="p-3 text-muted-foreground">Side the drawer slides in from. Values: Top, Right, Bottom, Left.</td>
                         </tr>
+                        <tr>
+                            <td class="p-3 font-mono text-xs text-primary">SnapPoints</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">IReadOnlyList&lt;double&gt;?</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">null</td>
+                            <td class="p-3 text-muted-foreground">vaul-style resting heights as ascending fractions (0&lt;f≤1), e.g. [0.4, 0.75, 1]. Top/Bottom only; the panel rests at one, drags between them, and dismisses below the lowest.</td>
+                        </tr>
+                        <tr>
+                            <td class="p-3 font-mono text-xs text-primary">ActiveSnapPoint</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">int</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">-1</td>
+                            <td class="p-3 text-muted-foreground">Index into SnapPoints of the current snap (two-way via @@bind-ActiveSnapPoint). -1 opens at the most-open (last) snap.</td>
+                        </tr>
+                        <tr>
+                            <td class="p-3 font-mono text-xs text-primary">ActiveSnapPointChanged</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">EventCallback&lt;int&gt;</td>
+                            <td class="p-3 font-mono text-xs text-muted-foreground">—</td>
+                            <td class="p-3 text-muted-foreground">Fires when the drawer settles on a new snap (drag/flick).</td>
+                        </tr>
 </tbody>
                 </table>
             </Stack>
@@ -364,6 +417,35 @@
     private bool _guardOpen;
     private bool _guardDirty;
     private string? _guardNote;
+
+    // Snap points demo (#218)
+    private bool _snapOpen;
+    private int _snapIndex = 1;                      // open at 75%
+    private double[] _snapPoints = { 0.4, 0.75, 1.0 };
+
+    private string _snapCode = @"<Drawer @bind-Open=""_snapOpen"">
+    <DrawerTrigger>
+        <Button Variant=""Button.ButtonVariant.Outline"">Open Snap Drawer</Button>
+    </DrawerTrigger>
+    <DrawerContent SnapPoints=""_snapPoints"" @bind-ActiveSnapPoint=""_snapIndex"">
+        <DrawerHeader>
+            <DrawerTitle>Snap Drawer</DrawerTitle>
+            <DrawerDescription>Drag the handle to snap between 40%, 75%, and full height.</DrawerDescription>
+        </DrawerHeader>
+        <Stack Gap=""2"" Class=""p-4"">
+            @* …content… *@
+        </Stack>
+        <DrawerFooter>
+            <DrawerClose><Button Class=""w-full"">Close</Button></DrawerClose>
+        </DrawerFooter>
+    </DrawerContent>
+</Drawer>
+
+@code {
+    private bool _snapOpen;
+    private int _snapIndex = 1;                      // open at 75%
+    private double[] _snapPoints = { 0.4, 0.75, 1.0 };
+}";
 
     private Task GuardDrawerClose(Lumeo.DismissEventArgs e)
     {

--- a/src/Lumeo.Editor/wwwroot/js/rich-text-editor.js
+++ b/src/Lumeo.Editor/wwwroot/js/rich-text-editor.js
@@ -506,9 +506,22 @@ function createBubbleMenu(editor, dotNetRef, instanceId, opts) {
                 e.preventDefault(); focusButton(0); break;
             case 'End':
                 e.preventDefault(); focusButton(buttons.length - 1); break;
+            case 'Tab':
+                // The toolbar lives at document.body, outside any modal focus
+                // trap around the editor. Returning focus to the editor on Tab
+                // keeps focus contained in that trap instead of escaping to a
+                // body-level element. (#345 review)
+                e.preventDefault(); editor.commands.focus(); break;
             case 'Escape':
                 e.preventDefault(); editor.commands.focus(); break;
         }
+    });
+
+    // Hide the toolbar once focus leaves it entirely (e.g. a click elsewhere) —
+    // the editor's own blur handler only covers the editor losing focus, so
+    // without this the keyboard-focused toolbar could stay stuck open. (#345)
+    root.addEventListener('focusout', (e) => {
+        if (!root.contains(e.relatedTarget)) root.style.display = 'none';
     });
 
     const focusToolbar = () => {
@@ -542,18 +555,26 @@ function createBubbleMenu(editor, dotNetRef, instanceId, opts) {
         root.style.left = left + 'px';
     }
 
-    editor.on('selectionUpdate', update);
+    // Named handlers so destroy() can unregister them (editor.on stacks
+    // listeners on re-creation otherwise). (#345 review)
+    const onSelectionUpdate = () => update();
     // Keep the menu open while keyboard focus is inside it (moving focus into
     // the floating toolbar blurs the editor).
-    editor.on('blur', () => { setTimeout(() => {
+    const onBlur = () => { setTimeout(() => {
         if (!editor.isFocused && !root.contains(document.activeElement)) root.style.display = 'none';
-    }, 200); });
-    editor.on('focus', update);
+    }, 200); };
+    const onFocus = () => update();
+    editor.on('selectionUpdate', onSelectionUpdate);
+    editor.on('blur', onBlur);
+    editor.on('focus', onFocus);
 
     return {
         update,
         focusToolbar,
         destroy() {
+            try { editor.off('selectionUpdate', onSelectionUpdate); } catch (_) {}
+            try { editor.off('blur', onBlur); } catch (_) {}
+            try { editor.off('focus', onFocus); } catch (_) {}
             try { editor.view.dom.removeEventListener('keydown', onEditorKeydown); } catch (_) {}
             try { root.remove(); } catch (_) {}
         },

--- a/src/Lumeo.Editor/wwwroot/js/rich-text-editor.js
+++ b/src/Lumeo.Editor/wwwroot/js/rich-text-editor.js
@@ -171,10 +171,36 @@ function createSuggestionRenderer(label, instanceId) {
     let lastProps = null;
     let scrollHandler = null;
 
+    // #320 — wire aria-activedescendant on the editor textbox to the active
+    // option so screen readers announce the highlighted suggestion as the user
+    // arrows through the listbox (the listbox itself never takes DOM focus).
+    const listboxId = 'lumeo-rte-lb-' + Math.random().toString(36).slice(2, 9);
+    const optionId = (i) => `${listboxId}-opt-${i}`;
+    function editorDom() { return editor && editor.view && editor.view.dom; }
+    function syncActiveDescendant() {
+        const dom = editorDom();
+        if (!dom) return;
+        if (items && items.length > 0) {
+            dom.setAttribute('aria-controls', listboxId);
+            dom.setAttribute('aria-expanded', 'true');
+            dom.setAttribute('aria-activedescendant', optionId(selectedIndex));
+        } else {
+            clearActiveDescendant();
+        }
+    }
+    function clearActiveDescendant() {
+        const dom = editorDom();
+        if (!dom) return;
+        dom.removeAttribute('aria-activedescendant');
+        dom.removeAttribute('aria-expanded');
+        dom.removeAttribute('aria-controls');
+    }
+
     function ensureRoot() {
         if (root) return root;
         root = document.createElement('div');
         root.className = 'lumeo-rte-suggestion';
+        root.id = listboxId;
         root.setAttribute('role', 'listbox');
         root.setAttribute('aria-label', label || 'Suggestions');
         // rc.43: tag with instance id so destroy() can find orphaned popups
@@ -199,6 +225,7 @@ function createSuggestionRenderer(label, instanceId) {
         ensureRoot();
         if (!items || items.length === 0) {
             root.innerHTML = '<div style="padding:0.5rem 0.625rem;color:var(--color-muted-foreground);font-size:0.8125rem">No results</div>';
+            clearActiveDescendant();
             return;
         }
         const html = items.map((it, i) => {
@@ -206,7 +233,7 @@ function createSuggestionRenderer(label, instanceId) {
             const subtitle = it.subtitle ? `<div style="font-size:0.75rem;color:var(--color-muted-foreground);line-height:1.1">${escapeHtml(it.subtitle)}</div>` : '';
             const icon = it.icon ? `<span style="display:inline-flex;align-items:center;width:1rem;height:1rem;color:var(--color-muted-foreground);margin-right:0.5rem">${iconSvg(it.icon)}</span>` : '';
             const bg = sel ? 'background:var(--color-accent);color:var(--color-accent-foreground);' : '';
-            return `<div role="option" data-index="${i}" aria-selected="${sel}" style="display:flex;align-items:flex-start;padding:0.4rem 0.55rem;border-radius:0.375rem;cursor:pointer;${bg}">
+            return `<div role="option" id="${optionId(i)}" data-index="${i}" aria-selected="${sel}" style="display:flex;align-items:flex-start;padding:0.4rem 0.55rem;border-radius:0.375rem;cursor:pointer;${bg}">
                 ${icon}
                 <div style="flex:1;min-width:0">
                     <div style="font-weight:500">${escapeHtml(it.label || it.id || '')}</div>
@@ -215,6 +242,7 @@ function createSuggestionRenderer(label, instanceId) {
             </div>`;
         }).join('');
         root.innerHTML = html;
+        syncActiveDescendant();
         root.querySelectorAll('[data-index]').forEach(el => {
             // mousedown: only prevent focus-loss; don't pick yet (would race with re-render).
             el.addEventListener('mousedown', (e) => { e.preventDefault(); });
@@ -239,6 +267,7 @@ function createSuggestionRenderer(label, instanceId) {
                     node.style.background = sel ? 'var(--color-accent)' : '';
                     node.style.color = sel ? 'var(--color-accent-foreground)' : '';
                 });
+                syncActiveDescendant();
             });
         });
     }
@@ -298,6 +327,7 @@ function createSuggestionRenderer(label, instanceId) {
 
     function destroy() {
         detachScrollHandler();
+        clearActiveDescendant();
         lastProps = null;
         if (root) {
             try { root.remove(); } catch (_) {}
@@ -449,6 +479,51 @@ function createBubbleMenu(editor, dotNetRef, instanceId, opts) {
 
     document.body.appendChild(root);
 
+    // --- Keyboard a11y (#320) ---
+    // The floating toolbar is now keyboard-reachable: Alt+F10 (the ARIA
+    // Authoring-Practices shortcut for "move focus into a toolbar") moves focus
+    // here when a selection is active; Arrow/Home/End rove between the buttons
+    // via a roving tabindex; Escape returns focus to the editor.
+    const buttons = Array.from(root.querySelectorAll('button'));
+    let focusIndex = 0;
+    const applyRoving = () => buttons.forEach((b, i) => { b.tabIndex = i === focusIndex ? 0 : -1; });
+    const focusButton = (i) => {
+        focusIndex = Math.max(0, Math.min(buttons.length - 1, i));
+        applyRoving();
+        if (buttons[focusIndex]) buttons[focusIndex].focus();
+    };
+    applyRoving();
+
+    root.addEventListener('keydown', (e) => {
+        switch (e.key) {
+            case 'ArrowRight':
+            case 'ArrowDown':
+                e.preventDefault(); focusButton((focusIndex + 1) % buttons.length); break;
+            case 'ArrowLeft':
+            case 'ArrowUp':
+                e.preventDefault(); focusButton((focusIndex - 1 + buttons.length) % buttons.length); break;
+            case 'Home':
+                e.preventDefault(); focusButton(0); break;
+            case 'End':
+                e.preventDefault(); focusButton(buttons.length - 1); break;
+            case 'Escape':
+                e.preventDefault(); editor.commands.focus(); break;
+        }
+    });
+
+    const focusToolbar = () => {
+        if (root.style.display === 'none' || buttons.length === 0) return false;
+        focusButton(0);
+        return true;
+    };
+
+    const onEditorKeydown = (e) => {
+        if (e.altKey && (e.key === 'F10' || e.code === 'F10')) {
+            if (focusToolbar()) e.preventDefault();
+        }
+    };
+    editor.view.dom.addEventListener('keydown', onEditorKeydown);
+
     function update() {
         const { from, to, empty } = editor.state.selection;
         if (empty || !editor.isFocused) {
@@ -457,7 +532,10 @@ function createBubbleMenu(editor, dotNetRef, instanceId, opts) {
         }
         const start = editor.view.coordsAtPos(from);
         const end = editor.view.coordsAtPos(to);
+        const wasHidden = root.style.display === 'none';
         root.style.display = 'flex';
+        // Re-arm roving so Alt+F10 always enters at the first button.
+        if (wasHidden) { focusIndex = 0; applyRoving(); }
         const top = Math.max(0, start.top - 44);
         const left = Math.max(8, (start.left + end.left) / 2 - root.offsetWidth / 2);
         root.style.top = top + 'px';
@@ -465,12 +543,20 @@ function createBubbleMenu(editor, dotNetRef, instanceId, opts) {
     }
 
     editor.on('selectionUpdate', update);
-    editor.on('blur', () => { setTimeout(() => { if (!editor.isFocused) root.style.display = 'none'; }, 200); });
+    // Keep the menu open while keyboard focus is inside it (moving focus into
+    // the floating toolbar blurs the editor).
+    editor.on('blur', () => { setTimeout(() => {
+        if (!editor.isFocused && !root.contains(document.activeElement)) root.style.display = 'none';
+    }, 200); });
     editor.on('focus', update);
 
     return {
         update,
-        destroy() { try { root.remove(); } catch (_) {} },
+        focusToolbar,
+        destroy() {
+            try { editor.view.dom.removeEventListener('keydown', onEditorKeydown); } catch (_) {}
+            try { root.remove(); } catch (_) {}
+        },
     };
 }
 

--- a/src/Lumeo/Services/ComponentInteropService.cs
+++ b/src/Lumeo/Services/ComponentInteropService.cs
@@ -409,6 +409,13 @@ public sealed class ComponentInteropService : IComponentInteropService
         await _swipe.RegisterDrawerSwipe(module, GetSelfRef(), elementId, direction, handler, activationPx, firePx);
     }
 
+    // 3.19 — adds velocity/flick dismiss (px/ms) on top of the distance thresholds.
+    public async ValueTask RegisterDrawerSwipe(string elementId, string direction, Func<Task> handler, int? activationPx, int? firePx, double? velocity)
+    {
+        var module = await GetModuleAsync();
+        await _swipe.RegisterDrawerSwipe(module, GetSelfRef(), elementId, direction, handler, activationPx, firePx, velocity);
+    }
+
     public async ValueTask UnregisterDrawerSwipe(string elementId)
     {
         var module = await GetModuleAsync();
@@ -417,6 +424,29 @@ public sealed class ComponentInteropService : IComponentInteropService
 
     [JSInvokable]
     public async Task OnSwipeDismiss(string elementId) => await _swipe.OnSwipeDismiss(elementId);
+
+    // --- Drawer Snap Points (3.19) ---
+
+    public async ValueTask RegisterDrawerSnap(string elementId, string direction, Func<Task> dismissHandler, Func<int, Task> snapHandler, IReadOnlyList<double> snapPoints, int activeIndex, int? activationPx, int? firePx, double? velocity)
+    {
+        var module = await GetModuleAsync();
+        await _swipe.RegisterDrawerSnap(module, GetSelfRef(), elementId, direction, dismissHandler, snapHandler, snapPoints, activeIndex, activationPx, firePx, velocity);
+    }
+
+    public async ValueTask SetDrawerSnap(string elementId, int index)
+    {
+        var module = await GetModuleAsync();
+        await _swipe.SetDrawerSnap(module, elementId, index);
+    }
+
+    public async ValueTask UnregisterDrawerSnap(string elementId)
+    {
+        var module = await GetModuleAsync();
+        await _swipe.UnregisterDrawerSnap(module, elementId);
+    }
+
+    [JSInvokable]
+    public async Task OnDrawerSnapChange(string elementId, int index) => await _swipe.OnDrawerSnapChange(elementId, index);
 
     // --- Sortable Touch (rc.44 mobile fix) ---
 

--- a/src/Lumeo/Services/ComponentInteropService.cs
+++ b/src/Lumeo/Services/ComponentInteropService.cs
@@ -427,10 +427,10 @@ public sealed class ComponentInteropService : IComponentInteropService
 
     // --- Drawer Snap Points (3.19) ---
 
-    public async ValueTask RegisterDrawerSnap(string elementId, string direction, Func<Task> dismissHandler, Func<int, Task> snapHandler, IReadOnlyList<double> snapPoints, int activeIndex, int? activationPx, int? firePx, double? velocity)
+    public async ValueTask RegisterDrawerSnap(string elementId, string direction, Func<Task<bool>> dismissHandler, Func<int, Task> snapHandler, IReadOnlyList<double> snapPoints, int activeIndex, bool dismissible, int? activationPx, int? firePx, double? velocity)
     {
         var module = await GetModuleAsync();
-        await _swipe.RegisterDrawerSnap(module, GetSelfRef(), elementId, direction, dismissHandler, snapHandler, snapPoints, activeIndex, activationPx, firePx, velocity);
+        await _swipe.RegisterDrawerSnap(module, GetSelfRef(), elementId, direction, dismissHandler, snapHandler, snapPoints, activeIndex, dismissible, activationPx, firePx, velocity);
     }
 
     public async ValueTask SetDrawerSnap(string elementId, int index)
@@ -447,6 +447,9 @@ public sealed class ComponentInteropService : IComponentInteropService
 
     [JSInvokable]
     public async Task OnDrawerSnapChange(string elementId, int index) => await _swipe.OnDrawerSnapChange(elementId, index);
+
+    [JSInvokable]
+    public async Task<bool> OnDrawerSnapDismiss(string elementId) => await _swipe.OnDrawerSnapDismiss(elementId);
 
     // --- Sortable Touch (rc.44 mobile fix) ---
 

--- a/src/Lumeo/Services/IComponentInteropService.cs
+++ b/src/Lumeo/Services/IComponentInteropService.cs
@@ -159,8 +159,8 @@ public interface IComponentInteropService : IAsyncDisposable, IDisposable
     /// fires with the new index on each settle; <paramref name="dismissHandler"/>
     /// fires on close. Default impl falls back to plain swipe-dismiss.
     /// </summary>
-    ValueTask RegisterDrawerSnap(string elementId, string direction, Func<Task> dismissHandler, Func<int, Task> snapHandler, IReadOnlyList<double> snapPoints, int activeIndex, int? activationPx, int? firePx, double? velocity) =>
-        RegisterDrawerSwipe(elementId, direction, dismissHandler, activationPx, firePx);
+    ValueTask RegisterDrawerSnap(string elementId, string direction, Func<Task<bool>> dismissHandler, Func<int, Task> snapHandler, IReadOnlyList<double> snapPoints, int activeIndex, bool dismissible, int? activationPx, int? firePx, double? velocity) =>
+        RegisterDrawerSwipe(elementId, direction, () => dismissHandler(), activationPx, firePx);
     /// <summary>Programmatically move a snap-point drawer to <paramref name="index"/>.</summary>
     ValueTask SetDrawerSnap(string elementId, int index) => ValueTask.CompletedTask;
     ValueTask UnregisterDrawerSnap(string elementId) => UnregisterDrawerSwipe(elementId);

--- a/src/Lumeo/Services/IComponentInteropService.cs
+++ b/src/Lumeo/Services/IComponentInteropService.cs
@@ -142,7 +142,28 @@ public interface IComponentInteropService : IAsyncDisposable, IDisposable
     /// <param name="firePx">Pull-distance above which release triggers a dismiss.</param>
     ValueTask RegisterDrawerSwipe(string elementId, string direction, Func<Task> handler, int? activationPx, int? firePx) =>
         RegisterDrawerSwipe(elementId, direction, handler);
+    /// <summary>
+    /// 3.19 — adds <paramref name="velocity"/> (px/ms): a flick faster than this
+    /// in the dismiss direction closes the drawer even below <paramref name="firePx"/>.
+    /// Default impl ignores it so non-overriding implementations keep working.
+    /// </summary>
+    ValueTask RegisterDrawerSwipe(string elementId, string direction, Func<Task> handler, int? activationPx, int? firePx, double? velocity) =>
+        RegisterDrawerSwipe(elementId, direction, handler, activationPx, firePx);
     ValueTask UnregisterDrawerSwipe(string elementId);
+
+    // Drawer Snap Points (3.19) — vaul-style fractional resting heights.
+    /// <summary>
+    /// Registers a snap-point gesture: the drawer rests at one of
+    /// <paramref name="snapPoints"/> (fractions 0&lt;f≤1), drags between them, and
+    /// dismisses when flicked/dragged below the lowest. <paramref name="snapHandler"/>
+    /// fires with the new index on each settle; <paramref name="dismissHandler"/>
+    /// fires on close. Default impl falls back to plain swipe-dismiss.
+    /// </summary>
+    ValueTask RegisterDrawerSnap(string elementId, string direction, Func<Task> dismissHandler, Func<int, Task> snapHandler, IReadOnlyList<double> snapPoints, int activeIndex, int? activationPx, int? firePx, double? velocity) =>
+        RegisterDrawerSwipe(elementId, direction, dismissHandler, activationPx, firePx);
+    /// <summary>Programmatically move a snap-point drawer to <paramref name="index"/>.</summary>
+    ValueTask SetDrawerSnap(string elementId, int index) => ValueTask.CompletedTask;
+    ValueTask UnregisterDrawerSnap(string elementId) => UnregisterDrawerSwipe(elementId);
 
     // Tab Swipe — horizontal swipe switches between TabsContent panels
     ValueTask RegisterTabSwipe(string elementId, bool wrap, Func<string, Task> handler);

--- a/src/Lumeo/Services/Interop/SwipeInterop.cs
+++ b/src/Lumeo/Services/Interop/SwipeInterop.cs
@@ -6,6 +6,8 @@ internal sealed class SwipeInterop
 {
     private readonly Dictionary<string, Func<Task>> _drawerSwipeHandlers = new();
     private readonly Dictionary<string, Func<int, Task>> _drawerSnapHandlers = new();
+    // Snap dismiss returns whether the close was honored, so JS can snap back on an OnBeforeClose veto.
+    private readonly Dictionary<string, Func<Task<bool>>> _drawerSnapDismissHandlers = new();
     private readonly Dictionary<string, Func<string, Task>> _carouselSwipeHandlers = new();
     private readonly Dictionary<string, Func<double, double, int, Task>> _carouselScrollHandlers = new();
     private readonly Dictionary<string, Func<string, Task>> _toastSwipeHandlers = new();
@@ -36,20 +38,28 @@ internal sealed class SwipeInterop
         DotNetObjectReference<ComponentInteropService> selfRef,
         string elementId,
         string direction,
-        Func<Task> dismissHandler,
+        Func<Task<bool>> dismissHandler,
         Func<int, Task> snapHandler,
         IReadOnlyList<double> snapPoints,
         int activeIndex,
+        bool dismissible = true,
         int? activationPx = null,
         int? firePx = null,
         double? velocity = null)
     {
-        // Dismiss reuses the swipe handler map so OnSwipeDismiss resolves; the
-        // snap-change callback lives in its own map.
-        _drawerSwipeHandlers[elementId] = dismissHandler;
+        _drawerSnapDismissHandlers[elementId] = dismissHandler;
         _drawerSnapHandlers[elementId] = snapHandler;
         await module.InvokeVoidAsync("registerDrawerSnap", elementId, direction, selfRef,
-            new { snapPoints, activeIndex, activationPx, firePx, velocity });
+            new { snapPoints, activeIndex, dismissible, activationPx, firePx, velocity });
+    }
+
+    public async Task<bool> OnDrawerSnapDismiss(string elementId)
+    {
+        if (_drawerSnapDismissHandlers.TryGetValue(elementId, out var handler))
+        {
+            return await handler();
+        }
+        return true;
     }
 
     public async ValueTask SetDrawerSnap(IJSObjectReference module, string elementId, int index)
@@ -59,7 +69,7 @@ internal sealed class SwipeInterop
 
     public async ValueTask UnregisterDrawerSnap(IJSObjectReference module, string elementId)
     {
-        _drawerSwipeHandlers.Remove(elementId);
+        _drawerSnapDismissHandlers.Remove(elementId);
         _drawerSnapHandlers.Remove(elementId);
         await module.InvokeVoidAsync("unregisterDrawerSnap", elementId);
     }
@@ -267,6 +277,7 @@ internal sealed class SwipeInterop
     {
         _drawerSwipeHandlers.Clear();
         _drawerSnapHandlers.Clear();
+        _drawerSnapDismissHandlers.Clear();
         _carouselSwipeHandlers.Clear();
         _carouselScrollHandlers.Clear();
         _toastSwipeHandlers.Clear();

--- a/src/Lumeo/Services/Interop/SwipeInterop.cs
+++ b/src/Lumeo/Services/Interop/SwipeInterop.cs
@@ -5,6 +5,7 @@ namespace Lumeo.Services.Interop;
 internal sealed class SwipeInterop
 {
     private readonly Dictionary<string, Func<Task>> _drawerSwipeHandlers = new();
+    private readonly Dictionary<string, Func<int, Task>> _drawerSnapHandlers = new();
     private readonly Dictionary<string, Func<string, Task>> _carouselSwipeHandlers = new();
     private readonly Dictionary<string, Func<double, double, int, Task>> _carouselScrollHandlers = new();
     private readonly Dictionary<string, Func<string, Task>> _toastSwipeHandlers = new();
@@ -21,10 +22,54 @@ internal sealed class SwipeInterop
         string direction,
         Func<Task> handler,
         int? activationPx = null,
-        int? firePx = null)
+        int? firePx = null,
+        double? velocity = null)
     {
         _drawerSwipeHandlers[elementId] = handler;
-        await module.InvokeVoidAsync("registerDrawerSwipe", elementId, direction, selfRef, new { activationPx, firePx });
+        await module.InvokeVoidAsync("registerDrawerSwipe", elementId, direction, selfRef, new { activationPx, firePx, velocity });
+    }
+
+    // --- Drawer Snap Points (3.19) ---
+
+    public async ValueTask RegisterDrawerSnap(
+        IJSObjectReference module,
+        DotNetObjectReference<ComponentInteropService> selfRef,
+        string elementId,
+        string direction,
+        Func<Task> dismissHandler,
+        Func<int, Task> snapHandler,
+        IReadOnlyList<double> snapPoints,
+        int activeIndex,
+        int? activationPx = null,
+        int? firePx = null,
+        double? velocity = null)
+    {
+        // Dismiss reuses the swipe handler map so OnSwipeDismiss resolves; the
+        // snap-change callback lives in its own map.
+        _drawerSwipeHandlers[elementId] = dismissHandler;
+        _drawerSnapHandlers[elementId] = snapHandler;
+        await module.InvokeVoidAsync("registerDrawerSnap", elementId, direction, selfRef,
+            new { snapPoints, activeIndex, activationPx, firePx, velocity });
+    }
+
+    public async ValueTask SetDrawerSnap(IJSObjectReference module, string elementId, int index)
+    {
+        await module.InvokeVoidAsync("setDrawerSnap", elementId, index);
+    }
+
+    public async ValueTask UnregisterDrawerSnap(IJSObjectReference module, string elementId)
+    {
+        _drawerSwipeHandlers.Remove(elementId);
+        _drawerSnapHandlers.Remove(elementId);
+        await module.InvokeVoidAsync("unregisterDrawerSnap", elementId);
+    }
+
+    public async Task OnDrawerSnapChange(string elementId, int index)
+    {
+        if (_drawerSnapHandlers.TryGetValue(elementId, out var handler))
+        {
+            await handler(index);
+        }
     }
 
     public async ValueTask RegisterDrawerSwipe(
@@ -221,6 +266,7 @@ internal sealed class SwipeInterop
     public void Clear()
     {
         _drawerSwipeHandlers.Clear();
+        _drawerSnapHandlers.Clear();
         _carouselSwipeHandlers.Clear();
         _carouselScrollHandlers.Clear();
         _toastSwipeHandlers.Clear();

--- a/src/Lumeo/Services/LumeoGestureOptions.cs
+++ b/src/Lumeo/Services/LumeoGestureOptions.cs
@@ -31,4 +31,12 @@ public sealed class LumeoGestureOptions
 
     /// <summary>Pull-down distance (px) above which a swipe-to-close fires after release. Default 100. Below this value the overlay snaps back.</summary>
     public int SwipeDismissFirePx { get; set; } = 100;
+
+    /// <summary>
+    /// Flick velocity (px/ms) above which a Drawer swipe dismisses on release
+    /// regardless of how far it travelled — a fast flick closes even below
+    /// <see cref="SwipeDismissFirePx"/>. Default 0.4. Set 0 to disable
+    /// velocity dismissal (distance-only, the pre-3.19 behaviour).
+    /// </summary>
+    public double SwipeDismissVelocity { get; set; } = 0.4;
 }

--- a/src/Lumeo/UI/Drawer/DrawerContent.razor
+++ b/src/Lumeo/UI/Drawer/DrawerContent.razor
@@ -102,6 +102,12 @@ else if (Context.IsOpen)
     // programmatic ActiveSnapPoint change from an echo of a gesture-driven one.
     private int _appliedSnap = -1;
 
+    // Which gesture path was actually registered on open, so cleanup and
+    // programmatic updates target the right one even if SnapPoints/Side change
+    // while the drawer stays open (PR #345 review).
+    private bool _gestureRegistered;
+    private bool _registeredWithSnap;
+
     private string PositionClasses => Side switch
     {
         Lumeo.Side.Top => "inset-x-0 top-0 rounded-b-[10px] max-h-[96vh]",
@@ -156,23 +162,7 @@ else if (Context.IsOpen)
             {
                 await Interop.AttachOverlaySlideEnd(_contentId);
             }
-            if (!PreventClose)
-            {
-                if (UsesSnapPoints)
-                {
-                    _appliedSnap = InitialSnapIndex;
-                    await Interop.RegisterDrawerSnap(_contentId, SwipeDirection, HandleSwipe, HandleSnapChange,
-                        SnapPoints!, _appliedSnap,
-                        GestureOpts.Value.SwipeDismissThresholdPx, GestureOpts.Value.SwipeDismissFirePx, GestureOpts.Value.SwipeDismissVelocity);
-                    // Surface the resolved initial snap if the consumer hadn't pinned it there.
-                    if (_appliedSnap != ActiveSnapPoint) await ActiveSnapPointChanged.InvokeAsync(_appliedSnap);
-                }
-                else
-                {
-                    await Interop.RegisterDrawerSwipe(_contentId, SwipeDirection, HandleSwipe,
-                        GestureOpts.Value.SwipeDismissThresholdPx, GestureOpts.Value.SwipeDismissFirePx, GestureOpts.Value.SwipeDismissVelocity);
-                }
-            }
+            await RegisterGestureAsync();
             _wasOpen = true;
         }
         else if (!Context.IsOpen && _wasOpen)
@@ -197,11 +187,56 @@ else if (Context.IsOpen)
         }
     }
 
+    // Registers the appropriate gesture for the current state and records which
+    // one (so cleanup/updates target it even if SnapPoints/Side change later).
+    private async Task RegisterGestureAsync()
+    {
+        if (UsesSnapPoints)
+        {
+            _appliedSnap = InitialSnapIndex;
+            // dismissible: a PreventClose drawer still snaps between points but
+            // never closes (the gesture settles at the lowest snap instead).
+            await Interop.RegisterDrawerSnap(_contentId, SwipeDirection,
+                () => Context.TryDismiss("swipe"), HandleSnapChange,
+                SnapPoints!, _appliedSnap, !PreventClose,
+                GestureOpts.Value.SwipeDismissThresholdPx, GestureOpts.Value.SwipeDismissFirePx, GestureOpts.Value.SwipeDismissVelocity);
+            _registeredWithSnap = true;
+            _gestureRegistered = true;
+            if (_appliedSnap != ActiveSnapPoint) await ActiveSnapPointChanged.InvokeAsync(_appliedSnap);
+        }
+        else if (!PreventClose)
+        {
+            await Interop.RegisterDrawerSwipe(_contentId, SwipeDirection, HandleSwipe,
+                GestureOpts.Value.SwipeDismissThresholdPx, GestureOpts.Value.SwipeDismissFirePx, GestureOpts.Value.SwipeDismissVelocity);
+            _registeredWithSnap = false;
+            _gestureRegistered = true;
+        }
+    }
+
+    private async Task UnregisterGestureAsync()
+    {
+        if (!_gestureRegistered) return;
+        if (_registeredWithSnap) await Interop.UnregisterDrawerSnap(_contentId);
+        else await Interop.UnregisterDrawerSwipe(_contentId);
+        _gestureRegistered = false;
+    }
+
     protected override async Task OnParametersSetAsync()
     {
+        if (!_wasOpen) return;
+
+        // SnapPoints/Side changed while open → the gesture mode flipped (e.g.
+        // empty→populated SnapPoints); re-register so the right JS is attached.
+        if (_registeredWithSnap != UsesSnapPoints)
+        {
+            await UnregisterGestureAsync();
+            await RegisterGestureAsync();
+            return;
+        }
+
         // Consumer moved the drawer programmatically (set ActiveSnapPoint to a
         // new in-range index that didn't originate from a gesture) → push to JS.
-        if (_wasOpen && UsesSnapPoints && SnapPoints is not null
+        if (_registeredWithSnap && SnapPoints is not null
             && ActiveSnapPoint >= 0 && ActiveSnapPoint < SnapPoints.Count
             && ActiveSnapPoint != _appliedSnap)
         {
@@ -221,8 +256,7 @@ else if (Context.IsOpen)
     {
         try
         {
-            if (UsesSnapPoints) await Interop.UnregisterDrawerSnap(_contentId);
-            else await Interop.UnregisterDrawerSwipe(_contentId);
+            await UnregisterGestureAsync();
             await Interop.RemoveFocusTrap(_contentId);
             await Interop.UnlockScroll();
         }

--- a/src/Lumeo/UI/Drawer/DrawerContent.razor
+++ b/src/Lumeo/UI/Drawer/DrawerContent.razor
@@ -20,7 +20,9 @@
 else if (Context.IsOpen)
 {
     <div class="fixed inset-0" style="z-index:@BackdropZ">
-        <div class="fixed inset-0 bg-black/80 animate-fade-in" style="z-index:@BackdropZ" @onclick="HandleBackdropClick"></div>
+        @* Backdrop — theme-aware --color-overlay-backdrop token (was a hardcoded
+           bg-black/80 that ignored the token, unlike Sheet/Dialog). #218 *@
+        <div class="fixed inset-0 animate-fade-in" style="background-color:var(--color-overlay-backdrop);z-index:@BackdropZ" @onclick="HandleBackdropClick"></div>
         @* @onkeydown:stopPropagation — keys handled inside this modal must not
            bubble into ancestor overlays (an Escape would cascade-close them).
            See DialogContent for the full rationale. *@
@@ -44,6 +46,25 @@ else if (Context.IsOpen)
     [Parameter] public Lumeo.Side Side { get; set; } = Lumeo.Side.Bottom;
     [Parameter] public DrawerAnimation Animation { get; set; } = DrawerAnimation.Slide;
     [Parameter] public bool PreventClose { get; set; }
+
+    /// <summary>
+    /// vaul-style snap points: fractional resting heights in ascending order,
+    /// each <c>0 &lt; f ≤ 1</c> (e.g. <c>[0.4, 0.75, 1]</c> = 40% / 75% / fully
+    /// open). When set on a Top/Bottom drawer, the panel rests at one of these
+    /// heights, drags between them, and dismisses when flicked/dragged below the
+    /// lowest. Ignored for Left/Right (which keep plain swipe-to-dismiss). (#218)
+    /// </summary>
+    [Parameter] public IReadOnlyList<double>? SnapPoints { get; set; }
+
+    /// <summary>
+    /// Index into <see cref="SnapPoints"/> of the current resting snap. Two-way
+    /// bindable: updates as the user drags between snaps, and setting it moves
+    /// the drawer programmatically. <c>-1</c> (default) opens at the most-open
+    /// (last) snap. (#218)
+    /// </summary>
+    [Parameter] public int ActiveSnapPoint { get; set; } = -1;
+    [Parameter] public EventCallback<int> ActiveSnapPointChanged { get; set; }
+
     [Parameter] public string? Class { get; set; }
     /// <summary>Backdrop z-index. Content sits at <c>ZIndex + 1</c>. Defaults
     /// to <see cref="OverlayService.BaseZIndex"/>; <see cref="OverlayProvider"/>
@@ -64,6 +85,23 @@ else if (Context.IsOpen)
 
     private bool ShowDragHandle => Side is Lumeo.Side.Top or Lumeo.Side.Bottom;
 
+    // Snap points only apply to vertical drawers (vaul is vertical-only).
+    private bool UsesSnapPoints => SnapPoints is { Count: > 0 } && Side is Lumeo.Side.Top or Lumeo.Side.Bottom;
+
+    // Clamp the requested initial snap into range; -1 (default) → most-open (last).
+    private int InitialSnapIndex
+    {
+        get
+        {
+            var last = (SnapPoints?.Count ?? 1) - 1;
+            return (ActiveSnapPoint >= 0 && ActiveSnapPoint <= last) ? ActiveSnapPoint : last;
+        }
+    }
+
+    // Last index we pushed to / received from JS, to distinguish a consumer's
+    // programmatic ActiveSnapPoint change from an echo of a gesture-driven one.
+    private int _appliedSnap = -1;
+
     private string PositionClasses => Side switch
     {
         Lumeo.Side.Top => "inset-x-0 top-0 rounded-b-[10px] max-h-[96vh]",
@@ -73,7 +111,9 @@ else if (Context.IsOpen)
         _ => "inset-x-0 bottom-0 rounded-t-[10px] max-h-[96vh]"
     };
 
-    private string AnimationClass => Animation switch
+    // Snap mode: the JS gesture owns the transform (slide-in + resting offset),
+    // so the CSS slide-in keyframe is suppressed to avoid fighting it.
+    private string AnimationClass => UsesSnapPoints ? "" : Animation switch
     {
         DrawerAnimation.None => "",
         DrawerAnimation.Fade => "animate-fade-in",
@@ -111,13 +151,27 @@ else if (Context.IsOpen)
             await Interop.SetupFocusTrap(_contentId);
             // Same animationend cleanup as SheetContent — bypasses Blazor
             // event roundtrip + filters strictly on slide-in-from-* names.
-            if (Animation == DrawerAnimation.Slide)
+            // Skipped in snap mode: the JS snap gesture owns the transform.
+            if (!UsesSnapPoints && Animation == DrawerAnimation.Slide)
             {
                 await Interop.AttachOverlaySlideEnd(_contentId);
             }
             if (!PreventClose)
             {
-                await Interop.RegisterDrawerSwipe(_contentId, SwipeDirection, HandleSwipe, GestureOpts.Value.SwipeDismissThresholdPx, GestureOpts.Value.SwipeDismissFirePx);
+                if (UsesSnapPoints)
+                {
+                    _appliedSnap = InitialSnapIndex;
+                    await Interop.RegisterDrawerSnap(_contentId, SwipeDirection, HandleSwipe, HandleSnapChange,
+                        SnapPoints!, _appliedSnap,
+                        GestureOpts.Value.SwipeDismissThresholdPx, GestureOpts.Value.SwipeDismissFirePx, GestureOpts.Value.SwipeDismissVelocity);
+                    // Surface the resolved initial snap if the consumer hadn't pinned it there.
+                    if (_appliedSnap != ActiveSnapPoint) await ActiveSnapPointChanged.InvokeAsync(_appliedSnap);
+                }
+                else
+                {
+                    await Interop.RegisterDrawerSwipe(_contentId, SwipeDirection, HandleSwipe,
+                        GestureOpts.Value.SwipeDismissThresholdPx, GestureOpts.Value.SwipeDismissFirePx, GestureOpts.Value.SwipeDismissVelocity);
+                }
             }
             _wasOpen = true;
         }
@@ -132,6 +186,30 @@ else if (Context.IsOpen)
 
     private Task HandleSwipe() => Dismiss("swipe");
 
+    // Invoked from JS when a drag settles on a new snap. Mirror it into the
+    // two-way ActiveSnapPoint without re-pushing to JS (it's already there).
+    private async Task HandleSnapChange(int index)
+    {
+        _appliedSnap = index;
+        if (index != ActiveSnapPoint)
+        {
+            await ActiveSnapPointChanged.InvokeAsync(index);
+        }
+    }
+
+    protected override async Task OnParametersSetAsync()
+    {
+        // Consumer moved the drawer programmatically (set ActiveSnapPoint to a
+        // new in-range index that didn't originate from a gesture) → push to JS.
+        if (_wasOpen && UsesSnapPoints && SnapPoints is not null
+            && ActiveSnapPoint >= 0 && ActiveSnapPoint < SnapPoints.Count
+            && ActiveSnapPoint != _appliedSnap)
+        {
+            _appliedSnap = ActiveSnapPoint;
+            await Interop.SetDrawerSnap(_contentId, ActiveSnapPoint);
+        }
+    }
+
     private async Task HandleKeyDown(KeyboardEventArgs e)
     {
         if (e.Key == "Escape" && !PreventClose) await Dismiss("escape");
@@ -143,7 +221,8 @@ else if (Context.IsOpen)
     {
         try
         {
-            await Interop.UnregisterDrawerSwipe(_contentId);
+            if (UsesSnapPoints) await Interop.UnregisterDrawerSnap(_contentId);
+            else await Interop.UnregisterDrawerSwipe(_contentId);
             await Interop.RemoveFocusTrap(_contentId);
             await Interop.UnlockScroll();
         }

--- a/src/Lumeo/wwwroot/js/components.js
+++ b/src/Lumeo/wwwroot/js/components.js
@@ -1054,9 +1054,15 @@ export function registerDrawerSnap(elementId, direction, dotnetRef, options) {
     const sign = (direction === 'up') ? -1 : +1;
     const EASING = 'transform 0.32s cubic-bezier(0.32, 0.72, 0, 1)';
     const velocityOverride = options && options.velocity;
-    const DISMISS_VELOCITY = (typeof velocityOverride === 'number' && velocityOverride > 0) ? velocityOverride : 0.4;
+    // Honor an explicit 0 (distance-only), matching the swipe path — only a
+    // non-number falls back to the default. (#345 review)
+    const DISMISS_VELOCITY = (typeof velocityOverride === 'number') ? velocityOverride : 0.4;
+    const hasVelocityDismiss = DISMISS_VELOCITY > 0;
     const VELOCITY_WINDOW_MS = 100;
     const DISMISS_FRACTION = 0.5; // drag this far from the lowest snap toward closed → dismiss
+    // A protected drawer (PreventClose) still snaps between points; it just
+    // never dismisses — dragging past the lowest snap settles back there. (#345)
+    const dismissAllowed = !(options && options.dismissible === false);
 
     const lastIndex = snapPoints.length - 1;
     let activeIndex = (options && Number.isInteger(options.activeIndex))
@@ -1121,24 +1127,29 @@ export function registerDrawerSnap(elementId, direction, dotnetRef, options) {
             const dt = b.t - a.t;
             if (dt > 0) velocity = (b.pos - a.pos) / dt;
         }
-        const flickDismiss = Math.sign(velocity) === sign && Math.abs(velocity) >= DISMISS_VELOCITY;
-        const flickOpen = Math.sign(velocity) === -sign && Math.abs(velocity) >= DISMISS_VELOCITY;
+        const flickDismiss = hasVelocityDismiss && Math.sign(velocity) === sign && Math.abs(velocity) >= DISMISS_VELOCITY;
+        const flickOpen = hasVelocityDismiss && Math.sign(velocity) === -sign && Math.abs(velocity) >= DISMISS_VELOCITY;
 
         // Distance dragged past the lowest snap, toward fully closed.
         const lowest = offsetFor(0);
         const distPastLowest = (currentOffset - lowest) * sign;
         const gapToClosed = Math.abs(closedOffset() - lowest) || 1;
 
+        // Would this release close the drawer — a flick-down at/below the lowest
+        // snap, or dragged most of the way past it?
+        const wantDismiss =
+            (flickDismiss && (activeIndex === 0 || distPastLowest > 0)) ||
+            (!flickDismiss && !flickOpen && distPastLowest > gapToClosed * DISMISS_FRACTION);
+
         let dismiss = false;
         let targetIndex = activeIndex;
-
-        if (flickDismiss) {
-            if (activeIndex === 0 || distPastLowest > 0) dismiss = true;
-            else targetIndex = activeIndex - 1;
+        if (wantDismiss) {
+            if (dismissAllowed) dismiss = true;
+            else targetIndex = 0;          // protected: settle at the lowest snap instead of closing
+        } else if (flickDismiss) {
+            targetIndex = Math.max(0, activeIndex - 1);
         } else if (flickOpen) {
             targetIndex = Math.min(lastIndex, activeIndex + 1);
-        } else if (distPastLowest > gapToClosed * DISMISS_FRACTION) {
-            dismiss = true;
         } else {
             // Settle to the nearest snap by position.
             let best = 0, bestDist = Infinity;
@@ -1152,7 +1163,16 @@ export function registerDrawerSnap(elementId, direction, dotnetRef, options) {
         el.style.transition = EASING;
         if (dismiss) {
             el.style.transform = `translateY(${closedOffset()}px)`;
-            dotnetRef.invokeMethodAsync('OnSwipeDismiss', elementId);
+            // Respect OnBeforeClose: if C# vetoes the dismiss, snap back to the
+            // active snap instead of leaving the panel translated off-screen. (#345)
+            Promise.resolve(dotnetRef.invokeMethodAsync('OnDrawerSnapDismiss', elementId))
+                .then(ok => {
+                    if (ok === false) {
+                        el.style.transition = EASING;
+                        el.style.transform = `translateY(${offsetFor(activeIndex)}px)`;
+                    }
+                })
+                .catch(() => {});
         } else {
             el.style.transform = `translateY(${offsetFor(targetIndex)}px)`;
             if (targetIndex !== activeIndex) {

--- a/src/Lumeo/wwwroot/js/components.js
+++ b/src/Lumeo/wwwroot/js/components.js
@@ -849,6 +849,7 @@ export function unregisterPinchZoom(elementId) {
 // --- Drawer Swipe ---
 
 const drawerHandlers = new Map();
+const drawerSnapHandlers = new Map();
 
 export function registerDrawerSwipe(elementId, direction, dotnetRef, options) {
     const el = document.getElementById(elementId);
@@ -887,12 +888,21 @@ export function registerDrawerSwipe(elementId, direction, dotnetRef, options) {
     const DISMISS_THRESHOLD = (typeof fireOverride === 'number') ? fireOverride : 100;
     const RUBBER_BAND_START = 150;
     const RUBBER_BAND_FACTOR = 0.5;
+    // 3.19 — velocity/flick dismiss. A fast flick in the dismiss direction
+    // closes even if the raw distance never reached DISMISS_THRESHOLD, which is
+    // how a native bottom-sheet feels. px/ms; 0 (or absent) keeps the historical
+    // distance-only behaviour. Measured over the last VELOCITY_WINDOW_MS of move
+    // samples so a slow drag that ends with a tiny twitch doesn't false-fire.
+    const velocityOverride = options && options.velocity;
+    const DISMISS_VELOCITY = (typeof velocityOverride === 'number') ? velocityOverride : 0;
+    const VELOCITY_WINDOW_MS = 100;
 
     let startX = 0, startY = 0;
     let currentPos = 0;
     let isDragging = false;
     let active = false;       // gesture passed activation threshold
     let aborted = false;      // axis-lock determined this gesture is for the wrong axis
+    let samples = [];         // recent {pos, t} on the active axis for velocity
 
     const onTouchStart = (e) => {
         startX = e.touches[0].clientX;
@@ -901,6 +911,7 @@ export function registerDrawerSwipe(elementId, direction, dotnetRef, options) {
         isDragging = true;
         active = false;
         aborted = false;
+        samples = [{ pos: currentPos, t: performance.now() }];
         el.style.transition = 'none';
     };
 
@@ -911,6 +922,12 @@ export function registerDrawerSwipe(elementId, direction, dotnetRef, options) {
         const dx = x - startX;
         const dy = y - startY;
         currentPos = isHorizontal ? x : y;
+
+        const now = performance.now();
+        samples.push({ pos: currentPos, t: now });
+        // Keep only the trailing window so end-velocity reflects the flick,
+        // not the whole drag.
+        while (samples.length > 2 && now - samples[0].t > VELOCITY_WINDOW_MS) samples.shift();
 
         if (!active) {
             // Wait for the finger to travel far enough to commit to a gesture,
@@ -972,10 +989,23 @@ export function registerDrawerSwipe(elementId, direction, dotnetRef, options) {
             return;
         }
         const delta = currentPos - (isHorizontal ? startX : startY);
+        // End velocity (px/ms) along the active axis, measured over the trailing
+        // sample window so it reflects the release flick rather than the whole drag.
+        let velocity = 0;
+        if (samples.length >= 2) {
+            const last = samples[samples.length - 1];
+            const first = samples[0];
+            const dt = last.t - first.t;
+            if (dt > 0) velocity = (last.pos - first.pos) / dt;
+        }
         // Dismiss threshold is measured on raw axis delta (intent), not the
         // rubber-banded visual translate, so the gesture feels predictable
-        // regardless of how far the rubber-band let the sheet travel.
-        const shouldDismiss = Math.sign(delta) === dismissSign && Math.abs(delta) > DISMISS_THRESHOLD;
+        // regardless of how far the rubber-band let the sheet travel. A fast
+        // flick in the dismiss direction also fires, even below the distance.
+        const correctDir = Math.sign(delta) === dismissSign;
+        const farEnough = Math.abs(delta) > DISMISS_THRESHOLD;
+        const fastEnough = DISMISS_VELOCITY > 0 && Math.sign(velocity) === dismissSign && Math.abs(velocity) >= DISMISS_VELOCITY;
+        const shouldDismiss = correctDir && (farEnough || fastEnough);
         if (shouldDismiss) {
             dotnetRef.invokeMethodAsync('OnSwipeDismiss', elementId);
         } else {
@@ -1001,6 +1031,171 @@ export function unregisterDrawerSwipe(elementId) {
             el.style.transform = '';
         }
         drawerHandlers.delete(elementId);
+    }
+}
+
+// --- Drawer Snap Points (vaul-style) ---
+//
+// A drawer with snap points rests at one of several fractional heights
+// (e.g. [0.4, 0.75, 1] = 40% / 75% / fully open) instead of only open/closed.
+// Dragging moves between snaps; on release it settles to the nearest snap
+// (velocity-biased), and dragging/flicking below the lowest snap dismisses.
+// Vertical only — the C# side calls this only for Top/Bottom drawers; Left/Right
+// keep the plain swipe-to-dismiss path above.
+export function registerDrawerSnap(elementId, direction, dotnetRef, options) {
+    const el = document.getElementById(elementId);
+    if (!el) return;
+
+    const snapPoints = (options && Array.isArray(options.snapPoints)) ? options.snapPoints.slice() : [];
+    if (snapPoints.length === 0) return;
+
+    // dismissSign: +1 = a bottom drawer hides by translating DOWN; -1 = a top
+    // drawer hides by translating UP. The same sign drives "more closed".
+    const sign = (direction === 'up') ? -1 : +1;
+    const EASING = 'transform 0.32s cubic-bezier(0.32, 0.72, 0, 1)';
+    const velocityOverride = options && options.velocity;
+    const DISMISS_VELOCITY = (typeof velocityOverride === 'number' && velocityOverride > 0) ? velocityOverride : 0.4;
+    const VELOCITY_WINDOW_MS = 100;
+    const DISMISS_FRACTION = 0.5; // drag this far from the lowest snap toward closed → dismiss
+
+    const lastIndex = snapPoints.length - 1;
+    let activeIndex = (options && Number.isInteger(options.activeIndex))
+        ? Math.max(0, Math.min(lastIndex, options.activeIndex))
+        : lastIndex;
+
+    let H = el.offsetHeight || 0;
+    const offsetFor = (i) => sign * H * (1 - snapPoints[i]);
+    const closedOffset = () => sign * H;
+
+    // Open sequence: commit the fully-closed transform synchronously (before
+    // the browser paints), then rAF up to the active snap. JS owns the
+    // transform for the drawer's whole lifetime, so Blazor re-renders (which
+    // don't write transform) never reset it.
+    H = el.offsetHeight || H;
+    el.style.transition = 'none';
+    el.style.transform = `translateY(${closedOffset()}px)`;
+    void el.offsetHeight; // force reflow so the closed state is the paint baseline
+    requestAnimationFrame(() => {
+        el.style.transition = EASING;
+        el.style.transform = `translateY(${offsetFor(activeIndex)}px)`;
+    });
+
+    let startY = 0, baseOffset = 0, isDragging = false, samples = [];
+
+    const clampOffset = (off) => {
+        const openLimit = offsetFor(lastIndex);   // most-open snap
+        const closed = closedOffset();            // fully hidden
+        // Don't allow dragging more open than the top snap, nor past fully closed.
+        let lo = Math.min(openLimit, closed), hi = Math.max(openLimit, closed);
+        return Math.max(lo, Math.min(hi, off));
+    };
+
+    const onTouchStart = (e) => {
+        H = el.offsetHeight || H;
+        startY = e.touches[0].clientY;
+        baseOffset = offsetFor(activeIndex);
+        isDragging = true;
+        samples = [{ pos: startY, t: performance.now() }];
+        el.style.transition = 'none';
+    };
+
+    const onTouchMove = (e) => {
+        if (!isDragging) return;
+        const y = e.touches[0].clientY;
+        const now = performance.now();
+        samples.push({ pos: y, t: now });
+        while (samples.length > 2 && now - samples[0].t > VELOCITY_WINDOW_MS) samples.shift();
+        const proposed = clampOffset(baseOffset + (y - startY));
+        el.style.transform = `translateY(${proposed}px)`;
+    };
+
+    const onTouchEnd = (e) => {
+        if (!isDragging) return;
+        isDragging = false;
+        const endY = (e.changedTouches && e.changedTouches[0]) ? e.changedTouches[0].clientY : startY;
+        const currentOffset = clampOffset(baseOffset + (endY - startY));
+
+        let velocity = 0;
+        if (samples.length >= 2) {
+            const a = samples[0], b = samples[samples.length - 1];
+            const dt = b.t - a.t;
+            if (dt > 0) velocity = (b.pos - a.pos) / dt;
+        }
+        const flickDismiss = Math.sign(velocity) === sign && Math.abs(velocity) >= DISMISS_VELOCITY;
+        const flickOpen = Math.sign(velocity) === -sign && Math.abs(velocity) >= DISMISS_VELOCITY;
+
+        // Distance dragged past the lowest snap, toward fully closed.
+        const lowest = offsetFor(0);
+        const distPastLowest = (currentOffset - lowest) * sign;
+        const gapToClosed = Math.abs(closedOffset() - lowest) || 1;
+
+        let dismiss = false;
+        let targetIndex = activeIndex;
+
+        if (flickDismiss) {
+            if (activeIndex === 0 || distPastLowest > 0) dismiss = true;
+            else targetIndex = activeIndex - 1;
+        } else if (flickOpen) {
+            targetIndex = Math.min(lastIndex, activeIndex + 1);
+        } else if (distPastLowest > gapToClosed * DISMISS_FRACTION) {
+            dismiss = true;
+        } else {
+            // Settle to the nearest snap by position.
+            let best = 0, bestDist = Infinity;
+            for (let i = 0; i < snapPoints.length; i++) {
+                const d = Math.abs(currentOffset - offsetFor(i));
+                if (d < bestDist) { bestDist = d; best = i; }
+            }
+            targetIndex = best;
+        }
+
+        el.style.transition = EASING;
+        if (dismiss) {
+            el.style.transform = `translateY(${closedOffset()}px)`;
+            dotnetRef.invokeMethodAsync('OnSwipeDismiss', elementId);
+        } else {
+            el.style.transform = `translateY(${offsetFor(targetIndex)}px)`;
+            if (targetIndex !== activeIndex) {
+                activeIndex = targetIndex;
+                dotnetRef.invokeMethodAsync('OnDrawerSnapChange', elementId, targetIndex);
+            }
+        }
+    };
+
+    el.addEventListener('touchstart', onTouchStart, { passive: true });
+    el.addEventListener('touchmove', onTouchMove, { passive: true });
+    el.addEventListener('touchend', onTouchEnd);
+
+    drawerSnapHandlers.set(elementId, {
+        onTouchStart, onTouchMove, onTouchEnd,
+        // setActive lets C# move the drawer programmatically (two-way ActiveSnapPoint).
+        setActive(i) {
+            if (!Number.isInteger(i) || i < 0 || i > lastIndex || i === activeIndex) return;
+            activeIndex = i;
+            H = el.offsetHeight || H;
+            el.style.transition = EASING;
+            el.style.transform = `translateY(${offsetFor(i)}px)`;
+        }
+    });
+}
+
+export function setDrawerSnap(elementId, index) {
+    const h = drawerSnapHandlers.get(elementId);
+    if (h) h.setActive(index);
+}
+
+export function unregisterDrawerSnap(elementId) {
+    const handlers = drawerSnapHandlers.get(elementId);
+    if (handlers) {
+        const el = document.getElementById(elementId);
+        if (el) {
+            el.removeEventListener('touchstart', handlers.onTouchStart);
+            el.removeEventListener('touchmove', handlers.onTouchMove);
+            el.removeEventListener('touchend', handlers.onTouchEnd);
+            el.style.transform = '';
+            el.style.transition = '';
+        }
+        drawerSnapHandlers.delete(elementId);
     }
 }
 

--- a/tests/Lumeo.Tests/Components/Drawer/DrawerSnapTests.cs
+++ b/tests/Lumeo.Tests/Components/Drawer/DrawerSnapTests.cs
@@ -26,7 +26,8 @@ public class DrawerSnapTests : IAsyncLifetime
         bool open,
         double[]? snapPoints = null,
         int? activeSnap = null,
-        EventCallback<int>? activeSnapChanged = null)
+        EventCallback<int>? activeSnapChanged = null,
+        bool preventClose = false)
     {
         return _ctx.Render(builder =>
         {
@@ -38,7 +39,8 @@ public class DrawerSnapTests : IAsyncLifetime
                 if (snapPoints is not null) b.AddAttribute(1, "SnapPoints", snapPoints);
                 if (activeSnap is not null) b.AddAttribute(2, "ActiveSnapPoint", activeSnap.Value);
                 if (activeSnapChanged is not null) b.AddAttribute(3, "ActiveSnapPointChanged", activeSnapChanged.Value);
-                b.AddAttribute(4, "ChildContent", (RenderFragment)(inner => inner.AddContent(0, "Snap content")));
+                if (preventClose) b.AddAttribute(4, "PreventClose", true);
+                b.AddAttribute(5, "ChildContent", (RenderFragment)(inner => inner.AddContent(0, "Snap content")));
                 b.CloseComponent();
             }));
             builder.CloseComponent();
@@ -94,6 +96,18 @@ public class DrawerSnapTests : IAsyncLifetime
         var cb = EventCallback.Factory.Create<int>(_ctx, (int i) => reported = i);
         var cut = RenderDrawer(open: true, snapPoints: new[] { 0.4, 1.0 }, activeSnap: 0, activeSnapChanged: cb);
         Assert.NotEmpty(cut.FindAll("[role='dialog']"));
+    }
+
+    [Fact]
+    public void PreventClose_With_SnapPoints_Still_Renders_In_Snap_Mode()
+    {
+        // #345: a protected drawer with snap points must still snap (gesture
+        // registered with dismissible=false), not fall back to a fully-open
+        // static panel. At the render level: dialog present, slide-in suppressed.
+        var cut = RenderDrawer(open: true, snapPoints: new[] { 0.4, 1.0 }, preventClose: true);
+        var panel = cut.Find("[role='dialog']").GetAttribute("class") ?? "";
+        Assert.DoesNotContain("animate-slide-in", panel);
+        Assert.Contains("Snap content", cut.Markup);
     }
 
     [Fact]

--- a/tests/Lumeo.Tests/Components/Drawer/DrawerSnapTests.cs
+++ b/tests/Lumeo.Tests/Components/Drawer/DrawerSnapTests.cs
@@ -1,0 +1,106 @@
+using Bunit;
+using Microsoft.AspNetCore.Components;
+using Xunit;
+using Lumeo.Tests.Helpers;
+using L = Lumeo;
+
+namespace Lumeo.Tests.Components.Drawer;
+
+/// <summary>
+/// #218 — Drawer snap points + velocity dismiss + overlay-backdrop token.
+/// The touch gesture itself (drag/flick/snap) is JS and browser-verified;
+/// these cover the C# surface: the new parameters render, snap mode suppresses
+/// the CSS slide-in (JS owns the transform), the backdrop uses the theme token,
+/// and the velocity option has the documented default.
+/// </summary>
+public class DrawerSnapTests : IAsyncLifetime
+{
+    private readonly BunitContext _ctx = new();
+
+    public DrawerSnapTests() => _ctx.AddLumeoServices();
+
+    public Task InitializeAsync() => Task.CompletedTask;
+    public async Task DisposeAsync() => await _ctx.DisposeAsync();
+
+    private IRenderedComponent<IComponent> RenderDrawer(
+        bool open,
+        double[]? snapPoints = null,
+        int? activeSnap = null,
+        EventCallback<int>? activeSnapChanged = null)
+    {
+        return _ctx.Render(builder =>
+        {
+            builder.OpenComponent<L.Drawer>(0);
+            builder.AddAttribute(1, "Open", open);
+            builder.AddAttribute(2, "ChildContent", (RenderFragment)(b =>
+            {
+                b.OpenComponent<L.DrawerContent>(0);
+                if (snapPoints is not null) b.AddAttribute(1, "SnapPoints", snapPoints);
+                if (activeSnap is not null) b.AddAttribute(2, "ActiveSnapPoint", activeSnap.Value);
+                if (activeSnapChanged is not null) b.AddAttribute(3, "ActiveSnapPointChanged", activeSnapChanged.Value);
+                b.AddAttribute(4, "ChildContent", (RenderFragment)(inner => inner.AddContent(0, "Snap content")));
+                b.CloseComponent();
+            }));
+            builder.CloseComponent();
+        });
+    }
+
+    [Fact]
+    public void SnapPoints_Drawer_Renders_Dialog()
+    {
+        var cut = RenderDrawer(open: true, snapPoints: new[] { 0.4, 0.75, 1.0 });
+        Assert.NotEmpty(cut.FindAll("[role='dialog']"));
+        Assert.Contains("Snap content", cut.Markup);
+    }
+
+    [Fact]
+    public void SnapPoints_Suppress_SlideIn_Animation()
+    {
+        // Snap mode: JS owns the transform, so the CSS slide-in keyframe is dropped.
+        var snap = RenderDrawer(open: true, snapPoints: new[] { 0.5, 1.0 });
+        var snapPanel = snap.Find("[role='dialog']").GetAttribute("class") ?? "";
+        Assert.DoesNotContain("animate-slide-in", snapPanel);
+    }
+
+    [Fact]
+    public void NonSnap_Bottom_Drawer_Keeps_SlideIn_Animation()
+    {
+        // Control: without snap points the bottom drawer still slides in via CSS.
+        var plain = RenderDrawer(open: true);
+        var plainPanel = plain.Find("[role='dialog']").GetAttribute("class") ?? "";
+        Assert.Contains("animate-slide-in-from-bottom", plainPanel);
+    }
+
+    [Fact]
+    public void Backdrop_Uses_Overlay_Token_Not_Hardcoded_Black()
+    {
+        var cut = RenderDrawer(open: true, snapPoints: new[] { 0.5, 1.0 });
+        var backdrop = cut.FindAll("div").First(d =>
+        {
+            var cls = d.GetAttribute("class") ?? "";
+            return cls.Contains("fixed") && cls.Contains("inset-0") && cls.Contains("animate-fade-in");
+        });
+        var style = backdrop.GetAttribute("style") ?? "";
+        Assert.Contains("overlay-backdrop", style);
+        Assert.DoesNotContain("bg-black", backdrop.GetAttribute("class") ?? "");
+    }
+
+    [Fact]
+    public void ActiveSnapPoint_TwoWay_Binding_Renders()
+    {
+        // Binding the index is accepted and the drawer renders (gesture-driven
+        // changes are exercised in the browser).
+        int? reported = null;
+        var cb = EventCallback.Factory.Create<int>(_ctx, (int i) => reported = i);
+        var cut = RenderDrawer(open: true, snapPoints: new[] { 0.4, 1.0 }, activeSnap: 0, activeSnapChanged: cb);
+        Assert.NotEmpty(cut.FindAll("[role='dialog']"));
+    }
+
+    [Fact]
+    public void GestureOptions_Velocity_Has_Default()
+    {
+        // Velocity/flick dismiss default documented as 0.4 px/ms.
+        var opts = new L.Services.LumeoGestureOptions();
+        Assert.Equal(0.4, opts.SwipeDismissVelocity);
+    }
+}

--- a/tests/Lumeo.Tests/Components/Drawer/DrawerTests.cs
+++ b/tests/Lumeo.Tests/Components/Drawer/DrawerTests.cs
@@ -125,7 +125,10 @@ public class DrawerTests : IAsyncLifetime
         var hasBackdrop = allDivs.Any(d =>
         {
             var cls = d.GetAttribute("class") ?? "";
-            return cls.Contains("bg-black") && cls.Contains("fixed") && cls.Contains("inset-0");
+            var style = d.GetAttribute("style") ?? "";
+            // #218: backdrop now uses the --color-overlay-backdrop token (inline
+            // style) instead of a hardcoded bg-black/80 class, matching Sheet/Dialog.
+            return style.Contains("overlay-backdrop") && cls.Contains("fixed") && cls.Contains("inset-0");
         });
         Assert.True(hasBackdrop, "Backdrop should be present when drawer is open");
     }
@@ -138,7 +141,10 @@ public class DrawerTests : IAsyncLifetime
         var hasBackdrop = allDivs.Any(d =>
         {
             var cls = d.GetAttribute("class") ?? "";
-            return cls.Contains("bg-black") && cls.Contains("fixed") && cls.Contains("inset-0");
+            var style = d.GetAttribute("style") ?? "";
+            // #218: backdrop now uses the --color-overlay-backdrop token (inline
+            // style) instead of a hardcoded bg-black/80 class, matching Sheet/Dialog.
+            return style.Contains("overlay-backdrop") && cls.Contains("fixed") && cls.Contains("inset-0");
         });
         Assert.False(hasBackdrop, "Backdrop should not be present when drawer is closed");
     }


### PR DESCRIPTION
Bundled feature work for the next release (**3.19.0**), targeting the two real P1 audit gaps. All additive and opt-in.

> ⚠️ **Needs browser verification before release.** Both features are gesture/JS-driven and cannot be runtime-verified in headless CI. Please verify on the Cloudflare preview (checklist below). The version bump / tag / NuGet publish happen **after** your OK (Rule #2).

## #218 — Drawer: vaul-style snap points + velocity dismiss
- **`SnapPoints`** (`IReadOnlyList<double>`, fractions `0<f≤1`, ascending) + **`ActiveSnapPoint`** / **`ActiveSnapPointChanged`** (two-way). A Top/Bottom drawer rests at fractional heights, drags between them, and dismisses when flicked/dragged below the lowest snap. Programmatically setting `ActiveSnapPoint` moves it.
- **Velocity / flick dismiss**: a fast flick in the dismiss direction closes even below the distance threshold (`LumeoGestureOptions.SwipeDismissVelocity`, default `0.4` px/ms; `0` = distance-only).
- **Backdrop** now uses the `--color-overlay-backdrop` token instead of a hardcoded `bg-black/80`, matching Sheet/Dialog.
- Implementation isolates the new snap gesture (`registerDrawerSnap`) so the existing, well-tested swipe path is untouched; in snap mode the JS owns the transform (CSS slide-in suppressed).

## #320 — RichTextEditor: a11y for the floating menus
- **Floating bubble toolbar is now keyboard-operable**: `Alt+F10` moves focus into it (ARIA Authoring-Practices pattern), `Arrow`/`Home`/`End` rove between buttons (roving tabindex), `Escape` returns focus to the editor. Stays open while focus is inside it.
- **Slash/mention listbox** wires `aria-activedescendant` (+ `aria-controls` / `aria-expanded`) on the editor textbox to the active option id, so screen readers announce the highlighted item as you arrow through. Cleared on close.

## Tests & build
- `dotnet test` — **3733 passing** (6 new Drawer-snap surface tests + the two backdrop tests updated for the token). Core + Editor build clean; both JS files pass `node --check`.
- bUnit covers the C# surface (params, snap-mode animation suppression, backdrop token, option default). The touch/keyboard behaviour is what the preview checklist below verifies.

## Verification checklist (Cloudflare preview)
**Drawer (#218)** — on a touch device / emulator:
- [ ] A drawer with `SnapPoints="[0.4, 0.75, 1]"` opens to the active snap and rests there.
- [ ] Dragging settles to the nearest snap; a fast flick down moves down a snap / dismisses from the lowest.
- [ ] A quick flick dismisses even with a short drag; a slow short drag snaps back.
- [ ] Backdrop tint matches Sheet/Dialog in both light and dark mode.

**RichTextEditor (#320)** — keyboard only:
- [ ] Select text → `Alt+F10` focuses the bubble toolbar; `←`/`→` move between buttons; `Esc` returns to the editor.
- [ ] Type `/` → arrow through the slash menu; a screen reader announces each highlighted item (aria-activedescendant).

## Deliberately out of scope (kept for dedicated efforts)
TipTap collaborative editing (Yjs) / markdown round-trip (#320 remainder); Drawer background-scaling & `dismissible`-vs-`modal` split (#218 remainder). These are larger and tracked under the audit index (#337).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XPntycNyvABSR9U5ZKRBoU)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Drawer snap points (touch): drawers can rest at multiple configurable heights, with two-way control via `ActiveSnapPoint`.
  * Velocity-based swipe dismissal: quick flicks can dismiss drawers in addition to distance-based swipes.
  * Editor selection (bubble) menu keyboard support, including focus return via keyboard.

* **Accessibility**
  * Improved screen-reader support for editor suggestion lists with correctly tracked active options.

* **Documentation / Demos**
  * Added a Drawer snap points (touch) demo and updated Drawer API docs.

* **Tests**
  * Expanded drawer snap-point and backdrop coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->