### PR TITLE
feat(scheduler): rebuild docs demos with realistic data and promote the first-party engine

### DIFF
--- a/docs/Lumeo.Docs/Pages/Components/SchedulerPage.razor
+++ b/docs/Lumeo.Docs/Pages/Components/SchedulerPage.razor
@@ -3,29 +3,39 @@
 <PageTitle>Scheduler — Lumeo</PageTitle>
 
 <PageHeader Title="Scheduler"
-            Description="A calendar & event scheduler with month, week, day, and list views. Drag events to reschedule, resize to change duration, or drag across the grid to create new ones." />
+            Description="A calendar & event scheduler with month, week, day, and agenda views. Drag events to reschedule, resize to change duration, or drag across the grid to create new ones." />
 
 <InstallUsage Component="Scheduler" Package="Lumeo.Scheduler" />
 
 <Alert Variant="Alert.AlertVariant.Warning" ShowIcon="true" Class="mt-6">
     <ChildContent>
-        <strong>In active development.</strong> Theme integration just landed — please refresh and report any
-        residual visual issues. FullCalendar Premium features (resource lane views, vertical resource view,
-        true timeline view) are NOT wrapped — see the licensing note below. This release adds simple
-        recurrence, resource color-coding, now-indicator, and slot-time controls.
+        <strong>Two rendering engines, one component family.</strong> <Lumeo.Code>Scheduler</Lumeo.Code> wraps
+        FullCalendar Standard (MIT) and is the default today. Alongside it, a first-party Blazor rendering engine
+        (<Lumeo.Code>SchedulerMonthView</Lumeo.Code> / <Lumeo.Code>SchedulerTimeGridView</Lumeo.Code> /
+        <Lumeo.Code>SchedulerAgendaView</Lumeo.Code>) ships no third-party JS calendar library at all — that is
+        where active development is focused, and it is demoed first below. See
+        <a href="#choosing-an-engine" class="underline hover:text-foreground">Choosing an engine</a> for the
+        trade-offs.
     </ChildContent>
 </Alert>
 
 <Alert Variant="Alert.AlertVariant.Info" ShowIcon="true" Class="mt-3">
     <ChildContent>
         <strong>Dependencies &amp; licensing — MIT for everything Lumeo ships.</strong>
-        Powered by <a href="https://fullcalendar.io/" class="underline hover:text-foreground">FullCalendar Standard</a>
-        (MIT), loaded once on demand. The month / week / day / list views Lumeo wraps are all in the free MIT bundle.
+        <Lumeo.Code>Scheduler</Lumeo.Code> is powered by
+        <a href="https://fullcalendar.io/" class="underline hover:text-foreground">FullCalendar Standard</a>
+        (MIT), fetched once on demand from a CDN. The month / week / day / list views Lumeo wraps are all in the
+        free MIT bundle — no FullCalendar Premium code is bundled or required.
         <br /><br />
         <strong>Important caveat:</strong> FullCalendar's <em>Premium</em> features (Resource Timeline, Vertical
         Resource View, Resource Day Grid, and adapter plugins for Vue/React if you embed those) require a paid
         FullCalendar Premium license direct from FullCalendar. Lumeo does NOT wrap these and does NOT bundle
         any Premium code — but if you extend the Scheduler in your own app to call those plugins, that's on you.
+        <br /><br />
+        <strong>Runtime note:</strong> because the FullCalendar bundle loads from a CDN at runtime, the
+        <Lumeo.Code>Scheduler</Lumeo.Code> demos below need outbound network access to render — if you're viewing
+        this offline or from an environment that blocks the CDN, they'll appear empty while the first-party engine
+        demos above them (no CDN dependency) still work.
     </ChildContent>
 </Alert>
 
@@ -33,22 +43,192 @@
     <Heading Id="when-to-use" Level="2" Class="scroll-mt-20">When to Use</Heading>
     <ul class="list-disc list-inside space-y-1 text-muted-foreground text-sm">
         <li>Displaying appointments, meetings, shifts, or any time-based event grid.</li>
-        <li>Giving users direct manipulation controls — drag to reschedule, drag-to-select to create.</li>
-        <li>Switching between month overviews and focused day/week planning within the same view.</li>
+        <li>Giving users direct manipulation controls — drag to reschedule, drag-to-select to create, resize to change duration.</li>
+        <li>Switching between month overviews, focused day/week planning, and a flat agenda list within the same data.</li>
+        <li>Showing overlapping events (double-booked rooms, parallel tracks), multi-day spans, and recurring series side by side.</li>
     </ul>
 </div>
 
