### PR TITLE
docs: facts/numbers currency pass + tool-narrative updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **164 accessible Blazor components, AI-ready, motion-integrated, shadcn-inspired.**
 
-**164 components · 5,800+ tests** · 14 locales · mobile-first · MIT · .NET 8+
+**164 components · 5,900+ tests** · 14 locales · mobile-first · MIT · .NET 8+
 
 [![NuGet](https://img.shields.io/nuget/v/Lumeo?logo=nuget&label=Lumeo)](https://www.nuget.org/packages/Lumeo)
 [![NuGet Downloads](https://img.shields.io/nuget/dt/Lumeo?logo=nuget&label=downloads)](https://www.nuget.org/packages/Lumeo)
@@ -12,14 +12,14 @@
 [![GitHub stars](https://img.shields.io/github/stars/Brain2k-0005/Lumeo?style=flat&logo=github)](https://github.com/Brain2k-0005/Lumeo/stargazers)
 [![Sponsor](https://img.shields.io/github/sponsors/Brain2k-0005?logo=github-sponsors&color=ea4aaa)](https://github.com/sponsors/Brain2k-0005)
 
-> **Lumeo 4.2.0 is on NuGet** — a first-party **icon family** (16 trimmable packs), **`dotnet new`** app + full-stack templates, and a **shadcn-parity campaign** (overlay exit animations, `data-*` styling hooks, native form participation, menu-system + NavigationMenu parity, chart/AI a11y) on top of the 4.0 major (Radix / Base UI / shadcn parity audit + a 164-component battle-test, ~355 bugs fixed, 5,800+ tests, CLI **100% NuGet-free** eject). `dotnet add package Lumeo`. See [`CHANGELOG.md`](./CHANGELOG.md) — 4.1 is an additive, opt-in upgrade from 4.0 (a few documented behaviour changes); from 3.x see [`MIGRATION.md`](./MIGRATION.md).
+> **Lumeo 4.2.0 is on NuGet** — a first-party **icon family** (16 trimmable packs), **`dotnet new`** app + full-stack templates, and a **shadcn-parity campaign** (overlay exit animations, `data-*` styling hooks, native form participation, menu-system + NavigationMenu parity, chart/AI a11y) on top of the 4.0 major (Radix / Base UI / shadcn parity audit + a 164-component battle-test, ~355 bugs fixed, 5,900+ tests, CLI **100% NuGet-free** eject). `dotnet add package Lumeo`. See [`CHANGELOG.md`](./CHANGELOG.md) — 4.1 is an additive, opt-in upgrade from 4.0 (a few documented behaviour changes); from 3.x see [`MIGRATION.md`](./MIGRATION.md).
 
 ## What's new in 4.0
 
 4.0 pairs a Radix / Base UI / shadcn **parity audit** with a library-wide **correctness hardening** pass. There are **no API-signature breaks** — see [`MIGRATION.md`](./MIGRATION.md) for the handful of behaviour changes.
 
 - **NuGet-free standalone eject** — `lumeo eject` (or `lumeo init --standalone`) vendors components **plus the whole runtime** as source, so a project compiles and runs with zero `Lumeo` / satellite `PackageReference`. Proven across all 164 components.
-- **Battle-test campaign** — an adversarial sweep of all 164 components fixed ~355 confirmed bugs (UI state surviving data refreshes, keyboard / ARIA, edge data, lifecycle teardown, keyed reorder), each with a bUnit regression test (suite 5,800+ green).
+- **Battle-test campaign** — an adversarial sweep of all 164 components fixed ~355 confirmed bugs (UI state surviving data refreshes, keyboard / ARIA, edge data, lifecycle teardown, keyed reorder), each with a bUnit regression test (suite 5,900+ green).
 - **OKLCH theme palette** — base + all 8 themes (878 tokens) migrated HSL → OKLCH, exact 1:1 (brand identity unchanged), matching Tailwind v4 / current shadcn.
 - **RTL** — new `DirectionProvider` + a logical-utility migration (`ml-→ms-`, `left-→start-`, …); identical in LTR, mirrored in RTL.
 - **tweakcn / shadcn native compatibility** — a bare shadcn `--primary` (or a pasted tweakcn export) drives Lumeo's tokens 1:1 with zero setup.
@@ -48,7 +48,7 @@
 - **Form validation** — DataAnnotations + custom validators with styled error states
 - **Accessible** — ARIA roles, keyboard navigation, focus trapping, screen-reader support
 - **Mobile-first** — touch gestures (swipe, pinch, long-press, pull-to-refresh, swipe-actions), 44×44 px hit targets per WCAG 2.5.5, iOS-style wheel pickers, haptic feedback service, safe-area helpers — try it at `/docs/mobile`
-- **5,800+ tests** — CI-enforced on every PR
+- **5,900+ tests** — CI-enforced on every PR
 
 ## Component Categories
 

--- a/docs/Lumeo.Docs/Pages/Docs/Accessibility.razor
+++ b/docs/Lumeo.Docs/Pages/Docs/Accessibility.razor
@@ -441,8 +441,9 @@
                 </li>
                 <li class="flex items-start gap-2">
                     <Lumeo.Text As="span" Class="mt-1.5 h-1.5 w-1.5 rounded-full bg-foreground shrink-0"></Lumeo.Text>
-                    <span>axe-core is not yet wired into CI as an automated gate. The scan below is run
-                        periodically by hand against the docs site, not on every commit or pull request.</span>
+                    <span>The axe-core sweep runs weekly (and on-demand) in CI against all 164 component
+                        routes, not per-commit or per-PR — a full sweep is a build + boot + 164-page crawl,
+                        too slow for the PR critical path. See the results below.</span>
                 </li>
                 <li class="flex items-start gap-2">
                     <Lumeo.Text As="span" Class="mt-1.5 h-1.5 w-1.5 rounded-full bg-foreground shrink-0"></Lumeo.Text>
@@ -509,51 +510,28 @@
     <Stack Gap="4">
         <Heading Level="2">Axe-core audit results</Heading>
         <Lumeo.Text Size="base" Color="muted" Leading="relaxed">
-            The docs site is periodically scanned with axe-core 4.10 across all major routes. The table below
-            summarises the most recent scan. Violations from browser-extension injected elements are excluded.
+            <code class="rounded bg-muted px-1.5 py-0.5 text-xs font-mono text-foreground">scripts/a11y-audit</code>
+            runs an axe-core WCAG A/AA sweep of every <code class="rounded bg-muted px-1.5 py-0.5 text-xs font-mono text-foreground">/components/&lt;slug&gt;</code>
+            docs route (all 164), scoped to each page's <code class="rounded bg-muted px-1.5 py-0.5 text-xs font-mono text-foreground">&lt;main&gt;</code>
+            content so shared app-shell chrome doesn't spam every report with the same findings. It runs weekly
+            and on-demand in CI, gated against a committed baseline of accepted-but-not-yet-fixed findings —
+            a pull request fails the gate only if it introduces a <em>new</em> (component, rule) violation, so
+            the backlog can only shrink, never silently grow.
         </Lumeo.Text>
 
-        <Alert Variant="Alert.AlertVariant.Success" Title="0 critical · 0 serious violations" ShowIcon="true">
-            All critical and serious axe-core violations have been resolved. The remaining findings are
-            moderate/minor and relate to third-party embedded content (PDF.js canvas, MapLibre GL map).
+        <Alert Variant="Alert.AlertVariant.Warning" Title="138 accepted critical/serious findings (last triage 2026-07-12)" ShowIcon="true">
+            These are tracked, known-not-yet-fixed violations across the component set — not zero. Each fix
+            removes its entry from the baseline in the same PR; any new (component, rule) pair not already in
+            the baseline fails CI. Confirmed false positives (shared docs-chrome or harness artifacts, e.g.
+            third-party embedded content like the PDF.js canvas or MapLibre GL map) are excluded entirely via
+            <code class="rounded bg-muted px-1.5 py-0.5 text-xs font-mono text-foreground">exclusions.json</code>
+            and aren't counted here.
         </Alert>
 
-        <div class="overflow-x-auto rounded-lg border border-border/40">
-            <Table>
-                <TableHeader>
-                    <TableRow>
-                        <TableHead Class="w-48">Route</TableHead>
-                        <TableHead Class="w-24">Before</TableHead>
-                        <TableHead Class="w-24">After</TableHead>
-                        <TableHead>Notes</TableHead>
-                    </TableRow>
-                </TableHeader>
-                <TableBody>
-                    <TableRow>
-                        <TableCell Class="font-medium"><code class="text-xs font-mono">/</code> (Home)</TableCell>
-                        <TableCell><Badge Variant="Badge.BadgeVariant.Destructive">6</Badge></TableCell>
-                        <TableCell><Badge Variant="Badge.BadgeVariant.Default" Class="bg-success text-success-text">0</Badge></TableCell>
-                        <TableCell>Fixed: DataGrid aggregate <code class="text-xs font-mono">role=row</code>, RadioGroupItem missing name, NumberInput missing label, code-block contrast (#64748b → #94a3b8)</TableCell>
-                    </TableRow>
-                    <TableRow>
-                        <TableCell Class="font-medium"><code class="text-xs font-mono">/components/button</code></TableCell>
-                        <TableCell><Badge Variant="Badge.BadgeVariant.Destructive">4</Badge></TableCell>
-                        <TableCell><Badge Variant="Badge.BadgeVariant.Default" Class="bg-success text-success-text">0</Badge></TableCell>
-                        <TableCell>Fixed: icon-only buttons in demo, sidebar nav landmark labels, sidebar subgroup contrast</TableCell>
-                    </TableRow>
-                    <TableRow>
-                        <TableCell Class="font-medium"><code class="text-xs font-mono">/docs/introduction</code></TableCell>
-                        <TableCell><Badge Variant="Badge.BadgeVariant.Destructive">4</Badge></TableCell>
-                        <TableCell><Badge Variant="Badge.BadgeVariant.Default" Class="bg-success text-success-text">0</Badge></TableCell>
-                        <TableCell>Fixed: code-block contrast, Alert h5→p heading order, landmark labels</TableCell>
-                    </TableRow>
-                </TableBody>
-            </Table>
-        </div>
-
         <Lumeo.Text Size="sm" Color="muted">
-            Scan date: 2026-05-25. Tool: axe-core 4.10.0 · rules: wcag2a, wcag2aa, best-practice.
-            Canvas-based and iframe-based third-party elements (MapLibre GL, PDF.js) are excluded from the scan scope.
+            Last triage: 2026-07-12. Tool: axe-core 4.12.1 · rules: wcag2a, wcag2aa, best-practice.
+            See <code class="rounded bg-muted px-1.5 py-0.5 text-xs font-mono text-foreground">scripts/a11y-audit/README.md</code>
+            for how to run the sweep locally and how the baseline/exclusions gate works.
         </Lumeo.Text>
     </Stack>
 

--- a/docs/Lumeo.Docs/Pages/Docs/BundleFacts.razor
+++ b/docs/Lumeo.Docs/Pages/Docs/BundleFacts.razor
@@ -425,7 +425,7 @@
                                 core and republished the same way. Its <code class="rounded bg-muted px-1.5 py-0.5 text-xs font-mono text-foreground">Lumeo.dll.br</code>
                                 measured 116,338 bytes (113.6 KiB) — an 83% reduction from the pre-#354 baseline for
                                 this usage shape. A headless-browser load check confirmed the trimmed publish still
-                                renders correctly (no console or page errors). An app using most or all 144 core
+                                renders correctly (no console or page errors). An app using most or all 143 core
                                 components will still approach the pre-#354 ceiling, since that shape genuinely
                                 reaches most of the assembly — trimming reduces cost with usage, it doesn't create free
                                 capacity. .NET runtime DLLs (~3–4&nbsp;MB brotli total) are excluded from every figure
@@ -569,7 +569,7 @@
 
     private readonly List<PackageRow> _packages =
     [
-        new("Lumeo",            "672 KB", 100, true,  "core — 144 components"),
+        new("Lumeo",            "672 KB", 100, true,  "core — 143 components"),
         new("Lumeo.Charts",     "128 KB",  20, false, "opt-in satellite"),
         new("Lumeo.DataGrid",   "120 KB",  19, false, "opt-in satellite"),
         new("Lumeo.Editor",      "29 KB",   5, false, "opt-in satellite"),
@@ -582,7 +582,7 @@
     [
         new("Package", "Lumeo.dll",
             "945 KB",
-            "Main Blazor component assembly — 3,076 KB raw IL, zip-compressed to 945 KB inside the .nupkg. The published WASM app brotli-compresses it to the 672 KB the browser actually downloads; the assembly itself is not IL-trimmed internally, so this size is the same whether you use 1 core component or all 144 (see 'What does WASM linker trimming do?' below)."),
+            "Main Blazor component assembly — 3,076 KB raw IL, zip-compressed to 945 KB inside the .nupkg. The published WASM app brotli-compresses it to the 672 KB the browser actually downloads; the assembly itself is not IL-trimmed internally, so this size is the same whether you use 1 core component or all 143 (see 'What does WASM linker trimming do?' below)."),
         new("FileText", "Lumeo.xml",
             "96 KB",
             "XML documentation comments for every public API. Powers IntelliSense in Visual Studio and Rider. Never included in the WASM publish output."),

--- a/docs/Lumeo.Docs/Pages/Home.razor
+++ b/docs/Lumeo.Docs/Pages/Home.razor
@@ -47,11 +47,11 @@
             <BlurFade DelayMs="190">
                 <Flex Wrap="true" Justify="center" Align="center" Gap="2" Class="mt-6">
                     <span class="inline-block rounded-full border border-border/50 bg-card/60 px-3 py-1 text-xs text-muted-foreground"><span class="font-semibold text-foreground">164</span> components</span>
-                    <span class="inline-block rounded-full border border-border/50 bg-card/60 px-3 py-1 text-xs text-muted-foreground"><span class="font-semibold text-foreground">24</span> blocks</span>
+                    <span class="inline-block rounded-full border border-border/50 bg-card/60 px-3 py-1 text-xs text-muted-foreground"><span class="font-semibold text-foreground">8</span> blocks</span>
                     <span class="inline-block rounded-full border border-border/50 bg-card/60 px-3 py-1 text-xs text-muted-foreground"><span class="font-semibold text-foreground">16</span> icon packs</span>
                     <span class="inline-block rounded-full border border-border/50 bg-card/60 px-3 py-1 text-xs text-muted-foreground"><span class="font-semibold text-foreground">672 KB</span> core</span>
                     <span class="inline-block rounded-full border border-border/50 bg-card/60 px-3 py-1 text-xs text-muted-foreground"><span class="font-semibold text-foreground">MIT</span></span>
-                    <span class="inline-block rounded-full border border-border/50 bg-card/60 px-3 py-1 text-xs text-muted-foreground"><span class="font-semibold text-foreground">5,800+</span> tests</span>
+                    <span class="inline-block rounded-full border border-border/50 bg-card/60 px-3 py-1 text-xs text-muted-foreground"><span class="font-semibold text-foreground">5,900+</span> tests</span>
                 </Flex>
             </BlurFade>
             <BlurFade DelayMs="240">
@@ -223,7 +223,7 @@
 
                     <Flex Align="center" Gap="2" Class="text-xs text-muted-foreground border-t border-border/40 pt-4">
                         <DynamicIcon Name="Info" Class="h-3.5 w-3.5" />
-                        <Lumeo.Text As="span">Brotli-compressed assembly bytes. Core brotli-compresses to 672 KB in your published app, whether you use 1 core component or all 144.</Lumeo.Text>
+                        <Lumeo.Text As="span">Brotli-compressed assembly bytes. Core brotli-compresses to 672 KB in your published app, whether you use 1 core component or all 143.</Lumeo.Text>
                     </Flex>
                 </Stack>
             </BentoTile>
@@ -236,7 +236,7 @@
                         </div>
                         <Stack Gap="0" Class="min-w-0 flex-1">
                             <Lumeo.Text Size="xs" Color="muted">Tests</Lumeo.Text>
-                            <div class="text-2xl font-semibold tracking-tight text-foreground leading-none">5,800+</div>
+                            <div class="text-2xl font-semibold tracking-tight text-foreground leading-none">5,900+</div>
                             <Lumeo.Text Size="xs" Color="muted" Class="truncate">CI green, every commit.</Lumeo.Text>
                         </Stack>
                     </Flex>
@@ -586,7 +586,7 @@ builder.Services.<span style="color: #a78bfa;">AddLumeo</span>();</pre>
 
         <Flex Align="center" Justify="between" Wrap="true" Gap="3" Class="mt-12 pt-6 border-t border-border/40">
             <Lumeo.Text Size="xs" Color="muted">&copy; Lumeo 2026 &middot; Released under the MIT License &middot; built with Lumeo</Lumeo.Text>
-            <Lumeo.Text Size="xs" Color="muted">164 components &middot; 24 blocks &middot; 16 icon packs &middot; 672 KB core &middot; 5,800+ tests</Lumeo.Text>
+            <Lumeo.Text Size="xs" Color="muted">164 components &middot; 8 blocks &middot; 16 icon packs &middot; 672 KB core &middot; 5,900+ tests</Lumeo.Text>
         </Flex>
     </Container>
 </footer>
@@ -599,7 +599,7 @@ builder.Services.<span style="color: #a78bfa;">AddLumeo</span>();</pre>
     // Size rows
     private readonly SizeRow[] _sizeRows =
     {
-        new("Lumeo",           "144 components", "672 KB", 100.0, true),
+        new("Lumeo",           "143 components", "672 KB", 100.0, true),
         new("Lumeo.Charts",    "30+ chart types", "128 KB",   32.0, false),
         new("Lumeo.DataGrid",  "3 components",  "120 KB",   30.0, false),
         new("Lumeo.Editor",    "1 component",  "29 KB",     7.25, false),
@@ -613,7 +613,7 @@ builder.Services.<span style="color: #a78bfa;">AddLumeo</span>();</pre>
     {
         new("FolderGit2",        "Vendor the source",       "lumeo add copies a component's source into your repo — edit it freely, no lock-in."),
         new("Palette",           "Tailwind CSS v4 native",  "CSS-variable theming, no SCSS pipeline. Swap palettes with lumeo apply --preset."),
-        new("Accessibility",     "Accessible by default",   "127 of 164 components carry automated accessibility tests — ARIA roles/attributes and keyboard behavior via bUnit, with Playwright E2E coverage for some. No axe-core scan or third-party audit yet.", "docs/accessibility"),
+        new("Accessibility",     "Accessible by default",   "128 of 164 components carry automated accessibility tests — ARIA roles/attributes and keyboard behavior via bUnit, with Playwright E2E coverage for some. Plus a weekly axe-core WCAG A/AA sweep of every component route, gated against a committed baseline.", "docs/accessibility"),
         new("MousePointerClick", "Motion built in",         "BlurFade, BorderBeam, Marquee and more — animation primitives with zero JS config."),
         new("ChartBar",          "Charts & data surfaces",  "30+ ECharts types plus a virtualized DataGrid with sort, group, and export."),
         new("Zap",               "AI primitives",           "Streaming messages, tool calls and prompt inputs — drop-in blocks for copilot UIs."),

--- a/scripts/server-leg/README.md
+++ b/scripts/server-leg/README.md
@@ -46,55 +46,43 @@ settle-timer/round-trip races) this leg exists to catch.
    to actually detach from the DOM (driven by the real
    `OnExitAnimationEnd` interop round-trip, not a blind timer).
 
-## Confirmed product bug: Toast under Blazor Server
+## Fixed product bug: Toast under Blazor Server (issue #363, closed)
 
-**Scenario 2 fails, by design of the assertion (not loosened).** Building
-this leg surfaced a real, reproducible bug: `ToastProvider` never renders a
-toast under a genuine interactive-server circuit.
+**Scenario 2 now passes — a hard `assert()`, not loosened.** This leg
+originally surfaced a real, reproducible bug: `ToastProvider` never rendered
+a toast under a genuine interactive-server circuit.
 
-**Root-caused, not just observed:**
-- `ToastService.Show()` executes and returns a valid id — confirmed via a
+**Root-caused, not just observed (original diagnosis):**
+- `ToastService.Show()` executed and returned a valid id — confirmed via a
   second, independent subscriber added directly in `Home.razor`
-  (`Toast.OnShow += ...`), which *does* fire for every call.
+  (`Toast.OnShow += ...`), which *did* fire for every call.
 - `ToastProvider.HandleShow` is subscribed to the same event and calls
   `SafeAsyncDispatcher.FireAndForget(InvokeAsync, () => HandleShowAsync(...))`
   (see `src/Lumeo/UI/Toast/ToastProvider.razor` and
-  `src/Lumeo/Services/SafeAsyncDispatcher.cs`), which swallows lifecycle
-  exceptions and logs anything else to `Console.Error` — nothing was ever
-  logged.
+  `src/Lumeo/Services/SafeAsyncDispatcher.cs`).
 - Captured raw WebSocket frames on the `_blazor` circuit (Playwright's
-  `page.on('websocket')` / `framereceived`): **zero new frames arrive**
-  after the burst click, for as long as 3 seconds. No render batch is ever
-  sent — this is a server-side dispatch failure, not a slow/lost client
-  update.
-- Isolated to Toast specifically: the **same page**, same render-mode setup,
-  same circuit — Dialog's `@bind-Open` (same-component two-way binding) and
-  DatePicker's popover both work correctly and were verified interactively.
-  Only the cross-component **provider + fire-and-forget-event** pattern
-  (Toast's architecture) fails.
-- Not a prerendering artifact: reproduces identically with
-  `@rendermode="@(new InteractiveServerRenderMode(prerender: false))"`.
+  `page.on('websocket')` / `framereceived`) showed **zero new frames
+  arriving** after the burst click — a server-side dispatch failure, not a
+  slow/lost client update.
+- Isolated to Toast specifically: Dialog's `@bind-Open` and DatePicker's
+  popover both worked correctly on the same page/circuit. Only the
+  cross-component **provider + fire-and-forget-event** pattern (Toast's
+  architecture) failed.
 
-**Not fixed here** — per instructions, product issues are reported, not
-hacked around from a test harness. `Home.razor`'s `BurstToasts` carries a
-comment pointing back to this section. The assertion in `run.mjs` stays
-honest (asserts real toast visibility, not "it didn't crash") so a future
-fix in `ToastProvider`/`SafeAsyncDispatcher` is provable by this scenario
-flipping to PASS.
+**Fixed by the toast admission rework (#357):** the canonical
+`TryAdmit`/`ReconcileGroup` admission model with synchronous `Leaving`
+stamps and a capped pending queue. Re-verified fixed on master (post-#357
+merge) via this leg at 200ms RTT: after a burst of 8, 5 toasts are visible,
+the `MaxToasts=5` cap invariant holds, and there is no renderer crash — all
+8 server-leg assertions pass (7 PASS baseline + this scenario). The scenario
+had been flagged `assertKnownBroken()`/XFAIL since this leg's introduction;
+it flipped to XPASS after #357 and has now been promoted to a plain
+`assert()` in `run.mjs` so a future regression here fails the leg for real.
 
-**Bonus finding — it's not just cosmetic:** `run.mjs` deliberately runs the
-Dialog scenario *before* the Toast scenario. With Toast first, the 8
-fire-and-forget `SafeAsyncDispatcher` dispatches that never resolve left the
-circuit unable to complete Dialog's (unrelated) open round-trip within any
-reasonable timeout under RTT throttling — i.e. this isn't purely a "toasts
-don't render" bug, it may also degrade the circuit's ability to process
-later, unrelated interactive events. Worth confirming under a longer-running
-session (this harness only observed it once, immediately downstream).
-
-**Likely next step for whoever picks this up:** compare
-`SafeAsyncDispatcher.FireAndForget`'s dispatch path against a
-known-working Blazor Server cross-component `InvokeAsync` + `StateHasChanged`
-pattern under a *real* circuit (this codebase's test suite is 100% WASM/bUnit
-— bUnit's synchronous test renderer and WASM's single-threaded execution
-both appear to mask whatever this is; it needed a real SignalR circuit to
-surface).
+**Bonus finding from the original investigation — not just cosmetic:**
+`run.mjs` deliberately runs the Dialog scenario *before* the Toast scenario.
+With Toast first (pre-fix), the 8 fire-and-forget `SafeAsyncDispatcher`
+dispatches that never resolved left the circuit unable to complete Dialog's
+(unrelated) open round-trip within any reasonable timeout under RTT
+throttling. The ordering is left as-is since it no longer matters
+functionally (both scenarios pass either way post-fix) but doesn't hurt.

--- a/scripts/server-leg/run.mjs
+++ b/scripts/server-leg/run.mjs
@@ -300,11 +300,12 @@ async function scenarioDataGridDragCommit(page, rtt) {
 
 // ---------------------------------------------------------------------
 // Scenario 2: Toast burst — cap invariant holds visually.
-// KNOWN BROKEN — see README.md. The "at least one toast renders" assertion
-// is kept honest (not loosened/skipped, still exercised every run) via
-// assertKnownBroken() so a future fix is provable by this flipping XFAIL ->
-// XPASS, WITHOUT making a red exit code the permanent, ignorable default for
-// this leg (npm test / CI must be able to treat this leg as a real gate).
+// Formerly KNOWN BROKEN under Blazor Server (see README.md) — fixed by the
+// toast admission rework (#357: canonical TryAdmit/ReconcileGroup, synchronous
+// Leaving stamps, capped pending queue) and re-verified fixed on master via
+// this leg (issue #363, closed): XPASSed with all 8 server-leg assertions
+// green. Promoted from assertKnownBroken() to a plain assert() so a future
+// regression here fails the leg for real instead of only logging XFAIL.
 // ---------------------------------------------------------------------
 async function scenarioToastBurst(page, rtt) {
   console.log(`\n--- Scenario: Toast burst cap invariant under ${rtt}ms RTT ---`);
@@ -314,10 +315,10 @@ async function scenarioToastBurst(page, rtt) {
   await page.waitForTimeout(rtt * 4 + 1_000);
   const toastCount = await page.evaluate(() =>
     document.querySelectorAll('[role="status"], [role="alert"]').length);
-  assertKnownBroken(toastCount > 0,
+  assert(toastCount > 0,
     `at least one toast is visible after firing a burst of 8 (got ${toastCount}) — ` +
-    `KNOWN FAILURE: confirmed product bug, ToastProvider never renders under Blazor Server ` +
-    `(ToastService.OnShow fires, but no SignalR render batch is sent — see README.md)`);
+    `regression check: ToastProvider must render under Blazor Server ` +
+    `(ToastService.OnShow fires and a SignalR render batch must be sent — see README.md, issue #363)`);
   assert(toastCount <= 5,
     `visible toast count never exceeds MaxToasts=5 (got ${toastCount})`);
 }

--- a/scripts/sr-audit/README.md
+++ b/scripts/sr-audit/README.md
@@ -6,21 +6,31 @@ captures its spoken output; `@guidepup/setup` provisions a **portable** NVDA
 with no system-wide install). VoiceOver (macOS) is out of scope here and
 stays manual — Guidepup's VoiceOver driver needs a macOS host.
 
-## Status: setup works, live run is blocked in this environment
+## Status: setup works, live runs now work unattended
 
 - **Setup: done, confirmed working.** `npx @guidepup/setup` (via `npm run
   setup`) downloaded and registered a portable NVDA build with no admin
   rights and no system-wide install. See "What setup changed" below.
-- **Live NVDA automation: blocked here by a foreground-focus problem, not
-  a Guidepup/NVDA problem.** `check-env.mjs` reproduces and diagnoses this
-  precisely. See "Known blocker" below — this is the honest failure report
-  the task asked for.
+- **Live NVDA automation: unblocked.** The foreground-focus problem
+  described below (NVDA only reads the real OS-foreground window, which a
+  programmatically-launched browser never gets on Windows) is solved by
+  `run.mjs --force-foreground`, which drags Edge to real foreground via
+  `force-foreground.ps1` (ALT-key foreground-lock release +
+  `AttachThreadInput` + `SetForegroundWindow`), re-asserted before each
+  component. Validated end-to-end: NVDA correctly read live announcements
+  (e.g. "Package Reference, tab, selected, 2 of 3") and Home correctly moved
+  focus to the first tab. `--pause` remains available as a human-in-the-loop
+  fallback (click Edge, auto-countdown) when running with a person present.
+  One known gap remains: the row-1 "focus" step still relies on
+  programmatic `el.focus()`, which NVDA does not announce (it only speaks on
+  user-driven navigation) — a `reportCurrentFocus` command was tried but
+  shifted NVDA to the Edge toolbar and corrupted following steps, so this is
+  left as a follow-up (e.g. Tab into the component with real key events); the
+  navigation steps, which do capture real announcements, are unaffected.
 - `run.mjs` is a complete, ready-to-run implementation of the top-5-component
-  sweep. It was **not** run end-to-end against the real docs site in this
-  session, because doing so on this machine right now would only produce
-  empty/`FAIL` noise from the blocker below, not genuine signal about the
-  components. A maintainer should run it after clearing the blocker (see
-  "What to run locally instead").
+  sweep. Run it with `--force-foreground` for a fully unattended sweep, or
+  `--pause` when a human is present to click Edge into focus (see "How to
+  run it" below).
 
 ## What setup changed
 
@@ -43,7 +53,10 @@ Nothing under `Program Files`, no Windows service, no scheduled task. To
 fully undo it: delete the `%TEMP%\guidepup_nvda_*` folder and the
 `HKCU:\Software\Guidepup` registry key.
 
-## Known blocker: OS foreground focus
+## Root cause: OS foreground focus (solved via `--force-foreground`)
+
+This section documents the original diagnosis; it's now mitigated by
+`run.mjs --force-foreground` (see "Status" above) rather than an open blocker.
 
 NVDA's navigation commands (`next()`, arrow-key presses, etc.) read whatever
 currently holds **real OS foreground focus** — not just whatever window is
@@ -79,27 +92,23 @@ the task anticipated — the session is fully interactive, not headless — it's
 a **different, more mundane** foreground-focus contention that happens to
 produce the same symptom (silence).
 
-## What a maintainer must run locally instead
+## How to run it
 
 To get real PASS/PARTIAL/FAIL results:
 
-1. Use a machine/session dedicated to this run — ideally a fresh interactive
-   Windows sign-in (RDP session used only for this, or a Windows CI runner
-   with no other GUI apps) so no other window can hold foreground focus.
-   Close/resolve any pending Windows Security / credential dialogs first.
-2. `cd scripts/sr-audit && npm install`
-3. `npm run setup` (skips cleanly if NVDA is already registered).
-4. `node check-env.mjs` — **all three checks must PASS** before proceeding.
-   If check 3 fails, nothing downstream will produce real data; fix the
-   foreground-focus contention (close whatever dialog/app is stuck in the
-   foreground, or run in a session where this script is the only GUI actor)
-   and re-run `check-env.mjs` until it's clean.
-5. `npm run run` (`node run.mjs`) — builds `docs/Lumeo.Docs` (Release),
-   boots it on `localhost:5292`, launches Edge (headed — NVDA needs a real
-   visible window, not headless), starts NVDA, and walks the top-5
+1. `cd scripts/sr-audit && npm install`
+2. `npm run setup` (skips cleanly if NVDA is already registered).
+3. `node check-env.mjs` — run once as a sanity check. If check 3 (foreground
+   focus) fails on your machine, pass `--force-foreground` to `run.mjs` in
+   the next step (or `--pause` for a human-in-the-loop fallback) rather than
+   trying to make `check-env.mjs` itself pass — it predates the fix.
+4. `node run.mjs --force-foreground` (or `npm run run -- --force-foreground`)
+   — builds `docs/Lumeo.Docs` (Release), boots it on `localhost:5292`,
+   launches Edge (headed — NVDA needs a real visible window, not headless),
+   starts NVDA, drags Edge to real foreground, and walks the top-5
    components: **DataGrid, FileManager, Tabs, Calendar, Cascader** (see
    "Component selection" below). Writes `results/nvda-<date>.json`.
-6. Everything the script starts (NVDA, the browser, the `dotnet run` docs
+5. Everything the script starts (NVDA, the browser, the `dotnet run` docs
    server) is torn down at the end of `run.mjs`, mirroring what this session
    did manually.
 

--- a/tests/Lumeo.Tests.E2E/README.md
+++ b/tests/Lumeo.Tests.E2E/README.md
@@ -58,14 +58,11 @@ perceptual diff (ImageSharp). Add per-page tests as the docs surface stabilizes.
 
 ## CI integration
 
-These tests are **not yet wired into CI by default** — they require:
-1. A running docs server
-2. Playwright browser binaries
+Wired into CI via `.github/workflows/e2e.yml`, which runs on every push and
+PR to `master`: it builds the CSS bundles, builds `Lumeo.Tests.E2E` (Release,
+which also restores the Playwright assets), installs the Playwright Chromium
+browser, and runs the tests against a docs server the workflow starts.
 
-When ready, create a separate GitHub Actions workflow that:
-1. Builds and starts `Lumeo.Docs` in the background
-2. Runs `playwright.ps1 install --with-deps chromium`
-3. Runs the tests with `LUMEO_E2E_BASE_URL` pointing at the running server
-
-The test project builds cleanly in CI without any of the above (just
-`dotnet build`) — only **running** the tests requires the dev server.
+The test project also builds cleanly outside that workflow with a plain
+`dotnet build` — only **running** the tests requires a docs dev-server and
+Playwright browser binaries (see "Running locally" above).


### PR DESCRIPTION
Measured every stat/claim in this table against the repo at HEAD (commands shown); rounded down for "+" claims per the honesty convention already used on this page.

| File | Old | New | Source |
|---|---|---|---|
| README.md, Home.razor (3x) | 5,800+ tests | 5,900+ tests | `dotnet test Lumeo.slnx --no-build --filter "FullyQualifiedName!~Lumeo.Tests.E2E&Category!=EjectGateFull"` → Lumeo.Tests: 5974 (rounded down) |
| Home.razor, BundleFacts.razor (4x) | 144 components (core) / "all 144" | 143 components / "all 143" | registry.json: `nugetPackage == "Lumeo"` count = 143 (of 164 total) |
| Home.razor (2x) | 24 blocks | 8 blocks | registry-search.json: `type == "block"` count = 8 (matches 8 files under `docs/Lumeo.Docs/Pages/Blocks/`) |
| Home.razor | 127 of 164 components carry automated accessibility tests / "No axe-core scan ... yet" | 128 of 164 / added note about the weekly CI axe-core sweep | registry.json: `testCoverage.a11y == true` count = 128; `.github/workflows/a11y-audit.yml` exists and runs weekly + on-demand |
| Accessibility.razor | "axe-core is not yet wired into CI"; stale one-time May-25 before/after table claiming 0 critical/0 serious | Rewrote to describe the current automated weekly sweep of all 164 routes, gated against `scripts/a11y-audit/baseline.json` (138 accepted critical/serious findings, last triage 2026-07-12) | `scripts/a11y-audit/README.md`, `.github/workflows/a11y-audit.yml`, `baseline.json` (138 entries, generated 2026-07-12), axe-core resolved version 4.12.1 (package-lock.json) |

Verified unchanged (checked, not stale): 164 components, 16 patterns, 8 blocks, 31 guides (registry-search.json); 16 icon packs (16 `Lumeo.Icons.*` projects); 11 packages (11 distinct `nugetPackage` values); 13 categories; 414 visual baselines; 138 axe baseline pairs (this is the number now surfaced on the Accessibility page, previously absent); 51,000+ icons (no icon-pack source changed since the last verified measurement).

## Tool-narrative updates

- **`scripts/sr-audit/README.md`** — was written when the NVDA harness was blocked by an OS foreground-focus problem (documented as unsolved). It's since been fixed (`d578ce72`): `run.mjs --force-foreground` drags the browser to real OS foreground via `force-foreground.ps1`, validated end-to-end. Rewrote the status section to describe the working unattended path, kept the original root-cause diagnosis for context, and noted the one remaining known gap (row-1 programmatic-focus doesn't get announced by NVDA).
- **`scripts/server-leg/run.mjs` + `README.md`** — the toast-burst scenario was marked `assertKnownBroken()` (XFAIL) for a confirmed Blazor-Server ToastProvider dispatch bug (issue #363). The toast admission rework (#357) fixed it; re-verified fixed on master via this leg (issue #363, closed, XPASS: 7 PASS baseline + this scenario). Promoted the scenario to a plain `assert()` so a future regression fails the leg for real, and updated the README's bug writeup to reflect the fix instead of describing it as still broken.
- **`tests/Lumeo.Tests.E2E/README.md`** — claimed E2E tests were "not yet wired into CI by default". `.github/workflows/e2e.yml` already runs them on every push/PR to master; updated the CI-integration section to describe that workflow.

## Not changed (flagged, left as-is)

- **Changelog.razor / CHANGELOG.md** — left untouched by design (historical entries); the current top entries (v4.2.0, Unreleased) had no stale numeric claims to begin with.
- **`docs/superpowers/shadcn-parity-audit-2026-07.md`**, **`shadcn-parity-test-checklist.md`** — dated, point-in-time snapshots referencing a since-merged branch (`feat/shadcn-parity-wave1`); treated as historical records, same category as the battle-wave triage docs, and left untouched.
- **`docs/superpowers/sr-test-protocol.md`** — no automation-status or setup-currency notes exist in this file to update (it's purely the manual protocol); nothing changed.
- **E2E fact/theory count** — measured 30 via `grep -rcE '\[(Fact|Theory)' tests/Lumeo.Tests.E2E --include=*.cs`, vs. the "known 32" approximation in the task brief; no docs page currently hardcodes this number, so nothing needed changing, but flagging the discrepancy for awareness.
- **`skills/lumeo/references/catalog.md`** and related skill docs — already correct (164 components, 16 patterns, 58 theme tokens all verified current); not regenerated since no drift found.

No version bump (stays 4.2.0 — 4.3.0 is a separate pending release, not pre-announced here).

## Gate results

- `dotnet build docs/Lumeo.Docs/Lumeo.Docs.csproj -m:1` — succeeded, 0 warnings / 0 errors.
- `python scripts/docs-parity/check.py` — exit 0 (source `[Parameter]`s and documented API tables in parity; one pre-existing non-blocking casing warning unrelated to this change).
- `dotnet build Lumeo.slnx -warnaserror -m:1` — Build succeeded, real-diag count 0 (`error|warning (CS|IL|RS|CA|NU|MSB)####` grep).
- `dotnet test tests/Lumeo.Docs.Tests/Lumeo.Docs.Tests.csproj --no-build -m:1` — 36/36 passed.
- Registry freshness: `git status --short src/Lumeo/registry` empty throughout; `docs/Lumeo.Docs/wwwroot/registry.json` regenerates its `generated` timestamp on every build (no content change) — reverted before each commit so the diff stays clean.