### PR TITLE
fix(e2e): stop ShimmerButtonGapTests racing the Blazor Server circuit

### DIFF
--- a/tests/Lumeo.Tests.E2E/Smokes/ShimmerButtonGapTests.cs
+++ b/tests/Lumeo.Tests.E2E/Smokes/ShimmerButtonGapTests.cs
@@ -22,6 +22,28 @@ namespace Lumeo.Tests.E2E.Smokes;
 /// Drives <c>tests/Lumeo.Tests.ServerHost</c>'s <c>/e2e/shimmer-button-gap</c> page the
 /// same way <see cref="InputSizingTests"/> drives <c>/e2e/input-sizing</c> — see that
 /// class's remarks for why a separate base URL / no shared Gantt collection is used.
+///
+/// CI flake fix (master e2e red, 2026-08-12): this suite intermittently failed with
+/// <c>Cannot read properties of null (reading 'querySelector')</c> — the exact same
+/// symptom <see cref="InputSizingTests"/>'s class-level remarks document under "CI
+/// flake fix, item 1". Root cause is identical: <c>tests/Lumeo.Tests.ServerHost</c>
+/// renders with <c>InteractiveServerRenderMode(prerender: false)</c> (see
+/// <c>App.razor</c>), so the initial HTML is an empty shell and every element only
+/// appears once the SignalR circuit's first render batch arrives over the
+/// already-open WebSocket. <c>Page.WaitForLoadStateAsync(NetworkIdle)</c> in
+/// <c>InitializeAsync</c> only observes HTTP/JS asset downloads settling, not that
+/// render batch — so a raw <c>document.querySelector</c> inside <c>Page.EvaluateAsync</c>
+/// can run before the button/icon/label elements attach, especially under the shared
+/// ServerHost process's resource contention from other Smokes classes running in
+/// xUnit's default parallel collection. Verified NOT a missing-CSS-utility issue: the
+/// actual CI error text was the null-querySelector TypeError above, not a wrong
+/// computed-gap value, and a literal substring scan of the shipped
+/// <c>src/Lumeo/wwwroot/css/lumeo-utilities.css</c> bundle confirms <c>.gap-1{</c>,
+/// <c>.gap-1\.5{</c> and <c>.gap-2{</c> are all present. Fixed the same way
+/// <see cref="InputSizingTests"/> was: every element lookup now goes through
+/// <c>Locator.WaitForAsync</c> (which waits, up to its own timeout, for the element to
+/// attach) before evaluating against it, instead of a one-shot
+/// <c>document.querySelector</c> that assumes the element already exists.
 /// </summary>
 public class ShimmerButtonGapTests : IAsyncLifetime
 {
@@ -49,25 +71,39 @@ public class ShimmerButtonGapTests : IAsyncLifetime
         _playwright.Dispose();
     }
 
+    // Resolves a data-testid to a Playwright Locator that WAITS (up to its default
+    // timeout) for a matching element to attach to the DOM, instead of a one-shot
+    // `document.querySelector` that assumes it already exists. See the class-level
+    // remarks (CI flake fix) for why this matters on this specific host.
+    private ILocator ByTestId(string testId) => _page.Locator($"[data-testid=\"{testId}\"]");
+
     private async Task<double> ComputedColumnGapPxAsync(string size)
-        => await _page.EvaluateAsync<double>(
-            @"(size) => {
-                const btn = document.querySelector(`[data-testid=""shimmer-${size}""]`);
-                const span = btn.querySelector(':scope > span');
+    {
+        var btn = ByTestId($"shimmer-{size}");
+        await btn.WaitForAsync(new LocatorWaitForOptions { State = WaitForSelectorState.Attached });
+        return await btn.EvaluateAsync<double>(
+            @"(el) => {
+                const span = el.querySelector(':scope > span');
                 return parseFloat(getComputedStyle(span).columnGap);
-            }",
-            size);
+            }");
+    }
 
     private async Task<double> MeasuredIconToLabelGapPxAsync(string size)
-        => await _page.EvaluateAsync<double>(
-            @"(size) => {
-                const icon = document.querySelector(`[data-testid=""shimmer-${size}-icon""]`);
-                const label = document.querySelector(`[data-testid=""shimmer-${size}-label""]`);
-                const iconRect = icon.getBoundingClientRect();
+    {
+        var icon = ByTestId($"shimmer-{size}-icon");
+        var label = ByTestId($"shimmer-{size}-label");
+        await icon.WaitForAsync(new LocatorWaitForOptions { State = WaitForSelectorState.Attached });
+        await label.WaitForAsync(new LocatorWaitForOptions { State = WaitForSelectorState.Attached });
+
+        return await icon.EvaluateAsync<double>(
+            @"(iconEl, testid) => {
+                const label = document.querySelector(`[data-testid=""${testid}""]`);
+                const iconRect = iconEl.getBoundingClientRect();
                 const labelRect = label.getBoundingClientRect();
                 return labelRect.left - iconRect.right;
             }",
-            size);
+            $"shimmer-{size}-label");
+    }
 
     // Predicted-vs-actual (disable check): reverting InnerContentClass back to the
     // pre-fix hardcoded "gap-2" on the inner span (with the outer button's SizeClasses