-<Stack Gap="8" Class="mt-8">
-    <ComponentDemo Title="Month View (basic)" Code="@_monthCode">
+<div class="mt-10 space-y-3">
+    <Heading Id="choosing-an-engine" Level="2" Class="scroll-mt-20">Choosing an engine</Heading>
+    <Lumeo.Text Size="sm" Color="muted">
+        Both engines read the same <Lumeo.Code>SchedulerEvent</Lumeo.Code> record and the same recurrence model, so
+        switching between them later is a component swap, not a data-model migration.
+    </Lumeo.Text>
+    <div class="overflow-x-auto">
+        <Table>
+            <TableHeader>
+                <TableRow>
+                    <TableHead Class="w-[260px]">Capability</TableHead>
+                    <TableHead Class="w-[220px]">Scheduler (FullCalendar)</TableHead>
+                    <TableHead>First-party engine (preview)</TableHead>
+                </TableRow>
+            </TableHeader>
+            <TableBody>
+                <TableRow><TableCell>Month / week / day / agenda views</TableCell><TableCell>Yes</TableCell><TableCell>Yes</TableCell></TableRow>
+                <TableRow><TableCell>Drag to reschedule</TableCell><TableCell>Direct-manipulation drag</TableCell><TableCell>Ghost-outline preview, commits on drop</TableCell></TableRow>
+                <TableRow><TableCell>Drop validation</TableCell><TableCell>Boolean accept/reject</TableCell><TableCell>Three-way: reject / accept / accept-with-adjustment</TableCell></TableRow>
+                <TableRow><TableCell>Overflow ("+N more")</TableCell><TableCell>Built-in popover</TableCell><TableCell>Built-in popover, lists hidden instances</TableCell></TableRow>
+                <TableRow><TableCell>Business-hours shading</TableCell><TableCell>Yes</TableCell><TableCell>Yes</TableCell></TableRow>
+                <TableRow><TableCell>Structured recurrence</TableCell><TableCell>Simple <Lumeo.Code>DaysOfWeek</Lumeo.Code> model</TableCell><TableCell><Lumeo.Code>DaysOfWeek</Lumeo.Code> or structured <Lumeo.Code>SchedulerRecurrenceRule</Lumeo.Code></TableCell></TableRow>
+                <TableRow><TableCell>Resource color-coding / legend</TableCell><TableCell>Yes</TableCell><TableCell>Not yet</TableCell></TableRow>
+                <TableRow><TableCell>N-day / custom views</TableCell><TableCell>Via FullCalendar view names</TableCell><TableCell>Not a public view yet</TableCell></TableRow>
+                <TableRow><TableCell>IANA time zones</TableCell><TableCell>Yes</TableCell><TableCell>Browser-local time only</TableCell></TableRow>
+                <TableRow><TableCell>ARIA grid + 2-D keyboard navigation</TableCell><TableCell>FullCalendar's own</TableCell><TableCell>First-party <Lumeo.Code>role="grid"</Lumeo.Code> + arrow-key roving tabindex</TableCell></TableRow>
+                <TableRow><TableCell>i18n</TableCell><TableCell>FullCalendar locale packs</TableCell><TableCell>English only today</TableCell></TableRow>
+                <TableRow><TableCell>Third-party JS on the page</TableCell><TableCell>FullCalendar (CDN, MIT)</TableCell><TableCell>None</TableCell></TableRow>
+                <TableRow><TableCell>Multi-calendar split / overlay panes</TableCell><TableCell colspan="2">Not implemented by either engine — see note below.</TableCell></TableRow>
+            </TableBody>
+        </Table>
+    </div>
+    <Alert Variant="Alert.AlertVariant.Info" ShowIcon="true">
+        <ChildContent>
+            <strong>Split / overlay panes (Outlook-style multi-calendar view)</strong> — showing several calendars
+            either overlaid in one column or side by side as separate panes, with per-calendar tabs to merge/split
+            them — is a real interaction pattern worth having eventually, but neither engine implements it today.
+            <Lumeo.Code>Scheduler</Lumeo.Code>'s <Lumeo.Code>Resources</Lumeo.Code> parameter only color-codes
+            events by resource; it does not lay out separate resource/calendar lanes (that's the FullCalendar
+            Premium Resource Timeline, which Lumeo does not wrap). Tracked as a roadmap item, not a current gap fix.
+        </ChildContent>
+    </Alert>
+</div>
+
+<div class="mt-16 space-y-3">
+    <Heading Id="first-party-engine" Level="2" Class="scroll-mt-20">First-party view engine</Heading>
+    <Lumeo.Text Size="sm" Color="muted">
+        A native Blazor rendering engine for Month, Week/Day, and Agenda views, built without FullCalendar —
+        no third-party JS calendar library on the page for these views. It ships alongside
+        <Lumeo.Code>Scheduler</Lumeo.Code> below, which remains the default and is unaffected.
+    </Lumeo.Text>
+    <Alert Variant="Alert.AlertVariant.Warning" ShowIcon="true">
+        <ChildContent>
+            <strong>Preview — not the default yet.</strong> <Lumeo.Code>SchedulerMonthView</Lumeo.Code>,
+            <Lumeo.Code>SchedulerTimeGridView</Lumeo.Code>, and <Lumeo.Code>SchedulerAgendaView</Lumeo.Code> are
+            separate, independently-usable components, not drop-in replacements for <Lumeo.Code>Scheduler</Lumeo.Code>
+            — there is no shared <Lumeo.Code>Scheduler</Lumeo.Code> switch to opt into this engine yet. See the
+            comparison table above for the current gap list (no resource lanes, no time zones, no N-day view,
+            English-only i18n).
+        </ChildContent>
+    </Alert>
+</div>
+
+<Stack Gap="8" Class="mt-6">
+    <ComponentDemo Title="Month view (first-party engine)" Code="@_fpMonthCode">
+        <Stack Gap="3">
+            <Lumeo.Text Size="sm" Color="muted">
+                Realistic month with overlapping events, a multi-day span, and a weekday-recurring standup.
+                Today's cell has 5 events — more than the 3-lane budget — so it overflows into a
+                "<Lumeo.Code>+N more</Lumeo.Code>" popover. Drag an event to move it (ghost preview until you
+                release); drag across empty days to create one.
+            </Lumeo.Text>
+            <SchedulerMonthView Events="_fpMonthEvents"
+                                 AnchorDate="_fpAnchor"
+                                 BusinessHours="true"
+                                 OnDateSelect="OnFpMonthDateSelect"
+                                 OnEventChange="OnFpMonthEventChange" />
+            <div class="rounded-md border border-border/60 bg-muted/40 p-3 text-sm">
+                <div class="font-medium mb-1">Last interaction</div>
+                @if (_fpMonthLog is null)
+                {
+                    <span class="text-muted-foreground">Drag an event, or drag-select empty days, to see it here.</span>
+                }
+                else
+                {
+                    <span class="font-mono text-xs">@_fpMonthLog</span>
+                }
+            </div>
+        </Stack>
+    </ComponentDemo>
+
+    <ComponentDemo Title="Week view (first-party engine)" Code="@_fpWeekCode">
+        <Stack Gap="3">
+            <Lumeo.Text Size="sm" Color="muted">
+                Same event set, time-grid layout. Overlapping events are packed side by side, off-hours are
+                shaded, and the red line tracks the current time. Drag moves an event across days/times as a
+                ghost outline; drag the bottom edge to resize.
+            </Lumeo.Text>
+            <SchedulerTimeGridView Events="_fpWeekEvents"
+                                    AnchorDate="_fpAnchor"
+                                    Days="7"
+                                    BusinessHours="true"
+                                    NowIndicator="true"
+                                    OnEventChange="OnFpWeekEventChange" />
+            <div class="rounded-md border border-border/60 bg-muted/40 p-3 text-sm">
+                <div class="font-medium mb-1">Last change</div>
+                @if (_fpWeekLog is null)
+                {
+                    <span class="text-muted-foreground">Drag or resize an event to see it here.</span>
+                }
+                else
+                {
+                    <span class="font-mono text-xs">@_fpWeekLog</span>
+                }
+            </div>
+        </Stack>
+    </ComponentDemo>
+
+    <ComponentDemo Title="Day view (first-party engine)">
+        <SchedulerTimeGridView Events="_fpWeekEvents" AnchorDate="_fpAnchor" Days="1" BusinessHours="true" NowIndicator="true" />
+    </ComponentDemo>
+
+    <ComponentDemo Title="Agenda view (first-party engine)" Code="@_fpAgendaCode">
+        <Stack Gap="3">
+            <Lumeo.Text Size="sm" Color="muted">
+                Flat chronological list across the next 30 days — the same events as the calendar views above,
+                including recurring occurrences and multi-day spans, grouped by day.
+            </Lumeo.Text>
+            <SchedulerAgendaView Events="_fpAgendaEvents" AnchorDate="_fpAnchor" DaysToShow="30" />
+        </Stack>
+    </ComponentDemo>
+
+    <ComponentDemo Title="Drop validation (CanDrop)" Code="@_fpCanDropCode">
+        <Stack Gap="3">
+            <Lumeo.Text Size="sm" Color="muted">
+                <Lumeo.Code>CanDrop</Lumeo.Code> is a three-way gate evaluated before any drop commits:
+                <Lumeo.Code>SchedulerDropResult.Reject</Lumeo.Code>, <Lumeo.Code>.Accept</Lumeo.Code>, or
+                <Lumeo.Code>.AcceptWith(adjustment)</Lumeo.Code> to snap the drop to a different time than the
+                user dragged to. Nothing mutates until <Lumeo.Code>CanDrop</Lumeo.Code> returns — dragging only
+                ever moves a ghost outline. Try dragging the event onto the <strong>15th</strong> (rejected) or
+                the <strong>22nd</strong> (accepted, but snapped forward one day) of this month.
+            </Lumeo.Text>
+            <SchedulerMonthView Events="_fpDropEvents"
+                                 AnchorDate="_fpAnchor"
+                                 CanDrop="ValidateDrop"
+                                 OnEventChange="OnFpDropEventChange" />
+            <div class="rounded-md border border-border/60 bg-muted/40 p-3 text-sm">
+                <div class="font-medium mb-1">Last CanDrop check</div>
+                @if (_fpDropLog is null)
+                {
+                    <span class="text-muted-foreground">Drag the event onto the 15th or the 22nd.</span>
+                }
+                else
+                {
+                    <span class="font-mono text-xs">@_fpDropLog</span>
+                }
+            </div>
+        </Stack>
+    </ComponentDemo>
+</Stack>
+
+<div class="mt-16 space-y-3">
+    <Heading Id="fullcalendar-engine" Level="2" Class="scroll-mt-20">Scheduler (FullCalendar-backed, default)</Heading>
+    <Lumeo.Text Size="sm" Color="muted">
+        The full-featured, currently-default engine — recurrence, resource color-coding, a now-indicator, and
+        slot-time controls, all on top of FullCalendar Standard (MIT). Requires the CDN fetch described above.
+    </Lumeo.Text>
+</div>
+
+<Stack Gap="8" Class="mt-6">
+    <ComponentDemo Title="Month View" Code="@_monthCode">
         <Scheduler Events="_monthEvents" InitialView="SchedulerView.Month" Height="620px" />
     </ComponentDemo>
 
