### PR TITLE
fix(e2e): serialize the Playwright assembly to stop CI collection oversubscription

### DIFF
--- a/tests/Lumeo.Tests.E2E/AssemblyInfo.cs
+++ b/tests/Lumeo.Tests.E2E/AssemblyInfo.cs
@@ -1,0 +1,52 @@
+using Xunit;
+
+// Gate-stability fix: this assembly has no xunit.runner.json, so xUnit v2 fell back
+// to its own default — parallelize test COLLECTIONS with maxParallelThreads =
+// Environment.ProcessorCount. Every test class in this project is its own implicit
+// collection except the Gantt specs (which already share one explicit sequential
+// collection, GanttSequentialCollection in Gantt/GanttParityTestBase.cs). That left
+// ~20 independent collections eligible to run concurrently, and PlaywrightTestBase
+// launches a brand-new headless Chromium PROCESS per [Fact]/[Theory]
+// (IAsyncLifetime.InitializeAsync runs per test-class-instance, and xUnit constructs
+// a fresh instance per test method) — so on GitHub's own documented public-repo
+// ubuntu-latest spec (4 vCPU / 16GB), "default parallelism" meant up to 4 collections
+// each spinning up their own multi-process Chromium at once, all fighting the same
+// 4 cores.
+//
+// That is the resource starvation seven master-run failures traced back to: a
+// different Gantt test timed out or mis-measured (e.g. GanttV3StickyHeaderTests'
+// horizontal-scroll assertion reading a stale position because the page's own JS
+// auto-center callback lost a race against the test's synchronous reset once the
+// runner's CPU was oversubscribed) on almost every run, never the same one twice —
+// the signature of scheduling contention, not a shared logic bug. The Gantt
+// collection's own internal DisableParallelization=true only serializes Gantt specs
+// against EACH OTHER; it does nothing to stop the ~20 OTHER collections (Smokes/,
+// Scheduler/, Visual/) from running alongside it and starving its CPU budget. Log
+// timestamps from a captured failure confirm this directly: Smokes/ and Scheduler/
+// tests were interleaving with Gantt output in the exact window the Gantt assertion
+// failed.
+//
+// Fix: fully serialize the assembly (one test collection executing at a time)
+// instead of leaving it at ProcessorCount. This was validated against two weaker
+// options first, both of which turned out insufficient:
+//
+//   - MaxParallelThreads=2 (halving the default): in a CPU-capped Docker repro of
+//     the actual CI runner (4 vCPU / 16GB, matching GitHub's public-repo hosted-runner
+//     spec), it took the flake rate from 2-of-5 repeated runs (unpatched default) to
+//     0-of-5 — but under ADDITIONAL induced background CPU load (a 2-core busy-loop
+//     container running alongside the same 4-vCPU test container, simulating a
+//     noisier host than an idle repro), it still flaked 1-of-3, on the exact same
+//     test with the exact same error signature: "expected the header to shift left
+//     by ~300px in lockstep with the row canvas, got a delta of -5633" — a
+//     byte-for-byte match to a real master CI failure.
+//   - Full serialization (this fix, MaxParallelThreads=1): under the identical
+//     induced-load repro, 3-of-3 clean.
+//
+// Cost: wall time for the filtered (non-Visual) suite rose from a ~150-175s baseline
+// (default parallelism) to ~250-255s fully serialized — roughly +65-70%, not the
+// mild ~10-15% MaxParallelThreads=2 cost. That is a real trade-off, not a rounding
+// error, but the workflow's own timeout budget (25 minutes for the whole job,
+// including two full solution builds and browser install) comfortably absorbs it,
+// and "the gate is trustworthy" was worth more here than "the gate is a little
+// faster."
+[assembly: CollectionBehavior(MaxParallelThreads = 1)]


### PR DESCRIPTION
## Summary

Master's E2E gate has been failing 4 of the last 5 runs, always on a
different Gantt test — the signature of resource contention, not a shared
logic bug. This fixes the actual contention, not the symptom.

## What competes with what

