### PR TITLE
docs(a11y): real NVDA-audit status + continuous-improvement statement

### DIFF
--- a/docs/Lumeo.Docs/Pages/Docs/Accessibility.razor
+++ b/docs/Lumeo.Docs/Pages/Docs/Accessibility.razor
@@ -27,6 +27,12 @@
             for interaction patterns, and use native HTML semantics wherever possible. When ARIA roles are necessary,
             they are applied automatically so you do not need to add them manually.
         </Lumeo.Text>
+        <Lumeo.Text Size="base" Color="muted" Leading="relaxed">
+            Accessibility is continuous work, not a checkbox: the automated audits below run on an ongoing basis,
+            and what they find flows straight back into the library as fixes — most recently keyboard navigation
+            for the FileManager folder tree and popup semantics on the Cascader trigger, both found by the
+            screen-reader audit described below.
+        </Lumeo.Text>
     </Stack>
 
     <Separator Class="my-4" />
@@ -429,6 +435,19 @@
                         where <code class="rounded bg-muted px-1.5 py-0.5 text-xs font-mono text-foreground">testCoverage.e2e</code>
                         is true.</span>
                 </li>
+                <li class="flex items-start gap-2">
+                    <Lumeo.Text As="span" Class="mt-1.5 h-1.5 w-1.5 rounded-full bg-foreground shrink-0"></Lumeo.Text>
+                    <span><strong class="text-foreground">Screen-reader audit (NVDA, automated).</strong>
+                        <code class="rounded bg-muted px-1.5 py-0.5 text-xs font-mono text-foreground">scripts/sr-audit</code>
+                        drives a real NVDA instance (via Guidepup) against every component docs route and captures
+                        what it actually speaks. The 18 highest-keyboard-surface components are verified against the
+                        expected announcements of the screen-reader protocol (27/27 checks passing, run 2026-07-13);
+                        every other page is probed for a genuine focus announcement of its demo element — 134 of the
+                        remaining 146 announce correctly; the other 12 have no keyboard-focusable demo element
+                        (mostly display-only components, plus a few link-based or pointer-driven demos tracked for
+                        follow-up). Findings become fixes: this audit is what surfaced the FileManager tree keyboard
+                        gap and the Cascader trigger's missing popup semantics.</span>
+                </li>
             </ul>
         </Stack>
 
@@ -447,8 +466,8 @@
                 </li>
                 <li class="flex items-start gap-2">
                     <Lumeo.Text As="span" Class="mt-1.5 h-1.5 w-1.5 rounded-full bg-foreground shrink-0"></Lumeo.Text>
-                    <span>There has been no systematic pass with NVDA or VoiceOver across the component set.
-                        Screen-reader feedback is genuinely welcomed —
+                    <span>No VoiceOver (macOS) pass yet — the automated screen-reader audit above currently covers
+                        NVDA on Windows only. Screen-reader feedback is genuinely welcomed —
                         <Lumeo.Link Href="https://github.com/Brain2k-0005/Lumeo/issues" Class="text-foreground underline underline-offset-4 hover:text-muted-foreground transition-colors">please open a GitHub issue</Lumeo.Link>
                         if something doesn't announce correctly.</span>
                 </li>


### PR DESCRIPTION
The Accessibility page's honesty section still said 'no systematic pass with NVDA or VoiceOver' — stale since today's automated NVDA audit. Now documents the measured reality (18 protocol components 27/27 checks passing; 134/146 remaining pages announce their demo element; 12 without a focusable demo element, honestly qualified) and keeps VoiceOver as the named remaining gap. Adds the continuous-improvement statement to 'Our approach' with the two audit-found, already-merged fixes as evidence. Gates: docs build 0 errors, parity OK, Lumeo.Docs.Tests 36/36.