-    <ComponentDemo Title="Week View (timed + all-day)" Code="@_weekCode">
-        <Scheduler Events="_weekEvents" InitialView="SchedulerView.Week" Height="620px" BusinessHours="true" />
+    <ComponentDemo Title="Week View (timed + all-day + overlaps)" Code="@_weekCode">
+        <Scheduler Events="_weekEvents" InitialView="SchedulerView.Week" Height="620px" BusinessHours="true" NowIndicator="true" />
     </ComponentDemo>
 
     <ComponentDemo Title="Day View">
-        <Scheduler Events="_weekEvents" InitialView="SchedulerView.Day" Height="620px" />
+        <Scheduler Events="_weekEvents" InitialView="SchedulerView.Day" Height="620px" NowIndicator="true" />
     </ComponentDemo>
 
     <ComponentDemo Title="List View (agenda)">
@@ -137,37 +317,6 @@
     </ComponentDemo>
 </Stack>
 
-<div class="mt-16 space-y-3">
-    <Heading Id="first-party-engine" Level="2" Class="scroll-mt-20">First-party view engine (preview)</Heading>
-    <Lumeo.Text Size="sm" Color="muted">
-        A native Blazor rendering engine for Month and Week/Day views, built without FullCalendar —
-        no third-party JS calendar library on the page for these views. It ships alongside
-        <Lumeo.Code>Scheduler</Lumeo.Code> above, which remains the default and is unaffected.
-    </Lumeo.Text>
-    <Alert Variant="Alert.AlertVariant.Warning" ShowIcon="true">
-        <ChildContent>
-            <strong>Experimental — not the default.</strong> <Lumeo.Code>SchedulerMonthView</Lumeo.Code> and
-            <Lumeo.Code>SchedulerTimeGridView</Lumeo.Code> are separate, independently-usable components, not
-            drop-in replacements for <Lumeo.Code>Scheduler</Lumeo.Code> — there is no shared <Lumeo.Code>Scheduler</Lumeo.Code>
-            switch to opt into this engine yet. Known gaps versus the FullCalendar-backed component: no resource
-            view, no IANA time-zone rendering (browser-local time only), no built-in N-day view, no raw RRULE
-            string support (structured <Lumeo.Code>SchedulerRecurrenceRule</Lumeo.Code> only), i18n is
-            English-only today, and drag/resize state changes are not yet announced to assistive tech via a live
-            region. Treat this section as a preview of where the Scheduler is heading, not a supported alternative.
-        </ChildContent>
-    </Alert>
-</div>
-
-<Stack Gap="8" Class="mt-6">
-    <ComponentDemo Title="Month view (first-party engine)">
-        <SchedulerMonthView Events="_monthEvents" BusinessHours="true" />
-    </ComponentDemo>
-
-    <ComponentDemo Title="Week view (first-party engine)">
-        <SchedulerTimeGridView Events="_weekEvents" Days="7" BusinessHours="true" />
-    </ComponentDemo>
-</Stack>
-
 <div class="mt-16">
     <Heading Id="api-reference" Level="2" Class="scroll-mt-20">API Reference</Heading>
 
@@ -195,9 +344,10 @@
                 <TableRow><TableCell Class="font-mono text-xs">Color</TableCell><TableCell Class="font-mono text-xs">string?</TableCell><TableCell>CSS color or variable reference like <Lumeo.Code>"var(--color-primary)"</Lumeo.Code>.</TableCell></TableRow>
                 <TableRow><TableCell Class="font-mono text-xs">Url</TableCell><TableCell Class="font-mono text-xs">string?</TableCell><TableCell>Optional link opened on click instead of firing <Lumeo.Code>OnEventClick</Lumeo.Code>.</TableCell></TableRow>
                 <TableRow><TableCell Class="font-mono text-xs">ExtendedProps</TableCell><TableCell Class="font-mono text-xs">Dictionary&lt;string, object&gt;?</TableCell><TableCell>Arbitrary app-level metadata round-tripped through the JS layer.</TableCell></TableRow>
-                <TableRow><TableCell Class="font-mono text-xs">DaysOfWeek</TableCell><TableCell Class="font-mono text-xs">IReadOnlyList&lt;DayOfWeek&gt;?</TableCell><TableCell>Recurring: days of the week on which the event repeats. Uses FullCalendar's free simple recurrence model. When set, Start/End provide the time-of-day only.</TableCell></TableRow>
+                <TableRow><TableCell Class="font-mono text-xs">DaysOfWeek</TableCell><TableCell Class="font-mono text-xs">IReadOnlyList&lt;DayOfWeek&gt;?</TableCell><TableCell>Recurring: days of the week on which the event repeats (both engines). When set, Start/End provide the time-of-day only.</TableCell></TableRow>
                 <TableRow><TableCell Class="font-mono text-xs">RecurrenceEnd</TableCell><TableCell Class="font-mono text-xs">DateTime?</TableCell><TableCell>Recurring: last date on which the event appears. Only meaningful when <Lumeo.Code>DaysOfWeek</Lumeo.Code> is set.</TableCell></TableRow>
-                <TableRow><TableCell Class="font-mono text-xs">ExceptionDates</TableCell><TableCell Class="font-mono text-xs">IReadOnlyList&lt;DateTime&gt;?</TableCell><TableCell>Recurring: specific dates to skip (one-off exclusions). Only meaningful when <Lumeo.Code>DaysOfWeek</Lumeo.Code> is set.</TableCell></TableRow>
+                <TableRow><TableCell Class="font-mono text-xs">ExceptionDates</TableCell><TableCell Class="font-mono text-xs">IReadOnlyList&lt;DateTime&gt;?</TableCell><TableCell>Recurring: specific dates to skip (one-off exclusions).</TableCell></TableRow>
+                <TableRow><TableCell Class="font-mono text-xs">Recurrence</TableCell><TableCell Class="font-mono text-xs">SchedulerRecurrenceRule?</TableCell><TableCell>Structured RRULE-subset recurrence (FREQ, INTERVAL, COUNT, UNTIL, BYDAY). Takes precedence over <Lumeo.Code>DaysOfWeek</Lumeo.Code>/<Lumeo.Code>RecurrenceEnd</Lumeo.Code> when set; supported by both engines.</TableCell></TableRow>
                 <TableRow><TableCell Class="font-mono text-xs">ResourceId</TableCell><TableCell Class="font-mono text-xs">string?</TableCell><TableCell>Matches this event to a <Lumeo.Code>SchedulerResource</Lumeo.Code> for color-coding when the Scheduler has a <Lumeo.Code>Resources</Lumeo.Code> list.</TableCell></TableRow>
                 <TableRow><TableCell Class="font-mono text-xs">ClassNames</TableCell><TableCell Class="font-mono text-xs">string?</TableCell><TableCell>Extra CSS class names applied directly to this event's chip (space-separated).</TableCell></TableRow>
             </TableBody>
@@ -257,6 +407,66 @@
             </TableBody>
         </Table>
     </div>