`Lumeo.Tests.E2E` has no `xunit.runner.json`, so xUnit v2's default applied:
parallelize test **collections** at `maxParallelThreads = Environment.ProcessorCount`.
Every test class here is its own implicit collection except the Gantt specs,
which already share one sequential collection (`GanttSequentialCollection`) —
serialized against *each other*, but still just one of ~20 collections free
to run concurrently against everything else. `PlaywrightTestBase` launches a
brand-new headless Chromium process per `[Fact]`/`[Theory]`, so on GitHub's
documented public-repo `ubuntu-latest` spec (4 vCPU / 16GB), default
parallelism meant up to 4 collections simultaneously spinning up their own
multi-process Chromium instances on 4 cores.

A CPU-capped Docker repro of the real runner spec confirmed this directly:
log timestamps around a captured failure show `Smokes/` and `Scheduler/`
tests actively interleaving with Gantt output in the same window the Gantt
assertion failed, and the repro reproduced the *exact* real CI failure
signature on demand (`GanttV3StickyHeaderTests`, delta of `-5633`,
byte-for-byte match to a master CI log).

## The fix and its cost

`[assembly: CollectionBehavior(MaxParallelThreads = 1)]` — full
serialization. A weaker `MaxParallelThreads = 2` was tried first and looked
sufficient in an idle repro (0-of-5 repeated runs failed, vs. 2-of-5 at the
unpatched default), but still flaked 1-of-3 under additional induced
background CPU load; full serialization held 3-of-3 clean under the same
induced load. Cost: the filtered (non-Visual) suite's wall time rose from a
~150-175s baseline to ~250-255s under load — roughly +65-70%, not the mild
~10-15% the weaker setting would have cost. The workflow's 25-minute budget
(covering two full solution builds and a browser install) comfortably
absorbs it.

## Tests judged genuinely fragile beyond scheduling

Even with full serialization, on a machine carrying real *external*
background load (unrelated to this suite), these still flaked at least
once:

- `GanttV3StickyHeaderTests.Header_columns_stay_aligned_with_the_row_canvas_after_a_horizontal_scroll` —
  reads a stale scroll position because the page's own JS auto-center
  callback can still land after the test's manual reset even once the
  `data-gantt-v3-initial-scroll="done"` barrier has already fired. The
  numeric delta this produces is suspiciously consistent across independent
  failures, which points at a real ordering gap in the app's own mount-time
  scroll logic, not simple jitter.
- `GanttDragParityTests.Drag_create_after_panning_computes_dates_from_the_new_origin` —
  times out waiting on a SignalR round-trip to populate an event-sink
  element.
- `DragInteractionTests.Dragging_the_splitter_separator_moves_it` — a
  synthetic mouse-drag sequence that can be dropped/coalesced under real
  event-loop pressure.

None of these are fixed by any scheduling change; they depend on real
wall-clock timing (JS callback ordering, SignalR latency, synthetic input
timing) that no amount of xUnit-side parallelism control can fully
guarantee. Flagging them explicitly rather than letting them read as noise.

## Not in scope here

`ShimmerButtonGapTests` is fixed separately in #403 (different root cause —
a `document.querySelector`/circuit-render race, not scheduling).

## Test plan

- [x] Conflict-marker + "adepto" sweep clean
- [x] `dotnet build Lumeo.slnx -warnaserror -m:1` — 0 errors/warnings
- [x] Registry regen + local Algolia index — no diff beyond the fix
- [x] `python scripts/docs-parity/check.py` — exit 0 (one pre-existing,
      non-blocking casing warning unrelated to this change)
- [x] Full filtered suite (net10.0 lane, matching CI's own filter) —
      7,741 tests, 0 failures, 0 delta from this change (it only touches
      the excluded E2E assembly)
- [x] CPU-capped Docker repro of the actual CI runner spec (4 vCPU/16GB):
      baseline 2-of-5 runs failed; `MaxParallelThreads=2` 0-of-5 idle but
      1-of-3 under induced load; `MaxParallelThreads=1` (this fix) 3-of-3
      clean under the same induced load
- [x] Local E2E, repeated runs against local servers (LUMEO_E2E_BASE_URL
      pinned off the owner's port) — 2-of-3 clean, both failures on tests
      named above as genuinely timing-fragile, under real ambient load
      from an unrelated process on the dev machine

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved end-to-end test stability by running test collections sequentially.
  * Reduced Chromium resource contention during automated testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->