### PR TITLE
fix(datagrid): sorting ignored while grouping is active

### DIFF
--- a/docs/Lumeo.Docs/wwwroot/registry/cdn-deps.json
+++ b/docs/Lumeo.Docs/wwwroot/registry/cdn-deps.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0",
-  "generated": "2026-07-18T08:12:42.4994039Z",
+  "generated": "2026-07-22T14:36:14.2184664Z",
   "deps": [
     {
       "key": "mapLibreJs",

--- a/docs/Lumeo.Docs/wwwroot/registry/data-grid.json
+++ b/docs/Lumeo.Docs/wwwroot/registry/data-grid.json
@@ -3065,8 +3065,8 @@
   },
   "testCoverage": {
     "tier": 4,
-    "files": 42,
-    "tests": 290,
+    "files": 43,
+    "tests": 299,
     "relatedFiles": 1,
     "render": true,
     "behavior": true,
@@ -3730,6 +3730,7 @@
     "tests/Lumeo.Tests/Components/DataGrid/DataGridGroupCollapsePersistenceTests.cs",
     "tests/Lumeo.Tests/Components/DataGrid/DataGridGroupPanelTests.cs",
     "tests/Lumeo.Tests/Components/DataGrid/DataGridGroupRowIndexTests.cs",
+    "tests/Lumeo.Tests/Components/DataGrid/DataGridGroupedSortingTests.cs",
     "tests/Lumeo.Tests/Components/DataGrid/DataGridHeaderDragRedesignTests.cs",
     "tests/Lumeo.Tests/Components/DataGrid/DataGridKeyboardNavTests.cs",
     "tests/Lumeo.Tests/Components/DataGrid/DataGridKeyboardPreventDefaultTests.cs",

--- a/docs/Lumeo.Docs/wwwroot/registry/sortable.json
+++ b/docs/Lumeo.Docs/wwwroot/registry/sortable.json
@@ -286,6 +286,7 @@
     "tests/Lumeo.Tests.E2E/Smokes/DragInteractionTests.cs",
     "tests/Lumeo.Tests/Components/DataGrid/DataGridAutoSaveStaleTests.cs",
     "tests/Lumeo.Tests/Components/DataGrid/DataGridExpandableTests.cs",
+    "tests/Lumeo.Tests/Components/DataGrid/DataGridGroupedSortingTests.cs",
     "tests/Lumeo.Tests/Components/DataGrid/DataGridHeaderDragRedesignTests.cs",
     "tests/Lumeo.Tests/Components/DataGrid/DataGridKeyboardNavTests.cs",
     "tests/Lumeo.Tests/Components/DataGrid/DataGridKeyboardPreventDefaultTests.cs",

--- a/src/Lumeo.DataGrid/UI/DataGrid/DataGrid.razor
+++ b/src/Lumeo.DataGrid/UI/DataGrid/DataGrid.razor
@@ -2431,6 +2431,29 @@
     }
 
     // ---- Single-level grouping (classic; now with per-group aggregates) ----
+    // Bug fix: group ORDER (the order the group sections/nodes themselves
+    // appear in, as opposed to row order WITHIN a group) used to be hardcoded
+    // ascending-by-key regardless of the grid's active Sorts — so clicking a
+    // grouped column's header to toggle Ascending/Descending had no visible
+    // effect at all, which is what got reported as "sorting doesn't work
+    // while grouping is active." Sorting a DIFFERENT (non-grouped) column
+    // already worked correctly (LINQ's GroupBy preserves _processedItems'
+    // pre-sorted relative order within each group), so this fix is scoped to
+    // group ORDER only.
+    //
+    // Semantic chosen (matches TanStack Table / AG Grid / MUI DataGrid's
+    // grouped-column behaviour, and is the only one under which sorting a
+    // grouped column can ever be visible at all): a group's member rows all
+    // share the SAME value for the grouped field by definition, so "sort
+    // within the group" is a no-op for that field — the ONLY way a user's
+    // Asc/Desc choice on the grouped column can express itself is by
+    // reordering the GROUPS. When the active Sorts contains an entry for the
+    // grouping field, its Direction governs group order (Descending reverses
+    // the normal alphabetical run); otherwise (no sort on that field, or
+    // explicitly None) falls back to the original ascending-by-key default.
+    private SortDirection GroupOrderDirection(string field) =>
+        _sorts.FirstOrDefault(s => s.Field == field)?.Direction ?? SortDirection.Ascending;
+
     private bool ProcessSingleLevelGrouping(string field)
     {
         var groupCol = EffectiveColumns.FirstOrDefault(c => c.Field == field);
@@ -2439,9 +2462,12 @@
         var groupByChanged = field != _lastGroupBy;
         _lastGroupBy = field;
 
-        _groupedSections = _processedItems
-            .GroupBy(item => groupCol.GetFormattedValue(item, EffectiveCulture))
-            .OrderBy(g => g.Key, StringComparer.CurrentCulture)
+        var groupedByKey = _processedItems.GroupBy(item => groupCol.GetFormattedValue(item, EffectiveCulture));
+        var orderedGroups = GroupOrderDirection(field) == SortDirection.Descending
+            ? groupedByKey.OrderByDescending(g => g.Key, StringComparer.CurrentCulture)
+            : groupedByKey.OrderBy(g => g.Key, StringComparer.CurrentCulture);
+
+        _groupedSections = orderedGroups
             .Select(g =>
             {
                 var its = g.ToList();
@@ -2572,9 +2598,16 @@
             // Skip a missing field — try the next level so grouping degrades gracefully.
             return BuildGroupNodes(items, fields, level + 1, parentPath);
         }
-        return items
-            .GroupBy(it => col.GetFormattedValue(it, EffectiveCulture))
-            .OrderBy(g => g.Key, StringComparer.CurrentCulture)
+        // Same group-order-follows-the-grouped-field's-Sort fix as
+        // ProcessSingleLevelGrouping (see GroupOrderDirection's own remarks) —
+        // applied per LEVEL, since each nesting level groups by its own field
+        // and should honour ITS OWN Sorts entry independently.
+        var groupedByKey = items.GroupBy(it => col.GetFormattedValue(it, EffectiveCulture));
+        var orderedGroups = GroupOrderDirection(fields[level]) == SortDirection.Descending
+            ? groupedByKey.OrderByDescending(g => g.Key, StringComparer.CurrentCulture)
+            : groupedByKey.OrderBy(g => g.Key, StringComparer.CurrentCulture);
+
+        return orderedGroups
             .Select(g =>
             {
                 var its = g.ToList();

--- a/src/Lumeo/registry/cdn-deps.json
+++ b/src/Lumeo/registry/cdn-deps.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0",
-  "generated": "2026-07-18T08:12:42.4994039Z",
+  "generated": "2026-07-22T14:36:14.2184664Z",
   "deps": [
     {
       "key": "mapLibreJs",

--- a/src/Lumeo/registry/registry.json
+++ b/src/Lumeo/registry/registry.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://lumeo.nativ.sh/registry-schema.json",
   "version": "4.3.3",
-  "generated": "2026-07-18T08:12:23.3710579Z",
+  "generated": "2026-07-22T14:35:58.6148610Z",
   "components": {
     "accordion": {
       "name": "Accordion",
@@ -1750,8 +1750,8 @@
       "registryUrl": "https://lumeo.nativ.sh/registry/data-grid.json",
       "testCoverage": {
         "tier": 4,
-        "files": 42,
-        "tests": 290,
+        "files": 43,
+        "tests": 299,
         "relatedFiles": 1,
         "render": true,
         "behavior": true,

--- a/tests/Lumeo.Tests/Components/DataGrid/DataGridGroupedSortingTests.cs
+++ b/tests/Lumeo.Tests/Components/DataGrid/DataGridGroupedSortingTests.cs
@@ -1,0 +1,282 @@
+using Bunit;
+using Xunit;
+using Lumeo.Tests.Helpers;
+
+namespace Lumeo.Tests.Components.DataGrid;
+
+/// <summary>
+/// Regression tests for a reported bug: with grouping active, clicking a
+/// column header to toggle Ascending/Descending sort appeared to do nothing.
+///
+/// Root cause: <c>ProcessSingleLevelGrouping</c> and <c>BuildGroupNodes</c>
+/// (multi-level) built the group list via
+/// <c>.GroupBy(...).OrderBy(g => g.Key, StringComparer.CurrentCulture)</c> —
+/// the group ORDER (which group section/node comes first) was hardcoded
+/// ascending-by-key, completely independent of the grid's active Sorts. Row
+/// order WITHIN a group was never actually broken: LINQ's GroupBy preserves
+/// the source sequence's relative order inside each group, and the sort is
+/// applied to `_processedItems` before grouping — so sorting a column OTHER
+/// than the grouped one already worked. The bug is specifically: sorting the
+/// GROUPED column itself had zero visible effect, since a group's members
+/// all share the same value for that field (sorting within the group is
+/// necessarily a no-op) and group order — the only place the sort direction
+/// COULD show up — was hardcoded.
+///
+/// Fix: group order now honours the active <c>Sorts</c> entry for the
+/// grouping field (Descending reverses the group run), falling back to the
+/// original ascending-by-key default when that field has no active sort.
+/// This matches how grouped columns behave in TanStack Table / AG Grid / MUI
+/// DataGrid — sorting the grouped field controls group order; sorting any
+/// other field controls order within each group.
+/// </summary>
+public class DataGridGroupedSortingTests : IAsyncLifetime
+{
+    private readonly BunitContext _ctx = new();
+
+    public DataGridGroupedSortingTests()
+    {
+        _ctx.AddLumeoServices();
+    }
+
+    public Task InitializeAsync() => Task.CompletedTask;
+    public async Task DisposeAsync() => await _ctx.DisposeAsync();
+
+    private class Row
+    {
+        public int Id { get; set; }
+        public string Category { get; set; } = "";
+        public string Name { get; set; } = "";
+    }
+
+    private static List<Row> Data() => new()
+    {
+        new Row { Id = 1, Category = "B", Name = "Zed" },
+        new Row { Id = 2, Category = "A", Name = "Amy" },
+        new Row { Id = 3, Category = "B", Name = "Anna" },
+        new Row { Id = 4, Category = "A", Name = "Bob" },
+    };
+
+    private static List<DataGridColumn<Row>> Columns() => new()
+    {
+        new() { Field = "Category", Title = "Category", Sortable = true, Groupable = true },
+        new() { Field = "Name", Title = "Name", Sortable = true },
+    };
+
+    private static AngleSharp.Dom.IElement SortButtonFor<TItem>(IRenderedComponent<Lumeo.DataGrid<TItem>> cut, string title)
+    {
+        var header = cut.FindAll("th[data-slot='datagrid-header-cell']").First(h => h.TextContent.Contains(title));
+        return header.QuerySelector("button[data-slot='datagrid-sort-button']")!;
+    }
+
+    private static List<string> NameCellValues(IRenderedComponent<Lumeo.DataGrid<Row>> cut) =>
+        cut.FindAll("[data-slot='datagrid-row']")
+            .Select(row => row.QuerySelectorAll("td").ElementAt(1).TextContent.Trim())
+            .ToList();
+
+    // ── Group order follows the GROUPED column's own sort direction ─────────
+
+    [Fact]
+    public void Sorting_The_Grouped_Column_Ascending_Keeps_Default_AZ_Group_Order()
+    {
+        var cut = _ctx.Render<Lumeo.DataGrid<Row>>(p => p
+            .Add(x => x.Items, Data())
+            .Add(x => x.GroupBy, "Category")
+            .Add(x => x.Columns, Columns()));
+
+        SortButtonFor(cut, "Category").Click(); // None -> Ascending
+
+        Assert.Equal(new[] { "A", "B" }, cut.FindAll("[data-slot='datagrid-group-row']").Select(e => e.TextContent.Trim()[..1]));
+    }
+
+    [Fact]
+    public void Sorting_The_Grouped_Column_Descending_Reverses_Group_Order()
+    {
+        var cut = _ctx.Render<Lumeo.DataGrid<Row>>(p => p
+            .Add(x => x.Items, Data())
+            .Add(x => x.GroupBy, "Category")
+            .Add(x => x.Columns, Columns()));
+
+        var sortBtn = SortButtonFor(cut, "Category");
+        sortBtn.Click(); // Ascending
+        sortBtn.Click(); // Descending
+
+        Assert.Equal(new[] { "B", "A" }, cut.FindAll("[data-slot='datagrid-group-row']").Select(e => e.TextContent.Trim()[..1]));
+    }
+
+    [Fact]
+    public void Clearing_Sort_On_The_Grouped_Column_Restores_Default_AZ_Order()
+    {
+        var cut = _ctx.Render<Lumeo.DataGrid<Row>>(p => p
+            .Add(x => x.Items, Data())
+            .Add(x => x.GroupBy, "Category")
+            .Add(x => x.Columns, Columns()));
+
+        var sortBtn = SortButtonFor(cut, "Category");
+        sortBtn.Click(); // Ascending
+        sortBtn.Click(); // Descending
+        sortBtn.Click(); // None
+
+        Assert.Equal(new[] { "A", "B" }, cut.FindAll("[data-slot='datagrid-group-row']").Select(e => e.TextContent.Trim()[..1]));
+    }
+
+    // ── Sorting a NON-grouped column still reorders rows WITHIN each group ──
+
+    [Fact]
+    public void Sorting_A_Nongrouped_Column_Reorders_Rows_Within_Groups_Both_Directions()
+    {
+        var cut = _ctx.Render<Lumeo.DataGrid<Row>>(p => p
+            .Add(x => x.Items, Data())
+            .Add(x => x.GroupBy, "Category")
+            .Add(x => x.Columns, Columns()));
+
+        var sortBtn = SortButtonFor(cut, "Name");
+        sortBtn.Click(); // Ascending by Name
+        var namesAsc = NameCellValues(cut);
+
+        sortBtn.Click(); // Descending by Name
+        var namesDesc = NameCellValues(cut);
+
+        // Category groups stay A, B (no sort active on Category) in BOTH cases;
+        // only the row order within each group flips. Group A = {Amy, Bob},
+        // Group B = {Zed, Anna}; sorting by Name reorders each group's OWN
+        // members (Amy/Bob within A, Anna/Zed within B) without touching
+        // which group comes first.
+        Assert.Equal(new List<string> { "Amy", "Bob", "Anna", "Zed" }, namesAsc);
+        Assert.Equal(new List<string> { "Bob", "Amy", "Zed", "Anna" }, namesDesc);
+    }
+
+    // ── Ungrouped sorting is unaffected by the fix ───────────────────────────
+
+    [Fact]
+    public void Ungrouped_Sorting_Still_Works_Ascending_And_Descending()
+    {
+        var cut = _ctx.Render<Lumeo.DataGrid<Row>>(p => p
+            .Add(x => x.Items, Data())
+            .Add(x => x.Columns, Columns()));
+
+        var sortBtn = SortButtonFor(cut, "Name");
+        sortBtn.Click(); // Ascending
+        Assert.Equal(new List<string> { "Amy", "Anna", "Bob", "Zed" }, NameCellValues(cut));
+
+        sortBtn.Click(); // Descending
+        Assert.Equal(new List<string> { "Zed", "Bob", "Anna", "Amy" }, NameCellValues(cut));
+    }
+
+    // ── Toggling grouping on/off keeps sort working ──────────────────────────
+
+    [Fact]
+    public void Sort_Keeps_Working_After_Toggling_From_Grouped_To_Ungrouped()
+    {
+        var cut = _ctx.Render<Lumeo.DataGrid<Row>>(p => p
+            .Add(x => x.Items, Data())
+            .Add(x => x.GroupBy, "Category")
+            .Add(x => x.Columns, Columns()));
+
+        SortButtonFor(cut, "Name").Click(); // Ascending by Name, while grouped
+
+        // Un-group.
+        cut.Render(p => p.Add(x => x.GroupBy, (string?)null));
+
+        Assert.Empty(cut.FindAll("[data-slot='datagrid-group-row']"));
+        // Ungrouped now — plain Name-ascending order across all rows, no group influence.
+        Assert.Equal(new List<string> { "Amy", "Anna", "Bob", "Zed" }, NameCellValues(cut));
+
+        // Sort is still live: clicking again flips to Descending.
+        SortButtonFor(cut, "Name").Click();
+        Assert.Equal(new List<string> { "Zed", "Bob", "Anna", "Amy" }, NameCellValues(cut));
+    }
+
+    [Fact]
+    public void Sort_Keeps_Working_After_Toggling_From_Ungrouped_To_Grouped()
+    {
+        var cut = _ctx.Render<Lumeo.DataGrid<Row>>(p => p
+            .Add(x => x.Items, Data())
+            .Add(x => x.Columns, Columns()));
+
+        SortButtonFor(cut, "Name").Click(); // Ascending by Name, ungrouped
+        Assert.Equal(new List<string> { "Amy", "Anna", "Bob", "Zed" }, NameCellValues(cut));
+
+        // Now group by Category.
+        cut.Render(p => p.Add(x => x.GroupBy, "Category"));
+
+        Assert.NotEmpty(cut.FindAll("[data-slot='datagrid-group-row']"));
+        // Category groups default A, B (no sort on Category); within each group,
+        // the pre-existing Name-ascending sort still applies: Group A = {Amy, Bob},
+        // Group B = {Anna, Zed} (their relative order from the Name-sorted list).
+        Assert.Equal(new List<string> { "Amy", "Bob", "Anna", "Zed" }, NameCellValues(cut));
+    }
+
+    // ── Multi-level grouping: each level honours its OWN sort direction ─────
+
+    private class MultiRow
+    {
+        public string Category { get; set; } = "";
+        public string Status { get; set; } = "";
+        public string Name { get; set; } = "";
+    }
+
+    private static List<MultiRow> MultiData() => new()
+    {
+        new MultiRow { Category = "B", Status = "Y", Name = "1" },
+        new MultiRow { Category = "A", Status = "X", Name = "2" },
+        new MultiRow { Category = "B", Status = "X", Name = "3" },
+        new MultiRow { Category = "A", Status = "Y", Name = "4" },
+    };
+
+    private static List<DataGridColumn<MultiRow>> MultiColumns() => new()
+    {
+        new() { Field = "Category", Title = "Category", Sortable = true, Groupable = true },
+        new() { Field = "Status", Title = "Status", Sortable = true, Groupable = true },
+        new() { Field = "Name", Title = "Name" },
+    };
+
+    [Fact]
+    public void MultiLevel_Grouping_Outer_Level_Sort_Reverses_Outer_Group_Order_Independently()
+    {
+        var cut = _ctx.Render<Lumeo.DataGrid<MultiRow>>(p => p
+            .Add(x => x.Items, MultiData())
+            .Add(x => x.GroupByFields, (IReadOnlyList<string>)new[] { "Category", "Status" })
+            .Add(x => x.Columns, MultiColumns()));
+
+        var outerFirstBefore = cut.FindAll("[data-slot='datagrid-group-row']")[0].TextContent.Trim()[..1];
+        Assert.Equal("A", outerFirstBefore); // default ascending: Category A before B
+
+        var catBtn = SortButtonFor(cut, "Category");
+        catBtn.Click(); // Ascending
+        catBtn.Click(); // Descending
+
+        var outerFirstAfter = cut.FindAll("[data-slot='datagrid-group-row']")[0].TextContent.Trim()[..1];
+        Assert.Equal("B", outerFirstAfter); // outer level reversed
+    }
+
+    // ── ServerMode: RegroupServerItems shares the same (fixed) code path ─────
+
+    [Fact]
+    public void ServerMode_Sorting_The_Grouped_Column_Reverses_Group_Order()
+    {
+        // In a real app, ServerMode's header-click path (HandleSort -> ServerMode
+        // branch -> RequestServerData) updates _sorts synchronously, then awaits
+        // OnServerRequest — whose consumer handler re-fetches server-side and
+        // reassigns Items, which is what actually re-triggers OnParametersSetAsync
+        // -> RegroupServerItems() with the new _sorts. With no OnServerRequest
+        // wired (as in this test and the pre-existing ServerMode grouping tests),
+        // that reassignment never happens automatically, so the round trip is
+        // simulated explicitly here via a second cut.Render(...) re-supplying
+        // Items — exactly what the consumer's callback would trigger for real.
+        var items = Data();
+        var cut = _ctx.Render<Lumeo.DataGrid<Row>>(p => p
+            .Add(x => x.ServerMode, true)
+            .Add(x => x.TotalCount, items.Count)
+            .Add(x => x.Items, items)
+            .Add(x => x.GroupBy, "Category")
+            .Add(x => x.Columns, Columns()));
+
+        var sortBtn = SortButtonFor(cut, "Category");
+        sortBtn.Click(); // Ascending
+        cut.Render(p => p.Add(x => x.Items, items));
+        sortBtn.Click(); // Descending
+        cut.Render(p => p.Add(x => x.Items, items));
+
+        Assert.Equal(new[] { "B", "A" }, cut.FindAll("[data-slot='datagrid-group-row']").Select(e => e.TextContent.Trim()[..1]));
+    }
+}

--- a/tools/lumeo-mcp/src/components-api.json
+++ b/tools/lumeo-mcp/src/components-api.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://lumeo.nativ.sh/components-api-schema.json",
   "version": "4.3.3",
-  "generated": "2026-07-18T08:12:28.3047920Z",
+  "generated": "2026-07-22T14:36:01.2725259Z",
   "stats": {
     "componentCount": 164,
     "totalParameters": 4275,

--- a/tools/lumeo-mcp/src/registry.json
+++ b/tools/lumeo-mcp/src/registry.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://lumeo.nativ.sh/registry-schema.json",
   "version": "4.3.3",
-  "generated": "2026-07-18T08:12:23.3710579Z",
+  "generated": "2026-07-22T14:35:58.6148610Z",
   "components": {
     "accordion": {
       "name": "Accordion",
@@ -1750,8 +1750,8 @@
       "registryUrl": "https://lumeo.nativ.sh/registry/data-grid.json",
       "testCoverage": {
         "tier": 4,
-        "files": 42,
-        "tests": 290,
+        "files": 43,
+        "tests": 299,
         "relatedFiles": 1,
         "render": true,
         "behavior": true,


### PR DESCRIPTION
## Bug

With grouping active, clicking a column header to toggle Ascending/Descending
sort appeared to do nothing.

## Root cause

The grouping pipeline (both single-level and multi-level) built its group
list via `.GroupBy(...).OrderBy(g => g.Key, StringComparer.CurrentCulture)` —
the group ORDER (which group section/node appears first) was hardcoded
ascending, completely independent of the grid's active sort state.

Row order *within* a group was never actually broken: the sort is applied to
the item list before grouping runs, and LINQ's `GroupBy` preserves each
group's members in their original relative order. The bug is specifically
that sorting the **grouped column itself** had zero visible effect — every
row in a group shares that column's value by definition, so "sort within the
group" is necessarily a no-op for that field, and group order (the one place
the sort direction could show up) was hardcoded.

## Fix

Group order now follows the active sort entry for the grouping field:
Descending reverses the group run, and no active sort on that field falls
back to the original ascending-by-key default. This is the semantic used by
grouped columns in TanStack Table, AG Grid, and MUI DataGrid — sorting the
grouped field controls group order; sorting any other field controls order
within each group (already working, unaffected by this change).

Applied to both single-level and multi-level (per nesting level
independently) grouping. Server mode shares the same fixed code path via its
existing regroup-the-delivered-page routine, so it benefits without any
separate change.

## Tests

New regression suite covers:
- Sorting the grouped column Ascending/Descending reverses group order;
  clearing the sort restores the default order.
- Sorting a non-grouped column still reorders rows within each group in both
  directions (regression guard for the part that already worked).
- Plain ungrouped sorting is unaffected.
- Sort state survives toggling grouping on and off in both directions.
- Multi-level grouping: each level honors its own sort direction
  independently.
- Server mode.

## Gates

- Release build (`-warnaserror`) of the grid library: 0 warnings, 0 errors,
  both target frameworks.
- Focused grid test filter: all passing, no regressions.
- Full unit suite: all passing.
- Component registry regenerated (doc-comment/test-discovery metadata only).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Grouped DataGrid sections now follow the selected ascending or descending sort direction.
  - Multi-level grouping honors sorting independently at each grouping level.
  - Sorting continues to work when switching between grouped and ungrouped views, including Server Mode.
  - Sorting non-grouped columns still reorders rows within their groups without changing group order.

- **Tests**
  - Expanded automated coverage for grouped sorting scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->