+
+    <Heading Id="first-party-views" Level="3" Class="mt-8 scroll-mt-20">First-party view components</Heading>
+    <Lumeo.Text Size="sm" Color="muted" Class="mt-2">
+        Not yet a registered public API surface (no dedicated docs registry entry), but usable and independently
+        testable today. Shared parameters across all three: <Lumeo.Code>Events</Lumeo.Code>,
+        <Lumeo.Code>AnchorDate</Lumeo.Code>, <Lumeo.Code>OnEventClick</Lumeo.Code>,
+        <Lumeo.Code>ResolveEventColor</Lumeo.Code>, <Lumeo.Code>Class</Lumeo.Code>, <Lumeo.Code>AdditionalAttributes</Lumeo.Code>.
+    </Lumeo.Text>
+    <div class="overflow-x-auto mt-4">
+        <Table>
+            <TableHeader>
+                <TableRow>
+                    <TableHead Class="w-[200px]">Component</TableHead>
+                    <TableHead Class="w-[220px]">Distinguishing parameters</TableHead>
+                    <TableHead>Description</TableHead>
+                </TableRow>
+            </TableHeader>
+            <TableBody>
+                <TableRow>
+                    <TableCell Class="font-mono text-xs">SchedulerMonthView</TableCell>
+                    <TableCell Class="font-mono text-xs">MaxVisibleLanes, SelectedDate(Changed), CanDrop, Selectable, BusinessHours(Days), Editable, OnDateSelect, OnEventChange</TableCell>
+                    <TableCell>Always-42-cell month grid. Events beyond <Lumeo.Code>MaxVisibleLanes</Lumeo.Code> (default 3) collapse into a "+N more" popover.</TableCell>
+                </TableRow>
+                <TableRow>
+                    <TableCell Class="font-mono text-xs">SchedulerTimeGridView</TableCell>
+                    <TableCell Class="font-mono text-xs">Days, SlotMinTime/MaxTime, NowIndicator, CanDrop, BusinessHours(Start/End/Days), Editable, Selectable, OnDateSelect, OnEventChange</TableCell>
+                    <TableCell>Hourly time grid. <Lumeo.Code>Days="7"</Lumeo.Code> is the week view, <Lumeo.Code>Days="1"</Lumeo.Code> is the day view.</TableCell>
+                </TableRow>
+                <TableRow>
+                    <TableCell Class="font-mono text-xs">SchedulerAgendaView</TableCell>
+                    <TableCell Class="font-mono text-xs">DaysToShow</TableCell>
+                    <TableCell>Flat chronological list, grouped by day, read-only (no drag/resize — it's a list).</TableCell>
+                </TableRow>
+            </TableBody>
+        </Table>
+    </div>
+
+    <Heading Id="scheduler-drop-result" Level="3" Class="mt-8 scroll-mt-20">SchedulerDropResult / CanDrop</Heading>
+    <Lumeo.Text Size="sm" Color="muted" Class="mt-2">
+        <Lumeo.Code>CanDrop</Lumeo.Code> is a plain
+        <Lumeo.Code>Func&lt;SchedulerEvent, SchedulerScheduleDropContext, SchedulerDropResult&gt;</Lumeo.Code>
+        parameter on the first-party views (Scheduler-family, not FullCalendar's own drop validation). It is
+        evaluated before a drag/resize/create commits — nothing mutates the underlying collection until it returns.
+    </Lumeo.Text>
+    <div class="overflow-x-auto mt-4">
+        <Table>
+            <TableHeader>
+                <TableRow>
+                    <TableHead Class="w-[240px]">Member</TableHead>
+                    <TableHead>Description</TableHead>
+                </TableRow>
+            </TableHeader>
+            <TableBody>
+                <TableRow><TableCell Class="font-mono text-xs">SchedulerDropResult.Reject</TableCell><TableCell>Cancels the drop; the event snaps back to its original position.</TableCell></TableRow>
+                <TableRow><TableCell Class="font-mono text-xs">SchedulerDropResult.Accept</TableCell><TableCell>Commits the drop exactly as proposed.</TableCell></TableRow>
+                <TableRow><TableCell Class="font-mono text-xs">SchedulerDropResult.AcceptWith(adjustment)</TableCell><TableCell>Commits the drop, overriding <Lumeo.Code>Start</Lumeo.Code>/<Lumeo.Code>End</Lumeo.Code>/<Lumeo.Code>AllDay</Lumeo.Code> with a <Lumeo.Code>SchedulerDropAdjustment</Lumeo.Code> (e.g. snapping to a valid slot).</TableCell></TableRow>
+                <TableRow><TableCell Class="font-mono text-xs">SchedulerScheduleDropContext</TableCell><TableCell><Lumeo.Code>ProposedStart</Lumeo.Code>, <Lumeo.Code>ProposedEnd</Lumeo.Code>, <Lumeo.Code>Source</Lumeo.Code> (which gesture — move, resize, or create — produced this proposal).</TableCell></TableRow>
+            </TableBody>
+        </Table>
+    </div>
 </div>
 
 <div class="mt-12">
@@ -268,7 +478,152 @@
 </div>
 
 @code {
-    // ── Month demo ───────────────────────────────────────────────────────
+    private static readonly DateTime Today = DateTime.Today;
+
+    // ── First-party engine: shared realistic dataset ───────────────────────
+    // Overlaps (4 same-time events on "today"), a multi-day all-day span
+    // crossing today, a weekday-recurring standup, a weekly-recurring
+    // review, and events spread across the surrounding weeks so month,
+    // week/day, and the 30-day agenda all have real content.
+    private readonly DateTime _fpAnchor = Today;
+
+    private static List<SchedulerEvent> BuildFirstPartyEvents()
+    {
+        var t = Today;
+        return new List<SchedulerEvent>
+        {
+            new("fp1", "Planning Q4", t.AddDays(-9).AddHours(9), t.AddDays(-9).AddHours(10), Color: "var(--color-chart-2)"),
+            new("fp2", "Design sync", t.AddDays(-6).AddHours(10), t.AddDays(-6).AddHours(11), Color: "var(--color-chart-3)"),
+            new("fp3", "Team offsite", t.AddDays(-1), t.AddDays(1), AllDay: true, Color: "var(--color-accent)"),
+            new("fp4", "Daily stand-up", t.AddHours(9), t.AddHours(9.25),
+                DaysOfWeek: new[] { DayOfWeek.Monday, DayOfWeek.Tuesday, DayOfWeek.Wednesday, DayOfWeek.Thursday, DayOfWeek.Friday },
+                RecurrenceEnd: t.AddMonths(2), Color: "var(--color-chart-1)"),
+            new("fp5", "Kickoff — Design", t.AddHours(10), t.AddHours(10.75), Color: "var(--color-primary)"),
+            new("fp6", "Kickoff — Backend", t.AddHours(10.25), t.AddHours(11), Color: "var(--color-chart-4)"),
+            new("fp7", "Kickoff — Docs", t.AddHours(10.5), t.AddHours(11.25), Color: "var(--color-chart-5)"),
+            new("fp8", "Kickoff — QA", t.AddHours(10.75), t.AddHours(11.5), Color: "var(--color-destructive)"),
+            new("fp9", "Release readiness", t.AddHours(15), t.AddHours(16), Color: "var(--color-chart-2)"),
+            new("fp10", "Design review", t.AddHours(14), t.AddHours(15),
+                DaysOfWeek: new[] { DayOfWeek.Tuesday }, RecurrenceEnd: t.AddMonths(2), Color: "var(--color-chart-3)"),
+            new("fp11", "1:1 sync", t.AddHours(16), t.AddHours(16.5),
+                DaysOfWeek: new[] { DayOfWeek.Thursday }, RecurrenceEnd: t.AddMonths(2), Color: "var(--color-chart-4)"),
+            new("fp12", "Client call", t.AddDays(2).AddHours(11), t.AddDays(2).AddHours(12), Color: "var(--color-primary)"),
+            new("fp13", "Hackathon", t.AddDays(4), t.AddDays(6), AllDay: true, Color: "var(--color-destructive)"),
+            new("fp14", "Sprint review", t.AddDays(7).AddHours(15), t.AddDays(7).AddHours(16), Color: "var(--color-chart-2)"),
+            new("fp15", "Docs sprint", t.AddDays(10), t.AddDays(12), AllDay: true, Color: "var(--color-accent)"),
+            new("fp16", "Beta tag", t.AddDays(15).AddHours(9), t.AddDays(15).AddHours(9.5), Color: "var(--color-chart-5)"),
+        };
+    }
+
+    private List<SchedulerEvent> _fpMonthEvents = BuildFirstPartyEvents();
+    private List<SchedulerEvent> _fpWeekEvents = BuildFirstPartyEvents();
+    private List<SchedulerEvent> _fpAgendaEvents = BuildFirstPartyEvents();
+    private string? _fpMonthLog;
+    private string? _fpWeekLog;
+
+    private Task OnFpMonthDateSelect(SchedulerDateRange range)
+    {
+        var ev = new SchedulerEvent(
+            Id: Guid.NewGuid().ToString("N"),
+            Title: "New event",
+            Start: range.Start,
+            End: range.End,
+            AllDay: range.AllDay,
+            Color: "var(--color-primary)");
+        _fpMonthEvents = _fpMonthEvents.Append(ev).ToList();
+        _fpMonthLog = $"created \"New event\" on {range.Start:MMM d}";
+        return Task.CompletedTask;
+    }
+
+    private Task OnFpMonthEventChange(SchedulerEvent ev)
+    {
+        var idx = _fpMonthEvents.FindIndex(e => e.Id == ev.Id);
+        if (idx >= 0) _fpMonthEvents[idx] = ev;
+        _fpMonthLog = $"{ev.Title} moved to {ev.Start:MMM d}";
+        return Task.CompletedTask;
+    }
+
+    private Task OnFpWeekEventChange(SchedulerEvent ev)
+    {
+        var idx = _fpWeekEvents.FindIndex(e => e.Id == ev.Id);
+        if (idx >= 0) _fpWeekEvents[idx] = ev;
+        _fpWeekLog = $"{ev.Title}: {ev.Start:MMM d HH:mm} → {ev.End:HH:mm}";
+        return Task.CompletedTask;
+    }
+
+    // ── First-party engine: CanDrop three-way validation demo ──────────────
+    private List<SchedulerEvent> _fpDropEvents = BuildDropValidationEvents();
+    private string? _fpDropLog;
+
+    private static List<SchedulerEvent> BuildDropValidationEvents()
+    {
+        var t = Today;
+        return new List<SchedulerEvent>
+        {
+            new("drop1", "Drag onto the 15th or 22nd", t.AddHours(10), t.AddHours(11), Color: "var(--color-primary)"),
+        };
+    }
+
+    private SchedulerDropResult ValidateDrop(SchedulerEvent ev, SchedulerScheduleDropContext ctx)
+    {
+        if (ctx.ProposedStart.Day == 15)
+        {
+            _fpDropLog = $"{ev.Title} -> {ctx.ProposedStart:MMM d} ({ctx.Source}) — rejected, the 15th is blocked";
+            _ = InvokeAsync(StateHasChanged);
+            return SchedulerDropResult.Reject;
+        }
+        if (ctx.ProposedStart.Day == 22)
+        {
+            var snapped = ctx.ProposedStart.AddDays(1);
+            _fpDropLog = $"{ev.Title} -> {ctx.ProposedStart:MMM d} ({ctx.Source}) — accepted, snapped to {snapped:MMM d}";
+            _ = InvokeAsync(StateHasChanged);
+            return SchedulerDropResult.AcceptWith(new SchedulerDropAdjustment(Start: snapped, End: snapped + (ctx.ProposedEnd - ctx.ProposedStart)));
+        }
+        _fpDropLog = $"{ev.Title} -> {ctx.ProposedStart:MMM d} ({ctx.Source}) — accepted as proposed";
+        _ = InvokeAsync(StateHasChanged);
+        return SchedulerDropResult.Accept;
+    }
+
+    private Task OnFpDropEventChange(SchedulerEvent ev)
+    {
+        var idx = _fpDropEvents.FindIndex(e => e.Id == ev.Id);
+        if (idx >= 0) _fpDropEvents[idx] = ev;
+        return Task.CompletedTask;
+    }
+
+    // ── First-party engine: code snippets ───────────────────────────────────
+    private string _fpMonthCode = @"<SchedulerMonthView Events=""_events""
+                     AnchorDate=""_anchor""
+                     BusinessHours=""true""
+                     OnDateSelect=""OnDateSelect""
+                     OnEventChange=""OnEventChange"" />";
+
+    private string _fpWeekCode = @"<SchedulerTimeGridView Events=""_events""
+                        AnchorDate=""_anchor""
+                        Days=""7""
+                        BusinessHours=""true""
+                        NowIndicator=""true""
+                        OnEventChange=""OnEventChange"" />";
+
+    private string _fpAgendaCode = @"<SchedulerAgendaView Events=""_events"" AnchorDate=""_anchor"" DaysToShow=""30"" />";
+
+    private string _fpCanDropCode = @"<SchedulerMonthView Events=""_events"" CanDrop=""ValidateDrop"" OnEventChange=""OnEventChange"" />
+
+@code {
+    private SchedulerDropResult ValidateDrop(SchedulerEvent ev, SchedulerScheduleDropContext ctx)
+    {
+        if (ctx.ProposedStart.Day == 15) return SchedulerDropResult.Reject;
+        if (ctx.ProposedStart.Day == 22)
+        {
+            var snapped = ctx.ProposedStart.AddDays(1);
+            return SchedulerDropResult.AcceptWith(new SchedulerDropAdjustment(
+                Start: snapped, End: snapped + (ctx.ProposedEnd - ctx.ProposedStart)));
+        }
+        return SchedulerDropResult.Accept;
+    }
+}";
+
+    // ── FullCalendar engine: Month demo ─────────────────────────────────────
     private List<SchedulerEvent> _monthEvents = BuildMonthEvents();
 
     private static List<SchedulerEvent> BuildMonthEvents()
@@ -286,11 +641,13 @@
             new("m7", "Engineering demo", first.AddDays(12).AddHours(13), first.AddDays(12).AddHours(14), Color: "var(--color-primary)"),
             new("m8", "Offsite", first.AddDays(16), first.AddDays(18), AllDay: true, Color: "var(--color-accent)"),
             new("m9", "Hackathon", first.AddDays(22).AddHours(9), first.AddDays(22).AddHours(17), Color: "var(--color-destructive)"),
-            new("m10", "Retro", first.AddDays(25).AddHours(16), first.AddDays(25).AddHours(17), Color: "var(--color-primary)")
+            new("m10", "Retro", first.AddDays(25).AddHours(16), first.AddDays(25).AddHours(17), Color: "var(--color-primary)"),
+            new("m11", "Design review", first.AddDays(2).AddHours(9), first.AddDays(2).AddHours(9).AddMinutes(30),
+                DaysOfWeek: new[] { today.DayOfWeek }, RecurrenceEnd: first.AddMonths(2), Color: "var(--color-chart-3)")
         };
     }
 
-    // ── Week demo ────────────────────────────────────────────────────────
+    // ── FullCalendar engine: Week demo ──────────────────────────────────────
     private List<SchedulerEvent> _weekEvents = BuildWeekEvents();
 
     private static List<SchedulerEvent> BuildWeekEvents()
@@ -305,7 +662,11 @@
             new("w3", "All-hands", monday.AddDays(1).AddHours(14), monday.AddDays(1).AddHours(15), Color: "var(--color-destructive)"),
             new("w4", "Interview", monday.AddDays(2).AddHours(11), monday.AddDays(2).AddHours(12), Color: "var(--color-primary)"),
             new("w5", "Conference", monday.AddDays(3), monday.AddDays(4), AllDay: true, Color: "var(--color-destructive)"),
-            new("w6", "Pair coding", monday.AddDays(4).AddHours(13), monday.AddDays(4).AddHours(15), Color: "var(--color-primary)")
+            new("w6", "Pair coding", monday.AddDays(4).AddHours(13), monday.AddDays(4).AddHours(15), Color: "var(--color-primary)"),
+            // Overlap cluster — three double-booked slots Wednesday morning, to show FullCalendar's own column packing.
+            new("w7", "Design huddle", monday.AddDays(2).AddHours(9), monday.AddDays(2).AddHours(9).AddMinutes(45), Color: "var(--color-chart-2)"),
+            new("w8", "Backend huddle", monday.AddDays(2).AddHours(9).AddMinutes(15), monday.AddDays(2).AddHours(10), Color: "var(--color-chart-4)"),
+            new("w9", "QA huddle", monday.AddDays(2).AddHours(9).AddMinutes(30), monday.AddDays(2).AddHours(10).AddMinutes(15), Color: "var(--color-chart-5)")
         };
     }
 