### PR DESCRIPTION
## Summary

Master's e2e was red on 4 of the last 5 runs. This restores it for the `ShimmerButtonGapTests` failure specifically.

- Root cause: `ShimmerButtonGapTests` used a raw `document.querySelector` inside `Page.EvaluateAsync`, which can run before `tests/Lumeo.Tests.ServerHost`'s Blazor Server circuit (`InteractiveServerRenderMode(prerender: false)`) delivers its first render batch — `Page.WaitForLoadStateAsync(NetworkIdle)` only observes asset downloads settling, not that batch. The actual CI failure text was `TypeError: Cannot read properties of null (reading 'querySelector')`, not a wrong computed value.
- This is the exact same class of flake `InputSizingTests` already hit and fixed (see its class-level remarks). Applied the identical fix here: every element lookup now goes through `Locator.WaitForAsync` + `Locator.EvaluateAsync` instead of a one-shot `querySelector`.
- Ruled out a missing-CSS-utility as the cause: a literal Python substring scan of the shipped `src/Lumeo/wwwroot/css/lumeo-utilities.css` bundle confirms `.gap-1{`, `.gap-1\.5{`, and `.gap-2{` are all present.
- The `ShimmerButton` component itself (`src/Lumeo.Motion/UI/ShimmerButton/ShimmerButton.razor`) needed no change — `InnerGapClass` already correctly renders `gap-1`/`gap-1.5`/`gap-2` per size, matching PR #386's original fix.

## Verification

- Disable check: temporarily reverted the `Xs` arm's gap back to the pre-#386 hardcoded `gap-2`, rebuilt, and re-ran — `Xs_Inner_Span_Computed_Gap_Is_4px_Not_8px` failed exactly as predicted (`Expected: 4, Actual: 8`). Reverted the sabotage; `git diff` on the component is clean.
- `ShimmerButtonGapTests` passed on 6 consecutive local runs against the ServerHost (Blazor Server, `ASPNETCORE_ENVIRONMENT=Development`, no prerender — mirrors CI).
- Full `Smokes/` suite: 76/76 passed.
- Full E2E suite (237 tests): 1 unrelated local-only visual-baseline failure (`HomePageVisualTests.Home_page_above_the_fold_matches_baseline`, a pixel-diff screenshot test — almost certainly Windows-vs-Ubuntu font/GPU rendering noise; this test has never appeared in any of master's actual CI failure logs I reviewed).
- `dotnet build Lumeo.slnx -warnaserror -m:1`: 0 errors/warnings (regex cross-checked).
- `python scripts/docs-parity/check.py`: exit 0.
- Full filtered unit suite (`ci.yml`'s exact filter): 136 + 7605 tests, all passed.
- Registry regen + algolia local index regen: no content drift (only build timestamps, discarded).

## Other master e2e failures found (out of scope for this PR)

Across the last 7 e2e runs on master, besides `ShimmerButtonGapTests`, every other failure was a *different* single Gantt test each time — consistent with CPU-contention flakiness under the shared ServerHost process, not a real regression:

- `GanttV3StickyHeaderTests.Header_columns_stay_aligned_with_the_row_canvas_after_a_horizontal_scroll`
- `GanttV3InfiniteScrollTests.Scrolling_To_Either_Physical_Extreme_Under_Rtl_Grows_The_Range`
- `GanttDragParityTests.Drag_create_beside_an_existing_bar_on_an_occupied_row_creates_a_snapped_task`
- `GanttDragParityTests.Drag_create_after_panning_computes_dates_from_the_new_origin` (x2)
- `GanttDragParityTests.No_move_ghost_survives_a_completed_drag`

These weren't tackled here since the task scope was `ShimmerButtonGapTests`; flagging so the gate isn't declared fully green prematurely.

## Test plan

- [x] `ShimmerButtonGapTests` passes repeatedly (6x) against a real ServerHost
- [x] Full `Smokes/` suite passes (76/76)
- [x] Disable check: predicted failure reproduced, then reverted
- [x] Full solution build, 0 warnings/errors
- [x] docs-parity check exit 0
- [x] Full filtered unit suite passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of visual spacing checks by ensuring elements are available before measurements are taken.
  * Reduced intermittent failures caused by timing differences during initial page rendering.

* **Tests**
  * Added more robust element targeting and wait conditions for end-to-end validation.
  * Updated test documentation to explain and prevent rendering-related CI flakes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->