@@ -357,7 +718,8 @@
     private string _weekCode = @"<Scheduler Events=""_events""
            InitialView=""SchedulerView.Week""
            Height=""620px""
-           BusinessHours=""true"" />";
+           BusinessHours=""true""
+           NowIndicator=""true"" />";
 
     private string _createCode = @"<Scheduler Events=""_events""
            InitialView=""SchedulerView.Week""

--- a/docs/Lumeo.Docs/wwwroot/registry.json
+++ b/docs/Lumeo.Docs/wwwroot/registry.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://lumeo.nativ.sh/registry-schema.json",
   "version": "4.3.3",
-  "generated": "2026-08-11T10:02:48.6933128Z",
+  "generated": "2026-08-11T16:40:16.1988919Z",
   "components": {
     "accordion": {
       "name": "Accordion",
@@ -4707,7 +4707,7 @@
       "gotchas": [],
       "registryUrl": "https://lumeo.nativ.sh/registry/scheduler.json",
       "testCoverage": {
-        "tier": 3,
+        "tier": 4,
         "files": 15,
         "tests": 120,
         "relatedFiles": 1,
@@ -4716,8 +4716,10 @@
         "a11y": true,
         "keyboard": true,
         "scale": false,
-        "e2e": false,
-        "e2eFiles": [],
+        "e2e": true,
+        "e2eFiles": [
+          "SchedulerDocsPageRenderTests.cs"
+        ],
         "contract": "smoke"
       }
     },

--- a/docs/Lumeo.Docs/wwwroot/registry/cdn-deps.json
+++ b/docs/Lumeo.Docs/wwwroot/registry/cdn-deps.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0",
-  "generated": "2026-08-11T10:03:07.8000357Z",
+  "generated": "2026-08-11T16:40:31.7373872Z",
   "deps": [
     {
       "key": "mapLibreJs",

--- a/docs/Lumeo.Docs/wwwroot/registry/scheduler.json
+++ b/docs/Lumeo.Docs/wwwroot/registry/scheduler.json
@@ -294,20 +294,20 @@
     ],
     "examples": [
       {
-        "title": "Month View (basic)",
-        "code": "<Scheduler Events=\"_events\" InitialView=\"SchedulerView.Month\" Height=\"620px\" />"
+        "title": "Month view (first-party engine)",
+        "code": "<SchedulerMonthView Events=\"_events\"\n                     AnchorDate=\"_anchor\"\n                     BusinessHours=\"true\"\n                     OnDateSelect=\"OnDateSelect\"\n                     OnEventChange=\"OnEventChange\" />"
       },
       {
-        "title": "Week View (timed + all-day)",
-        "code": "<Scheduler Events=\"_events\"\n           InitialView=\"SchedulerView.Week\"\n           Height=\"620px\"\n           BusinessHours=\"true\" />"
+        "title": "Week view (first-party engine)",
+        "code": "<SchedulerTimeGridView Events=\"_events\"\n                        AnchorDate=\"_anchor\"\n                        Days=\"7\"\n                        BusinessHours=\"true\"\n                        NowIndicator=\"true\"\n                        OnEventChange=\"OnEventChange\" />"
       },
       {
-        "title": "Click to Create",
-        "code": "<Scheduler Events=\"_events\"\n           InitialView=\"SchedulerView.Week\"\n           OnDateSelect=\"HandleDateSelect\" />\n\n<Dialog @bind-Open=\"_open\">\n    <DialogContent>\n        <DialogHeader><DialogTitle>New event</DialogTitle></DialogHeader>\n        <Input @bind-Value=\"_title\" placeholder=\"Title\" />\n        <DialogFooter>\n            <Button OnClick=\"Add\">Add event</Button>\n        </DialogFooter>\n    </DialogContent>\n</Dialog>\n\n@code {\n    private bool _open;\n    private SchedulerDateRange? _range;\n    private string _title = \"\";\n    private List<SchedulerEvent> _events = new();\n\n    void HandleDateSelect(SchedulerDateRange r) { _range = r; _open = true; }\n    void Add() {\n        _events = _events.Append(new SchedulerEvent(\n            Id: Guid.NewGuid().ToString(\"N\"),\n            Title: _title,\n            Start: _range!.Start,\n            End: _range.End,\n            AllDay: _range.AllDay\n        )).ToList();\n        _open = false;\n    }\n}"
+        "title": "Agenda view (first-party engine)",
+        "code": "<SchedulerAgendaView Events=\"_events\" AnchorDate=\"_anchor\" DaysToShow=\"30\" />"
       },
       {
-        "title": "Drag to Reschedule",
-        "code": "<Scheduler @bind-Events=\"_events\" InitialView=\"SchedulerView.Week\" />\n\n@code {\n    private IEnumerable<SchedulerEvent> _events = new List<SchedulerEvent> { /* ... */ };\n}"
+        "title": "Drop validation (CanDrop)",
+        "code": "<SchedulerMonthView Events=\"_events\" CanDrop=\"ValidateDrop\" OnEventChange=\"OnEventChange\" />\n\n@code {\n    private SchedulerDropResult ValidateDrop(SchedulerEvent ev, SchedulerScheduleDropContext ctx)\n    {\n        if (ctx.ProposedStart.Day == 15) return SchedulerDropResult.Reject;\n        if (ctx.ProposedStart.Day == 22)\n        {\n            var snapped = ctx.ProposedStart.AddDays(1);\n            return SchedulerDropResult.AcceptWith(new SchedulerDropAdjustment(\n                Start: snapped, End: snapped + (ctx.ProposedEnd - ctx.ProposedStart)));\n        }\n        return SchedulerDropResult.Accept;\n    }\n}"
       }
     ],
     "subComponents": {},
@@ -324,7 +324,7 @@
     "parseError": null
   },
   "testCoverage": {
-    "tier": 3,
+    "tier": 4,
     "files": 15,
     "tests": 120,
     "relatedFiles": 1,
@@ -333,8 +333,10 @@
     "a11y": true,
     "keyboard": true,
     "scale": false,
-    "e2e": false,
-    "e2eFiles": [],
+    "e2e": true,
+    "e2eFiles": [
+      "SchedulerDocsPageRenderTests.cs"
+    ],
     "contract": "smoke"
   },
   "$schema": "https://lumeo.nativ.sh/registry-component-schema.json",
@@ -392,6 +394,7 @@
   ],
   "keyboardInteractions": [],
   "tests": [
+    "tests/Lumeo.Tests.E2E/Scheduler/SchedulerDocsPageRenderTests.cs",
     "tests/Lumeo.Tests.E2E/Scheduler/SchedulerViewsDragTests.cs",
     "tests/Lumeo.Tests.E2E/Scheduler/SchedulerViewsInteractionTests.cs",
     "tests/Lumeo.Tests/Components/Localization/P2LocalizationSweepTests.cs",

--- a/src/Lumeo/registry/cdn-deps.json
+++ b/src/Lumeo/registry/cdn-deps.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0",
-  "generated": "2026-08-11T10:03:07.8000357Z",
+  "generated": "2026-08-11T16:40:31.7373872Z",
   "deps": [
     {
       "key": "mapLibreJs",

--- a/src/Lumeo/registry/registry.json
+++ b/src/Lumeo/registry/registry.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://lumeo.nativ.sh/registry-schema.json",
   "version": "4.3.3",
-  "generated": "2026-08-11T11:01:17.6777505Z",
+  "generated": "2026-08-11T16:40:16.1988919Z",
   "components": {
     "accordion": {
       "name": "Accordion",
@@ -4707,7 +4707,7 @@
       "gotchas": [],
       "registryUrl": "https://lumeo.nativ.sh/registry/scheduler.json",
       "testCoverage": {
-        "tier": 3,
+        "tier": 4,
         "files": 15,
         "tests": 120,
         "relatedFiles": 1,
@@ -4716,8 +4716,10 @@
         "a11y": true,
         "keyboard": true,
         "scale": false,
-        "e2e": false,
-        "e2eFiles": [],
+        "e2e": true,
+        "e2eFiles": [
+          "SchedulerDocsPageRenderTests.cs"
+        ],
         "contract": "smoke"
       }
     },

--- a/tests/Lumeo.Tests.E2E/Scheduler/SchedulerDocsPageRenderTests.cs
+++ b/tests/Lumeo.Tests.E2E/Scheduler/SchedulerDocsPageRenderTests.cs
@@ -1,0 +1,139 @@
+using Microsoft.Playwright;
+using Xunit;
+
+namespace Lumeo.Tests.E2E.Scheduler;
+
+/// <summary>
+/// Real-browser coverage for <c>/components/scheduler</c> — the docs page rebuilt to show
+/// realistic, dense event data (overlaps, multi-day spans, all-day events, recurrence) across
+/// both Scheduler engines. Asserts PER-SECTION presence rather than just a 200 response: a
+/// Blazor render exception anywhere in the tree silently drops everything rendered after it
+/// (no console error, no visible crash banner — see the "First-party view engine" section's
+/// history before this task, which vanished from the DOM with zero errors under a too-short
+/// wait budget), so a page that half-renders can otherwise look fine.
+///
+/// Timeout budget: measured locally, the first-party engine section (5 live component
+/// instances: SchedulerMonthView x2, SchedulerTimeGridView x2, SchedulerAgendaView) settles
+/// within ~20s of navigation on a Debug/interpreted WASM build — noticeably slower than the
+/// FullCalendar-backed demos alone (~8-10s) because each view does synchronous recurrence
+/// expansion + month/week grid layout + JS interop drag registration on init. 30s is used
+/// below to leave headroom.
+///
+/// The FullCalendar-backed "Scheduler (FullCalendar-backed, default)" section is asserted only
+/// for its STATIC scaffolding (heading + demo card titles), not for FullCalendar's own rendered
+/// DOM. That section fetches 5 FullCalendar packages from esm.sh at runtime; even with a clean
+/// network path this project's own vendoring fix (tracked separately, PR #396 on
+/// feat/gantt-v3-promote — NOT merged as of this test) hasn't landed, and locally the CDN calls
+/// are observably flaky under load (esm.sh returned intermittent 408s here once ~13 concurrent
+/// Scheduler-family components were booting on one page). Asserting deep FullCalendar content
+/// here would make this suite flaky for a reason unrelated to Lumeo's own code.
+/// </summary>
+public class SchedulerDocsPageRenderTests : PlaywrightTestBase
+{
+    private const float LongTimeoutMs = 30000;
+
+    [Fact]
+    public async Task Page_Header_And_Choosing_An_Engine_Table_Render()
+    {
+        await Goto("/components/scheduler");
+
+        await Assertions.Expect(Page.Locator("h1", new() { HasTextString = "Scheduler" })).ToBeVisibleAsync(new() { Timeout = LongTimeoutMs });
+        await Assertions.Expect(Page.Locator("#choosing-an-engine")).ToBeVisibleAsync(new() { Timeout = LongTimeoutMs });
+
+        var table = Page.Locator("table", new() { HasTextString = "Multi-calendar split / overlay panes" });
+        await Assertions.Expect(table).ToBeVisibleAsync(new() { Timeout = LongTimeoutMs });
+        await Assertions.Expect(table).ToContainTextAsync("Drop validation");
+    }
+
+    [Fact]
+    public async Task First_Party_Engine_Section_Renders_All_Five_Demo_Cards_With_Live_Grids()
+    {
+        await Goto("/components/scheduler");
+
+        await Assertions.Expect(Page.Locator("#first-party-engine")).ToBeVisibleAsync(new() { Timeout = LongTimeoutMs });
+
+        // Every first-party demo card, by its ComponentDemo-computed slug id (Title, slugified).
+        string[] expectedCardIds =
+        [
+            "month-view-first-party-engine",
+            "week-view-first-party-engine",
+            "day-view-first-party-engine",
+            "agenda-view-first-party-engine",
+            "drop-validation-candrop",
+        ];
+        foreach (var id in expectedCardIds)
+        {
+            await Assertions.Expect(Page.Locator($"#{id}")).ToBeVisibleAsync(new() { Timeout = LongTimeoutMs });
+        }
+
+        // The month and week demos each render a real ARIA grid (SchedulerMonthView /
+        // SchedulerTimeGridView both use role="grid") — proof the component actually
+        // initialized, not just that the surrounding card chrome rendered.
+        var monthGrid = Page.Locator("#month-view-first-party-engine [role='grid']");
+        await Assertions.Expect(monthGrid).ToBeVisibleAsync(new() { Timeout = LongTimeoutMs });
+
+        var weekGrid = Page.Locator("#week-view-first-party-engine [role='grid']");
+        await Assertions.Expect(weekGrid).ToBeVisibleAsync(new() { Timeout = LongTimeoutMs });
+
+        // The dense dataset's overlap cluster on "today" (5 same-day events, over the
+        // default 3-lane budget) must overflow into a "+N more" affordance.
+        var monthCard = Page.Locator("#month-view-first-party-engine");
+        await Assertions.Expect(monthCard.GetByTestId("month-more-events")).ToBeVisibleAsync(new() { Timeout = LongTimeoutMs });
+
+        // Agenda view is a flat list, not a grid — assert its known event titles instead.
+        var agendaCard = Page.Locator("#agenda-view-first-party-engine");
+        await Assertions.Expect(agendaCard).ToContainTextAsync("Daily stand-up", new() { Timeout = LongTimeoutMs });
+    }
+
+    [Fact]
+    public async Task CanDrop_Demo_Explains_The_Three_Way_Gate_And_Renders_A_Live_Grid()
+    {
+        await Goto("/components/scheduler");
+
+        var card = Page.Locator("#drop-validation-candrop");
+        await Assertions.Expect(card).ToBeVisibleAsync(new() { Timeout = LongTimeoutMs });
+        await Assertions.Expect(card).ToContainTextAsync("15th");
+        await Assertions.Expect(card).ToContainTextAsync("22nd");
+        await Assertions.Expect(card.Locator("[role='grid']")).ToBeVisibleAsync(new() { Timeout = LongTimeoutMs });
+        await Assertions.Expect(card).ToContainTextAsync("Last CanDrop check");
+    }
+
+    [Fact]
+    public async Task FullCalendar_Section_Static_Scaffolding_Renders_All_Eight_Demo_Cards()
+    {
+        // Static scaffolding only (see class-level remarks) — this section's actual FullCalendar
+        // content depends on a CDN fetch this test deliberately does not gate on.
+        await Goto("/components/scheduler");
+
+        await Assertions.Expect(Page.Locator("#fullcalendar-engine")).ToBeVisibleAsync(new() { Timeout = LongTimeoutMs });
+
+        string[] expectedCardIds =
+        [
+            "month-view",
+            "week-view-timed-all-day-overlaps",
+            "day-view",
+            "list-view-agenda",
+            "click-to-create",
+            "drag-to-reschedule",
+            "recurring-events",
+            "resource-color-coding",
+        ];
+        foreach (var id in expectedCardIds)
+        {
+            await Assertions.Expect(Page.Locator($"#{id}")).ToBeVisibleAsync(new() { Timeout = LongTimeoutMs });
+        }
+    }
+
+    [Fact]
+    public async Task Api_Reference_Covers_Both_Engines_Including_CanDrop_Types()
+    {
+        await Goto("/components/scheduler");
+
+        await Assertions.Expect(Page.Locator("#api-reference")).ToBeVisibleAsync(new() { Timeout = LongTimeoutMs });
+        await Assertions.Expect(Page.Locator("#first-party-views")).ToBeVisibleAsync(new() { Timeout = LongTimeoutMs });
+        await Assertions.Expect(Page.Locator("#scheduler-drop-result")).ToBeVisibleAsync(new() { Timeout = LongTimeoutMs });
+
+        var dropTable = Page.Locator("table", new() { HasTextString = "AcceptWith" });
+        await Assertions.Expect(dropTable).ToBeVisibleAsync(new() { Timeout = LongTimeoutMs });
+    }
+}

--- a/tools/lumeo-mcp/src/components-api.json
+++ b/tools/lumeo-mcp/src/components-api.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://lumeo.nativ.sh/components-api-schema.json",
   "version": "4.3.3",
-  "generated": "2026-08-11T11:01:21.4526475Z",
+  "generated": "2026-08-11T16:40:18.9533531Z",
   "stats": {
     "componentCount": 164,
     "totalParameters": 4281,
@@ -47812,20 +47812,20 @@
       ],
       "examples": [
         {
-          "title": "Month View (basic)",
-          "code": "<Scheduler Events=\"_events\" InitialView=\"SchedulerView.Month\" Height=\"620px\" />"
+          "title": "Month view (first-party engine)",
+          "code": "<SchedulerMonthView Events=\"_events\"\n                     AnchorDate=\"_anchor\"\n                     BusinessHours=\"true\"\n                     OnDateSelect=\"OnDateSelect\"\n                     OnEventChange=\"OnEventChange\" />"
         },
         {
-          "title": "Week View (timed + all-day)",
-          "code": "<Scheduler Events=\"_events\"\n           InitialView=\"SchedulerView.Week\"\n           Height=\"620px\"\n           BusinessHours=\"true\" />"
+          "title": "Week view (first-party engine)",
+          "code": "<SchedulerTimeGridView Events=\"_events\"\n                        AnchorDate=\"_anchor\"\n                        Days=\"7\"\n                        BusinessHours=\"true\"\n                        NowIndicator=\"true\"\n                        OnEventChange=\"OnEventChange\" />"
         },
         {
-          "title": "Click to Create",
-          "code": "<Scheduler Events=\"_events\"\n           InitialView=\"SchedulerView.Week\"\n           OnDateSelect=\"HandleDateSelect\" />\n\n<Dialog @bind-Open=\"_open\">\n    <DialogContent>\n        <DialogHeader><DialogTitle>New event</DialogTitle></DialogHeader>\n        <Input @bind-Value=\"_title\" placeholder=\"Title\" />\n        <DialogFooter>\n            <Button OnClick=\"Add\">Add event</Button>\n        </DialogFooter>\n    </DialogContent>\n</Dialog>\n\n@code {\n    private bool _open;\n    private SchedulerDateRange? _range;\n    private string _title = \"\";\n    private List<SchedulerEvent> _events = new();\n\n    void HandleDateSelect(SchedulerDateRange r) { _range = r; _open = true; }\n    void Add() {\n        _events = _events.Append(new SchedulerEvent(\n            Id: Guid.NewGuid().ToString(\"N\"),\n            Title: _title,\n            Start: _range!.Start,\n            End: _range.End,\n            AllDay: _range.AllDay\n        )).ToList();\n        _open = false;\n    }\n}"
+          "title": "Agenda view (first-party engine)",
+          "code": "<SchedulerAgendaView Events=\"_events\" AnchorDate=\"_anchor\" DaysToShow=\"30\" />"
         },
         {
-          "title": "Drag to Reschedule",
-          "code": "<Scheduler @bind-Events=\"_events\" InitialView=\"SchedulerView.Week\" />\n\n@code {\n    private IEnumerable<SchedulerEvent> _events = new List<SchedulerEvent> { /* ... */ };\n}"
+          "title": "Drop validation (CanDrop)",
+          "code": "<SchedulerMonthView Events=\"_events\" CanDrop=\"ValidateDrop\" OnEventChange=\"OnEventChange\" />\n\n@code {\n    private SchedulerDropResult ValidateDrop(SchedulerEvent ev, SchedulerScheduleDropContext ctx)\n    {\n        if (ctx.ProposedStart.Day == 15) return SchedulerDropResult.Reject;\n        if (ctx.ProposedStart.Day == 22)\n        {\n            var snapped = ctx.ProposedStart.AddDays(1);\n            return SchedulerDropResult.AcceptWith(new SchedulerDropAdjustment(\n                Start: snapped, End: snapped + (ctx.ProposedEnd - ctx.ProposedStart)));\n        }\n        return SchedulerDropResult.Accept;\n    }\n}"
         }
       ],
       "subComponents": {},

--- a/tools/lumeo-mcp/src/registry.json
+++ b/tools/lumeo-mcp/src/registry.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://lumeo.nativ.sh/registry-schema.json",
   "version": "4.3.3",
-  "generated": "2026-08-11T11:01:17.6777505Z",
+  "generated": "2026-08-11T16:40:16.1988919Z",
   "components": {
     "accordion": {
       "name": "Accordion",
@@ -4707,7 +4707,7 @@
       "gotchas": [],
       "registryUrl": "https://lumeo.nativ.sh/registry/scheduler.json",
       "testCoverage": {
-        "tier": 3,
+        "tier": 4,
         "files": 15,
         "tests": 120,
         "relatedFiles": 1,
@@ -4716,8 +4716,10 @@
         "a11y": true,
         "keyboard": true,
         "scale": false,
-        "e2e": false,
-        "e2eFiles": [],
+        "e2e": true,
+        "e2eFiles": [
+          "SchedulerDocsPageRenderTests.cs"
+        ],
         "contract": "smoke"
       }
     },


### PR DESCRIPTION
## Summary
- Rebuilt the Scheduler docs page (`/components/scheduler`) demos: the previous ones were thin, non-overlapping placeholder events that the owner judged unusable ("die Demos sind unbrauchbar").
- Promoted the first-party view engine (`SchedulerMonthView` / `SchedulerTimeGridView` / new `SchedulerAgendaView` demo) to the top of the page with a shared, realistic dataset — overlaps, multi-day all-day spans, daily/weekly recurrence — dense enough to trigger the month "+N more" overflow and time-grid overlap packing.
- Added a dedicated CanDrop demo showing the three-way reject / accept / accept-with-adjustment gate with a live log.
- Added a "Choosing an engine" comparison table (FullCalendar-backed `Scheduler` vs. the first-party engine) and documented that Outlook-style split/overlay multi-calendar panes are not implemented by either engine today — a roadmap note, not a fix in this PR.
- Kept the FullCalendar-backed `Scheduler` section (8 demos), enriched its data similarly, and added a runtime-CDN-dependency callout.
- Added real-browser smoke coverage (`SchedulerDocsPageRenderTests`) asserting per-section presence for both engines — a Blazor render exception anywhere in the tree silently drops everything rendered after it with no console error, so section-level assertions matter more than a 200 response.
- Regenerated the component registry (tier bump + new e2e file reference) and the local search index.

## Not in scope (flagged, not duplicated)
- FullCalendar vendoring (the deployed-site CDN-fetch failure) is tracked on `feat/gantt-v3-promote` (PR #396, not yet merged). The FullCalendar-backed section's demo cards are asserted structurally only in the new test, not for FullCalendar's own rendered DOM, since that also proved flaky locally under concurrent CDN load independent of this change.

## Test plan
- [x] `dotnet build Lumeo.slnx -warnaserror -m:1` — 0 warnings, 0 errors (clean rebuild from nuked `obj`/`bin`)
- [x] `dotnet test tests/Lumeo.Tests/Lumeo.Tests.csproj` — 7557/7557 passed (both `net8.0`/`net10.0`)
- [x] `dotnet test tests/Lumeo.Docs.Tests/Lumeo.Docs.Tests.csproj` — 37/37 passed, incl. `AllComponentPagesRenderTests` (175 docs pages render headless without throwing)
- [x] `dotnet test tests/Lumeo.Tests.E2E` (`Scheduler` filter) — 19/19 passed against an isolated local dev server (`127.0.0.1:5299`, `ASPNETCORE_ENVIRONMENT=Development`)
- [x] `python scripts/docs-parity/check.py` — exit 0
- [x] Conflict-marker / "adepto" sweep — clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Expanded Scheduler documentation with guidance for choosing between the default FullCalendar engine and the first-party Blazor engine.
  - Added month, week, day, and agenda demonstrations, capability comparisons, CDN/runtime notes, and drop-validation examples.
  - Documented scheduler view APIs, drop-validation types, and structured recurring events.
  - Refreshed examples with overlapping, recurring, multi-day, and agenda events, plus a FullCalendar now indicator.

- **Tests**
  - Added end-to-end coverage validating Scheduler documentation pages, live demos, engine guidance, and API references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->