### PR TITLE
docs: every count and size re-measured on 5.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Lumeo
 
-**164 accessible Blazor components, AI-ready, motion-integrated, shadcn-inspired.**
+**166 accessible Blazor components, AI-ready, motion-integrated, shadcn-inspired.**
 
-**164 components · 5,900+ tests** · 14 locales · mobile-first · MIT · .NET 8+
+**166 components · 8,800+ tests** · 14 locales · mobile-first · MIT · .NET 8+
 
 [![NuGet](https://img.shields.io/nuget/v/Lumeo?logo=nuget&label=Lumeo)](https://www.nuget.org/packages/Lumeo)
 [![NuGet Downloads](https://img.shields.io/nuget/dt/Lumeo?logo=nuget&label=downloads)](https://www.nuget.org/packages/Lumeo)
@@ -12,14 +12,14 @@
 [![GitHub stars](https://img.shields.io/github/stars/Brain2k-0005/Lumeo?style=flat&logo=github)](https://github.com/Brain2k-0005/Lumeo/stargazers)
 [![Sponsor](https://img.shields.io/github/sponsors/Brain2k-0005?logo=github-sponsors&color=ea4aaa)](https://github.com/sponsors/Brain2k-0005)
 
-> **Lumeo 4.2.0 is on NuGet** — a first-party **icon family** (16 trimmable packs), **`dotnet new`** app + full-stack templates, and a **shadcn-parity campaign** (overlay exit animations, `data-*` styling hooks, native form participation, menu-system + NavigationMenu parity, chart/AI a11y) on top of the 4.0 major (Radix / Base UI / shadcn parity audit + a 164-component battle-test, ~355 bugs fixed, 5,900+ tests, CLI **100% NuGet-free** eject). `dotnet add package Lumeo`. See [`CHANGELOG.md`](./CHANGELOG.md) — 4.1 is an additive, opt-in upgrade from 4.0 (a few documented behaviour changes); from 3.x see [`MIGRATION.md`](./MIGRATION.md).
+> **Lumeo 5.1.1 is on NuGet** — the 5.x line measures against shadcn's live docs instead of reading its source: the control scale, radius scale, sidebar geometry, icon sizing, shadows and card spacing all land on shadcn's numbers, a production field report's 47 findings are worked through (DataGrid virtualization, server mode, range selection, composable toolbar, column resize), Excel/PDF export moved to `Lumeo.DataGrid.Export`, and `lumeo-classes.txt` ships for consumers who run their own Tailwind build. See the [changelog](CHANGELOG.md).
 
 ## What's new in 4.0
 
 4.0 pairs a Radix / Base UI / shadcn **parity audit** with a library-wide **correctness hardening** pass. There are **no API-signature breaks** — see [`MIGRATION.md`](./MIGRATION.md) for the handful of behaviour changes.
 
 - **NuGet-free standalone eject** — `lumeo eject` (or `lumeo init --standalone`) vendors components **plus the whole runtime** as source, so a project compiles and runs with zero `Lumeo` / satellite `PackageReference`. Proven across all 164 components.
-- **Battle-test campaign** — an adversarial sweep of all 164 components fixed ~355 confirmed bugs (UI state surviving data refreshes, keyboard / ARIA, edge data, lifecycle teardown, keyed reorder), each with a bUnit regression test (suite 5,900+ green).
+- **Battle-test campaign** — an adversarial sweep of every component fixed ~355 confirmed bugs (UI state surviving data refreshes, keyboard / ARIA, edge data, lifecycle teardown, keyed reorder), each with a bUnit regression test (suite 5,900+ green).
 - **OKLCH theme palette** — base + all 8 themes (878 tokens) migrated HSL → OKLCH, exact 1:1 (brand identity unchanged), matching Tailwind v4 / current shadcn.
 - **RTL** — new `DirectionProvider` + a logical-utility migration (`ml-→ms-`, `left-→start-`, …); identical in LTR, mirrored in RTL.
 - **tweakcn / shadcn native compatibility** — a bare shadcn `--primary` (or a pasted tweakcn export) drives Lumeo's tokens 1:1 with zero setup.
@@ -29,7 +29,7 @@
 
 ## Feature overview
 
-- **164 components** — accessible UI primitives, Blazor WASM & Server
+- **166 components** — accessible UI primitives, Blazor WASM & Server
 - **AI primitives** — `PromptInput`, `StreamingText`, `AgentMessageList`, `ToolCallCard`, `ReasoningDisplay`
 - **Motion primitives** — `Marquee`, `NumberTicker`, `TextReveal`, `BlurFade`, `BorderBeam`, `ShimmerButton`, `Sparkles`, `Sparkline`
 - **Dashboard tiles** — `KpiCard`, `SparkCard`, `Delta`, `Bento`, `BentoTile`, `PickList<T>`
@@ -48,7 +48,7 @@
 - **Form validation** — DataAnnotations + custom validators with styled error states
 - **Accessible** — ARIA roles, keyboard navigation, focus trapping, screen-reader support
 - **Mobile-first** — touch gestures (swipe, pinch, long-press, pull-to-refresh, swipe-actions), 44×44 px hit targets per WCAG 2.5.5, iOS-style wheel pickers, haptic feedback service, safe-area helpers — try it at `/docs/mobile`
-- **5,900+ tests** — CI-enforced on every PR
+- **8,800+ tests** — CI-enforced on every PR
 
 ## Component Categories
 
@@ -92,18 +92,19 @@ Or reference them in your `.csproj`. All packages share one version (lockstep) �
 
 ```xml
 <ItemGroup>
-  <PackageReference Include="Lumeo"            Version="4.2.0" />
+  <PackageReference Include="Lumeo"            Version="5.1.1" />
   <!-- add only the satellites you need: -->
-  <PackageReference Include="Lumeo.Charts"    Version="4.2.0" />
-  <PackageReference Include="Lumeo.DataGrid"  Version="4.2.0" />
-  <PackageReference Include="Lumeo.Editor"    Version="4.2.0" />
-  <PackageReference Include="Lumeo.Scheduler" Version="4.2.0" />
-  <PackageReference Include="Lumeo.Gantt"     Version="4.2.0" />
-  <PackageReference Include="Lumeo.Motion"    Version="4.2.0" />
-  <PackageReference Include="Lumeo.PdfViewer" Version="4.2.0" />
-  <PackageReference Include="Lumeo.Maps"      Version="4.2.0" />
-  <PackageReference Include="Lumeo.CodeEditor" Version="4.2.0" />
-  <PackageReference Include="Lumeo.FileViewer" Version="4.2.0" />
+  <PackageReference Include="Lumeo.Charts"    Version="5.1.1" />
+  <PackageReference Include="Lumeo.DataGrid"  Version="5.1.1" />
+  <PackageReference Include="Lumeo.DataGrid.Export" Version="5.1.1" /> <!-- Excel / PDF export; CSV is built in -->
+  <PackageReference Include="Lumeo.Editor"    Version="5.1.1" />
+  <PackageReference Include="Lumeo.Scheduler" Version="5.1.1" />
+  <PackageReference Include="Lumeo.Gantt"     Version="5.1.1" />
+  <PackageReference Include="Lumeo.Motion"    Version="5.1.1" />
+  <PackageReference Include="Lumeo.PdfViewer" Version="5.1.1" />
+  <PackageReference Include="Lumeo.Maps"      Version="5.1.1" />
+  <PackageReference Include="Lumeo.CodeEditor" Version="5.1.1" />
+  <PackageReference Include="Lumeo.FileViewer" Version="5.1.1" />
 </ItemGroup>
 ```
 
@@ -126,7 +127,7 @@ lumeo diff button         # diff vendored copy vs registry
 lumeo eject               # go 100% NuGet-free (vendor the runtime too)
 ```
 
-`lumeo eject` (or `lumeo init --standalone`) vendors the components **and** the runtime they need, so the project builds with no `Lumeo` package reference at all — proven across all 164 components.
+`lumeo eject` (or `lumeo init --standalone`) vendors the components **and** the runtime they need, so the project builds with no `Lumeo` package reference at all — proven across all 166 components.
 
 ### `Lumeo.Templates` — `dotnet new` scaffolders
 

--- a/docs/Lumeo.Docs/Pages/Blocks/HeroSectionBlock.razor
+++ b/docs/Lumeo.Docs/Pages/Blocks/HeroSectionBlock.razor
@@ -34,7 +34,7 @@
 
             <BlurFade DelayMs="200" Yoffset="12">
                 <Lumeo.Text Color="muted" Class="text-base md:text-lg leading-relaxed max-w-2xl">
-                    A production-ready component library for .NET 10 — 164 accessible component families
+                    A production-ready component library for .NET 10 — 166 accessible component families
                     (351 importable primitives) across a 627 KB core + opt-in satellites, fully themeable,
                     and crafted by engineers who ship.
                 </Lumeo.Text>

--- a/docs/Lumeo.Docs/Pages/Catalog.razor
+++ b/docs/Lumeo.Docs/Pages/Catalog.razor
@@ -7,7 +7,7 @@
 @inject NavigationManager Nav
 @implements IDisposable
 
-<PageTitle>Browse All 164 Lumeo Components</PageTitle>
+<PageTitle>Browse All 166 Lumeo Components</PageTitle>
 
 @if (_groups is null)
 {

--- a/docs/Lumeo.Docs/Pages/Docs/Accessibility.razor
+++ b/docs/Lumeo.Docs/Pages/Docs/Accessibility.razor
@@ -460,8 +460,8 @@
                 </li>
                 <li class="flex items-start gap-2">
                     <Lumeo.Text As="span" Class="mt-1.5 h-1.5 w-1.5 rounded-full bg-foreground shrink-0"></Lumeo.Text>
-                    <span>The axe-core sweep runs weekly (and on-demand) in CI against all 164 component
-                        routes, not per-commit or per-PR — a full sweep is a build + boot + 164-page crawl,
+                    <span>The axe-core sweep runs weekly (and on-demand) in CI against all 166 component
+                        routes, not per-commit or per-PR — a full sweep is a build + boot + 166-page crawl,
                         too slow for the PR critical path. See the results below.</span>
                 </li>
                 <li class="flex items-start gap-2">
@@ -531,7 +531,7 @@
         <Lumeo.Text Size="base" Color="muted" Leading="relaxed">
             <code class="rounded bg-muted px-1.5 py-0.5 text-xs font-mono text-foreground">scripts/a11y-audit</code>
             runs an axe-core WCAG A/AA sweep of every <code class="rounded bg-muted px-1.5 py-0.5 text-xs font-mono text-foreground">/components/&lt;slug&gt;</code>
-            docs route (all 164), scoped to each page's <code class="rounded bg-muted px-1.5 py-0.5 text-xs font-mono text-foreground">&lt;main&gt;</code>
+            docs route (all 166), scoped to each page's <code class="rounded bg-muted px-1.5 py-0.5 text-xs font-mono text-foreground">&lt;main&gt;</code>
             content so shared app-shell chrome doesn't spam every report with the same findings. It runs weekly
             and on-demand in CI, gated against a committed baseline of accepted-but-not-yet-fixed findings —
             a pull request fails the gate only if it introduces a <em>new</em> (component, rule) violation, so

--- a/docs/Lumeo.Docs/Pages/Docs/BundleFacts.razor
+++ b/docs/Lumeo.Docs/Pages/Docs/BundleFacts.razor
@@ -17,7 +17,7 @@
                 <Heading Level="1" Class="text-4xl sm:text-5xl font-bold tracking-tight leading-tight">
                     How Lumeo stays at
                     <Sparkles Count="6" Class="inline-flex items-baseline">
-                        <NumberTicker Value="672"
+                        <NumberTicker Value="712"
                                       Suffix=" KB"
                                       DurationMs="2000"
                                       Class="text-primary font-mono" />
@@ -26,7 +26,7 @@
 
                 <Lumeo.Text Size="base" Color="muted" Class="max-w-xl leading-relaxed">
                     What the browser actually downloads — brotli-compressed assembly size, measured
-                    <Lumeo.Text As="span" Weight="medium" Color="foreground">2026-07-11 (4.2.0)</Lumeo.Text>.
+                    <Lumeo.Text As="span" Weight="medium" Color="foreground">2026-09-02 (5.2.0)</Lumeo.Text>.
                 </Lumeo.Text>
             </Stack>
         </BlurFade>
@@ -119,8 +119,8 @@
         <BlurFade DelayMs="320" ForceHidden="true">
             <div class="mt-4 rounded-lg border border-border/40 bg-muted/20 px-4 py-3">
                 <Lumeo.Text Size="xs" Color="muted">
-                    Total: <Lumeo.Text As="span" Weight="semibold" Color="foreground">~1,180 KB</Lumeo.Text> in the .nupkg —
-                    matches the NuGet "Download package" badge (~1.18 MB). The <Lumeo.Text As="span" Weight="semibold" Color="foreground">672 KB brotli number</Lumeo.Text>
+                    Total: <Lumeo.Text As="span" Weight="semibold" Color="foreground">~2,580 KB</Lumeo.Text> in the .nupkg —
+                    matches the NuGet "Download package" badge (~2.5 MB; it carries net8.0 and net10.0, each with its XML docs). The <Lumeo.Text As="span" Weight="semibold" Color="foreground">712 KB brotli number</Lumeo.Text>
                     is just the DLL, which is the only thing the WASM linker ships to the browser.
                 </Lumeo.Text>
             </div>
@@ -219,9 +219,9 @@
                 published app) and the JS/CSS static web assets each library ships separately — some
                 substantial (e.g. Telerik's ~4.8&nbsp;MB JS bundle, Radzen's multi-theme CSS, and Lumeo's own
                 components.js&nbsp;+&nbsp;lumeo.css). DLL size reflects managed footprint, not features or final shipped size.
-                Only the Lumeo row was re-measured on 2026-07-11 against 4.2.0 — 671.6&nbsp;KiB
-                (687,723&nbsp;bytes) brotli of <code class="rounded bg-muted px-1 py-0.5 text-xs font-mono text-foreground">lib/net10.0/Lumeo.dll</code>,
-                rounded to 672&nbsp;KB above; every other row remains the 2026-06-29 measurement.
+                Only the Lumeo row was re-measured on 2026-09-02 against 5.2.0 — 712.4&nbsp;KiB
+                (729,545&nbsp;bytes) brotli of <code class="rounded bg-muted px-1 py-0.5 text-xs font-mono text-foreground">lib/net10.0/Lumeo.dll</code>,
+                rounded to 712&nbsp;KB above; every other row remains the 2026-06-29 measurement.
             </Lumeo.Text>
         </BlurFade>
     </section>
@@ -313,7 +313,7 @@
             <Stack Gap="3" Class="mb-6">
                 <Heading Level="2" Class="text-2xl font-semibold tracking-tight">Why brotli, not .nupkg?</Heading>
                 <Lumeo.Text Size="sm" Color="muted">
-                    NuGet shows ~1.18 MB for the core .nupkg — here's what that actually means.
+                    NuGet shows ~2.5 MB for the core .nupkg — here's what that actually means.
                 </Lumeo.Text>
             </Stack>
         </BlurFade>
@@ -343,19 +343,19 @@
                                         <Lumeo.Text As="span" Size="xs" Class="font-mono text-muted-foreground line-through">~1.35 MB</Lumeo.Text>
                                     </Flex>
                                     <Flex Align="center" Justify="between">
-                                        <Lumeo.Text Size="xs" Weight="medium" Color="foreground">.nupkg size as of 4.2.0 (registry on CDN, PDB ships as .snupkg)</Lumeo.Text>
-                                        <Lumeo.Text As="span" Size="xs" Class="font-mono font-semibold text-primary">~1.18 MB</Lumeo.Text>
+                                        <Lumeo.Text Size="xs" Weight="medium" Color="foreground">.nupkg size as of 5.2.0 (registry on CDN, PDB ships as .snupkg)</Lumeo.Text>
+                                        <Lumeo.Text As="span" Size="xs" Class="font-mono font-semibold text-primary">~2.5 MB</Lumeo.Text>
                                     </Flex>
                                     <Flex Align="center" Justify="between">
                                         <Lumeo.Text Size="xs" Weight="medium" Color="foreground">Brotli DLL actually shipped to browser</Lumeo.Text>
-                                        <Lumeo.Text As="span" Size="xs" Class="font-mono font-semibold text-primary">672 KB</Lumeo.Text>
+                                        <Lumeo.Text As="span" Size="xs" Class="font-mono font-semibold text-primary">712 KB</Lumeo.Text>
                                     </Flex>
                                 </Stack>
                             </div>
 
                             <Lumeo.Text Size="sm" Color="muted" Leading="relaxed">
-                                Even the 4.2.0 ~1.18 MB overstates the browser cost because XML docs (96 KB), static web
-                                assets (components.js, lumeo-utilities.css, lumeo.css, and smaller JS files totalling ~127 KB),
+                                Even the 5.2.0 ~2.5 MB overstates the browser cost because XML docs (929 KB per target framework), static web
+                                assets (components.js, lumeo-utilities.css, lumeo.css, and smaller JS files totalling ~775 KB),
                                 the Roslyn source generator (14 KB), and MSBuild props (~4 KB) never reach the browser — they
                                 only matter at development time. And PDB symbols no longer inflate the .nupkg at all: they now
                                 ship separately as a
@@ -425,7 +425,7 @@
                                 core and republished the same way. Its <code class="rounded bg-muted px-1.5 py-0.5 text-xs font-mono text-foreground">Lumeo.dll.br</code>
                                 measured 116,338 bytes (113.6 KiB) — an 83% reduction from the pre-#354 baseline for
                                 this usage shape. A headless-browser load check confirmed the trimmed publish still
-                                renders correctly (no console or page errors). An app using most or all 143 core
+                                renders correctly (no console or page errors). An app using most or all 144 core
                                 components will still approach the pre-#354 ceiling, since that shape genuinely
                                 reaches most of the assembly — trimming reduces cost with usage, it doesn't create free
                                 capacity. .NET runtime DLLs (~3–4&nbsp;MB brotli total) are excluded from every figure
@@ -569,25 +569,25 @@
 
     private readonly List<PackageRow> _packages =
     [
-        new("Lumeo",            "672 KB", 100, true,  "core — 143 components"),
-        new("Lumeo.Charts",     "128 KB",  20, false, "opt-in satellite"),
-        new("Lumeo.DataGrid",   "120 KB",  19, false, "opt-in satellite"),
-        new("Lumeo.Editor",      "29 KB",   5, false, "opt-in satellite"),
-        new("Lumeo.Motion",      "18 KB",   3, false, "opt-in satellite"),
-        new("Lumeo.Scheduler",   "16 KB",   3, false, "opt-in satellite"),
-        new("Lumeo.Gantt",       "12 KB",   2, false, "opt-in satellite"),
+        new("Lumeo",            "712 KB", 100, true,  "core — 144 components"),
+        new("Lumeo.Charts",     "135 KB",  19, false, "opt-in satellite"),
+        new("Lumeo.DataGrid",   "132 KB",  19, false, "opt-in satellite"),
+        new("Lumeo.Editor",      "27 KB",   4, false, "opt-in satellite"),
+        new("Lumeo.Motion",      "19 KB",   3, false, "opt-in satellite"),
+        new("Lumeo.Scheduler",   "73 KB",  10, false, "opt-in satellite"),
+        new("Lumeo.Gantt",       "82 KB",  12, false, "opt-in satellite"),
     ];
 
     private readonly List<NupkgAsset> _nupkgAssets =
     [
         new("Package", "Lumeo.dll",
-            "945 KB",
-            "Main Blazor component assembly — 3,076 KB raw IL, zip-compressed to 945 KB inside the .nupkg. The published WASM app brotli-compresses it to the 672 KB the browser actually downloads; the assembly itself is not IL-trimmed internally, so this size is the same whether you use 1 core component or all 143 (see 'What does WASM linker trimming do?' below)."),
+            "1,004 KB",
+            "Main Blazor component assembly — 3,281 KB raw IL, zip-compressed to 1,004 KB inside the .nupkg. The published WASM app brotli-compresses it to the 712 KB the browser actually downloads; the assembly itself is not IL-trimmed internally, so this size is the same whether you use 1 core component or all 143 (see 'What does WASM linker trimming do?' below)."),
         new("FileText", "Lumeo.xml",
-            "96 KB",
+            "176 KB",
             "XML documentation comments for every public API. Powers IntelliSense in Visual Studio and Rider. Never included in the WASM publish output."),
         new("Zap", "components.js",
-            "65 KB",
+            "100 KB",
             "Static web asset: focus traps, scroll lock, element measurement, and third-party canvas wrappers. Automatically injected into host projects via MSBuild StaticWebAssets."),
         new("Palette", "lumeo-utilities.css",
             "35 KB",
@@ -607,12 +607,12 @@
     // latest-stable public .nupkg, .NET 10 target where shipped (Telerik ships net8.0 only).
     // Sorted ascending — neutral measured ranking, no cherry-picked order. Reproducible by
     // brotli-compressing the DLL inside each package. See the note under the table for exclusions.
-    // Only the Lumeo row was re-measured 2026-07-11 against 4.2.0 (dotnet pack + brotli-11 of
+    // Only the Lumeo row was re-measured 2026-09-02 against 5.2.0 (dotnet pack + brotli-11 of
     // lib/net10.0/Lumeo.dll); every other row is still the 2026-06-29 measurement.
     private readonly List<ComparisonRow> _comparisonRows =
     [
         new("FluentUI Blazor",   "302 KB",    "v4.14.3 (net10.0)"),
-        new("Lumeo (core)",      "672 KB",    "v4.2.0 (net10.0)",   IsUs: true),
+        new("Lumeo (core)",      "712 KB",    "v5.2.0 (net10.0)",   IsUs: true),
         new("Radzen Blazor",     "1,003 KB",  "v11.0.5 (net10.0)"),
         new("MudBlazor",         "1,318 KB",  "v9.6.0 (net10.0)"),
         new("Telerik UI Blazor", "1,480 KB",  "v14.0.0 (net8.0)"),

--- a/docs/Lumeo.Docs/Pages/Docs/Cli.razor
+++ b/docs/Lumeo.Docs/Pages/Docs/Cli.razor
@@ -464,7 +464,7 @@ npm run watch:css</Stack>
   "registry": "https://lumeo.nativ.sh/registry.json",
   "assets": @("{")
     "mode": "prebuilt",
-    "version": "4.2.0",
+    "version": "5.1.1",
     "files": [
       "wwwroot/css/lumeo.css",
       "wwwroot/css/lumeo-utilities.css",
@@ -473,8 +473,8 @@ npm run watch:css</Stack>
     ]
   @("}"),
   "components": @("{")
-    "button":  @("{") "version": "4.2.0", "files": ["UI/Button/Button.razor"] @("}"),
-    "spinner": @("{") "version": "4.2.0", "files": ["UI/Spinner/Spinner.razor"] @("}")
+    "button":  @("{") "version": "5.1.1", "files": ["UI/Button/Button.razor"] @("}"),
+    "spinner": @("{") "version": "5.1.1", "files": ["UI/Spinner/Spinner.razor"] @("}")
   @("}")
 @("}")</Stack>
             <Lumeo.Text Size="sm" Color="muted" Leading="relaxed">
@@ -549,7 +549,7 @@ npm run watch:css</Stack>
                 Internal / Services / Theming / interop closure, copied once into
                 <code class="rounded bg-muted px-1.5 py-0.5 text-xs font-mono text-foreground">_LumeoRuntime/</code> (kept under the
                 <code class="rounded bg-muted px-1.5 py-0.5 text-xs font-mono text-foreground">Lumeo</code> namespace) — so the project builds and runs with
-                <Lumeo.Text As="span" Weight="medium" Class="text-foreground">zero Lumeo / satellite PackageReference</Lumeo.Text>, validated across all 164 components.
+                <Lumeo.Text As="span" Weight="medium" Class="text-foreground">zero Lumeo / satellite PackageReference</Lumeo.Text>, validated across all 166 components.
                 To also self-host CDN-delivered JS/CSS, run <code class="rounded bg-muted px-1.5 py-0.5 text-xs font-mono text-foreground">lumeo deps install</code>.
             </Lumeo.Text>
             <Lumeo.Text Size="sm" Color="muted" Leading="relaxed">

--- a/docs/Lumeo.Docs/Pages/Docs/Introduction.razor
+++ b/docs/Lumeo.Docs/Pages/Docs/Introduction.razor
@@ -671,7 +671,7 @@
     // tell an acronym run from a single capitalized word — plus "OtpInput"/"KpiCard", where the
     // acronym is only capitalized on its first letter so the rule would render "Otp"/"Kpi"
     // instead of the properly-cased "OTP"/"KPI"). Verified this is the complete set across all
-    // 164 components by inspection of registry.json's "name" field for every component; a small
+    // 166 components by inspection of registry.json's "name" field for every component; a small
     // explicit override is simpler and more accurate than a fancier acronym-detection algorithm.
     private static readonly Dictionary<string, string> _acronymOverrides = new(StringComparer.Ordinal)
     {

--- a/docs/Lumeo.Docs/Pages/Docs/McpServer.razor
+++ b/docs/Lumeo.Docs/Pages/Docs/McpServer.razor
@@ -38,7 +38,7 @@
             <Heading Level="2">What it exposes</Heading>
 
             <Lumeo.Text Size="base" Color="muted" Leading="relaxed">
-                The server covers <Lumeo.Text As="span" Weight="medium" Class="text-foreground">all 164 components</Lumeo.Text>
+                The server covers <Lumeo.Text As="span" Weight="medium" Class="text-foreground">all 166 components</Lumeo.Text>
                 from Lumeo's <Lumeo.Link Href="docs/registry" Class="text-foreground underline underline-offset-4 hover:text-muted-foreground transition-colors">component registry</Lumeo.Link>.
                 The top ~35 most-used components ship with rich, hand-curated schemas (parameters, slots, ready-to-use Razor examples);
                 the rest are discoverable and returned with category, description, files, dependencies, and CSS variables
@@ -50,7 +50,7 @@
                 <ul class="space-y-2 text-base text-muted-foreground list-none">
                     <li class="flex items-start gap-2">
                         <Lumeo.Text As="span" Class="mt-1 h-1.5 w-1.5 rounded-full bg-foreground shrink-0"></Lumeo.Text>
-                        <span><code class="rounded bg-muted px-1.5 py-0.5 text-xs font-mono text-foreground">lumeo_list_components</code> — list all 164 components, optionally filtered by category or free-text query.</span>
+                        <span><code class="rounded bg-muted px-1.5 py-0.5 text-xs font-mono text-foreground">lumeo_list_components</code> — list all 166 components, optionally filtered by category or free-text query.</span>
                     </li>
                     <li class="flex items-start gap-2">
                         <Lumeo.Text As="span" Class="mt-1 h-1.5 w-1.5 rounded-full bg-foreground shrink-0"></Lumeo.Text>
@@ -276,7 +276,7 @@ npm run build</Stack>
         <Stack Gap="4">
             <Heading Level="2">Scope</Heading>
             <Lumeo.Text Size="base" Color="muted" Leading="relaxed">
-                The catalog covers <Lumeo.Text As="span" Weight="medium" Class="text-foreground">all 164 components</Lumeo.Text>
+                The catalog covers <Lumeo.Text As="span" Weight="medium" Class="text-foreground">all 166 components</Lumeo.Text>
                 across Forms, Layout, Overlay, Data Display, Navigation, Feedback, Charts, Dashboard, AI, Motion,
                 Drag &amp; Drop, Typography and Utility. Rich schemas exist for the top ~35; the rest resolve to a thin
                 payload (files, dependencies, CSS variables) with a link to the component's docs page. Rich coverage

--- a/docs/Lumeo.Docs/Pages/Home.razor
+++ b/docs/Lumeo.Docs/Pages/Home.razor
@@ -46,12 +46,12 @@
             </BlurFade>
             <BlurFade DelayMs="190">
                 <Flex Wrap="true" Justify="center" Align="center" Gap="2" Class="mt-6">
-                    <span class="inline-block rounded-full border border-border/50 bg-card/60 px-3 py-1 text-xs text-muted-foreground"><span class="font-semibold text-foreground">164</span> components</span>
+                    <span class="inline-block rounded-full border border-border/50 bg-card/60 px-3 py-1 text-xs text-muted-foreground"><span class="font-semibold text-foreground">166</span> components</span>
                     <span class="inline-block rounded-full border border-border/50 bg-card/60 px-3 py-1 text-xs text-muted-foreground"><span class="font-semibold text-foreground">8</span> blocks</span>
                     <span class="inline-block rounded-full border border-border/50 bg-card/60 px-3 py-1 text-xs text-muted-foreground"><span class="font-semibold text-foreground">16</span> icon packs</span>
-                    <span class="inline-block rounded-full border border-border/50 bg-card/60 px-3 py-1 text-xs text-muted-foreground"><span class="font-semibold text-foreground">672 KB</span> core</span>
+                    <span class="inline-block rounded-full border border-border/50 bg-card/60 px-3 py-1 text-xs text-muted-foreground"><span class="font-semibold text-foreground">712 KB</span> core</span>
                     <span class="inline-block rounded-full border border-border/50 bg-card/60 px-3 py-1 text-xs text-muted-foreground"><span class="font-semibold text-foreground">MIT</span></span>
-                    <span class="inline-block rounded-full border border-border/50 bg-card/60 px-3 py-1 text-xs text-muted-foreground"><span class="font-semibold text-foreground">5,900+</span> tests</span>
+                    <span class="inline-block rounded-full border border-border/50 bg-card/60 px-3 py-1 text-xs text-muted-foreground"><span class="font-semibold text-foreground">8,800+</span> tests</span>
                 </Flex>
             </BlurFade>
             <BlurFade DelayMs="240">
@@ -167,7 +167,7 @@
     <Container MaxWidth="[1400px]" Class="px-4 py-6">
         <Flex Align="center" Justify="between" Wrap="true" Gap="4">
             <Flex Align="center" Gap="3" Wrap="true">
-                <Badge Variant="Badge.BadgeVariant.Outline" Class="shrink-0">164 components</Badge>
+                <Badge Variant="Badge.BadgeVariant.Outline" Class="shrink-0">166 components</Badge>
                 <Lumeo.Text Size="sm" Color="muted">Every primitive in one place &mdash; 13 categories, from Forms and Overlays to Data surfaces and AI.</Lumeo.Text>
             </Flex>
             <Lumeo.Link Href="components" Class="inline-flex h-8 items-center gap-2 justify-center rounded-lg border border-border/60 bg-background px-2.5 text-sm font-semibold text-foreground hover:bg-accent hover:text-accent-foreground transition-colors no-underline shrink-0">
@@ -195,7 +195,7 @@
                 <Stack Gap="5">
                     <Stack Gap="1">
                         <Heading Level="3" Class="text-2xl font-semibold tracking-tight">
-                            164 components across 11 packages. <Lumeo.Text As="span" Class="text-primary">672 KB core</Lumeo.Text>.
+                            166 components across 12 packages. <Lumeo.Text As="span" Class="text-primary">712 KB core</Lumeo.Text>.
                         </Heading>
                         <Lumeo.Text Size="sm" Color="muted">Per-package breakdown &mdash; install only the satellites you use.</Lumeo.Text>
                     </Stack>
@@ -223,7 +223,7 @@
 
                     <Flex Align="center" Gap="2" Class="text-xs text-muted-foreground border-t border-border/40 pt-4">
                         <DynamicIcon Name="Info" Class="h-3.5 w-3.5" />
-                        <Lumeo.Text As="span">Brotli-compressed assembly bytes. Core brotli-compresses to 672 KB in your published app, whether you use 1 core component or all 143.</Lumeo.Text>
+                        <Lumeo.Text As="span">Brotli-compressed assembly bytes. Core brotli-compresses to 712 KB in your published app, whether you use 1 core component or all 144.</Lumeo.Text>
                     </Flex>
                 </Stack>
             </BentoTile>
@@ -236,7 +236,7 @@
                         </div>
                         <Stack Gap="0" Class="min-w-0 flex-1">
                             <Lumeo.Text Size="xs" Color="muted">Tests</Lumeo.Text>
-                            <div class="text-2xl font-semibold tracking-tight text-foreground leading-none">5,900+</div>
+                            <div class="text-2xl font-semibold tracking-tight text-foreground leading-none">8,800+</div>
                             <Lumeo.Text Size="xs" Color="muted" Class="truncate">CI green, every commit.</Lumeo.Text>
                         </Stack>
                     </Flex>
@@ -273,7 +273,7 @@
                             </div>
                             <Stack Gap="0" Class="min-w-0 flex-1">
                                 <Lumeo.Text Size="xs" Color="muted">Accessibility</Lumeo.Text>
-                                <div class="text-2xl font-semibold tracking-tight text-foreground leading-none">127/164</div>
+                                <div class="text-2xl font-semibold tracking-tight text-foreground leading-none">114/144</div>
                                 <Lumeo.Text Size="xs" Color="muted" Class="truncate">Components with automated ARIA + keyboard tests.</Lumeo.Text>
                             </Stack>
                         </Flex>
@@ -304,7 +304,7 @@
                     </div>
                     <Heading Level="3" Class="text-base font-semibold">NuGet</Heading>
                 </Flex>
-                <Lumeo.Text Size="sm" Color="muted" Class="flex-1">Core package (672 KB brotli) is always required. Add satellites only for the heavy components you use.</Lumeo.Text>
+                <Lumeo.Text Size="sm" Color="muted" Class="flex-1">Core package (712 KB brotli) is always required. Add satellites only for the heavy components you use.</Lumeo.Text>
                 <div class="rounded-lg overflow-hidden ring-1 ring-border/40" style="background-color: #0a0a0a;">
                     <div class="flex items-center justify-between px-3 py-2 border-b" style="border-color: rgba(255,255,255,0.08);">
                         <div class="flex items-center gap-1.5">
@@ -518,7 +518,7 @@ builder.Services.<span style="color: #a78bfa;">AddLumeo</span>();</pre>
                     <span class="text-base font-bold tracking-tight text-foreground">Lumeo</span>
                 </Flex>
                 <Lumeo.Text Size="sm" Color="muted" Class="max-w-xs leading-relaxed">
-                    164 MIT-licensed Blazor components, blocks and motion primitives &mdash; ship fast, keep the source.
+                    166 MIT-licensed Blazor components, blocks and motion primitives &mdash; ship fast, keep the source.
                 </Lumeo.Text>
                 <Flex Align="center" Gap="2" Class="mt-4">
                     <a href="https://github.com/Brain2k-0005/Lumeo" target="_blank" rel="noopener"
@@ -543,7 +543,7 @@ builder.Services.<span style="color: #a78bfa;">AddLumeo</span>();</pre>
                     <li><Lumeo.Link Href="components/data-grid" Class="text-sm text-muted-foreground hover:text-foreground transition-colors no-underline">DataGrid</Lumeo.Link></li>
                     <li><Lumeo.Link Href="components/chart" Class="text-sm text-muted-foreground hover:text-foreground transition-colors no-underline">Chart</Lumeo.Link></li>
                     <li><Lumeo.Link Href="components/dialog" Class="text-sm text-muted-foreground hover:text-foreground transition-colors no-underline">Dialog</Lumeo.Link></li>
-                    <li><Lumeo.Link Href="components" Class="text-sm font-medium text-primary hover:underline no-underline">All 164 &rarr;</Lumeo.Link></li>
+                    <li><Lumeo.Link Href="components" Class="text-sm font-medium text-primary hover:underline no-underline">All 166 &rarr;</Lumeo.Link></li>
                 </ul>
             </div>
 
@@ -586,7 +586,7 @@ builder.Services.<span style="color: #a78bfa;">AddLumeo</span>();</pre>
 
         <Flex Align="center" Justify="between" Wrap="true" Gap="3" Class="mt-12 pt-6 border-t border-border/40">
             <Lumeo.Text Size="xs" Color="muted">&copy; Lumeo 2026 &middot; Released under the MIT License &middot; built with Lumeo</Lumeo.Text>
-            <Lumeo.Text Size="xs" Color="muted">164 components &middot; 8 blocks &middot; 16 icon packs &middot; 672 KB core &middot; 5,900+ tests</Lumeo.Text>
+            <Lumeo.Text Size="xs" Color="muted">166 components &middot; 25 blocks &middot; 16 icon packs &middot; 712 KB core &middot; 8,800+ tests</Lumeo.Text>
         </Flex>
     </Container>
 </footer>
@@ -599,11 +599,11 @@ builder.Services.<span style="color: #a78bfa;">AddLumeo</span>();</pre>
     // Size rows
     private readonly SizeRow[] _sizeRows =
     {
-        new("Lumeo",           "143 components", "672 KB", 100.0, true),
-        new("Lumeo.Charts",    "30+ chart types", "128 KB",   32.0, false),
-        new("Lumeo.DataGrid",  "3 components",  "120 KB",   30.0, false),
-        new("Lumeo.Editor",    "1 component",  "29 KB",     7.25, false),
-        new("Lumeo.Motion",    "10 components", "18 KB",     4.5, false),
+        new("Lumeo",           "144 components", "712 KB", 100.0, true),
+        new("Lumeo.Charts",    "30 chart types",  "135 KB",   19.0, false),
+        new("Lumeo.DataGrid",  "3 components",  "132 KB",   18.5, false),
+        new("Lumeo.Editor",    "1 component",  "27 KB",     3.8, false),
+        new("Lumeo.Motion",    "10 components", "19 KB",     2.7, false),
         new("Lumeo.Scheduler", "1 component",   "16 KB",     4.0, false),
         new("Lumeo.Gantt",     "1 component",   "12 KB",     3.0, false),
     };
@@ -613,13 +613,13 @@ builder.Services.<span style="color: #a78bfa;">AddLumeo</span>();</pre>
     {
         new("FolderGit2",        "Vendor the source",       "lumeo add copies a component's source into your repo — edit it freely, no lock-in."),
         new("Palette",           "Tailwind CSS v4 native",  "CSS-variable theming, no SCSS pipeline. Swap palettes with lumeo apply --preset."),
-        new("Accessibility",     "Accessible by default",   "128 of 164 components carry automated accessibility tests — ARIA roles/attributes and keyboard behavior via bUnit, with Playwright E2E coverage for some. Plus a weekly axe-core WCAG A/AA sweep of every component route, gated against a committed baseline.", "docs/accessibility"),
+        new("Accessibility",     "Accessible by default",   "114 of the 144 core components carry automated accessibility tests — ARIA roles/attributes and keyboard behavior via bUnit, with Playwright E2E coverage for some. Plus a weekly axe-core WCAG A/AA sweep of every component route, gated against a committed baseline.", "docs/accessibility"),
         new("MousePointerClick", "Motion built in",         "BlurFade, BorderBeam, Marquee and more — animation primitives with zero JS config."),
         new("ChartBar",          "Charts & data surfaces",  "30+ ECharts types plus a virtualized DataGrid with sort, group, and export."),
         new("Zap",               "AI primitives",           "Streaming messages, tool calls and prompt inputs — drop-in blocks for copilot UIs."),
         new("Languages",         "i18n & RTL",              "14 bundled locales, ILumeoLocalizer overrides, and correct right-to-left mirroring."),
         new("Shield",            "MIT, no tiers",           "Commercial use, white-label and redistribution — no community edition, no revenue cap."),
-        new("Package",           "One core + satellites",   "672 KB core; add Charts, DataGrid, Editor, Scheduler, Gantt or Motion only when needed."),
+        new("Package",           "One core + satellites",   "712 KB core; add Charts, DataGrid, Editor, Scheduler, Gantt, Motion, PdfViewer, Maps, CodeEditor or FileViewer only when needed."),
     };
 
     // Built for — compact 3-item row (top surfaces surviving the merge).

--- a/tools/lumeo-mcp/README.md
+++ b/tools/lumeo-mcp/README.md
@@ -128,7 +128,7 @@ The component schema is generated at build time, not hand-maintained:
 `tools/Lumeo.RegistryGen` reads the actual Razor source via Roslyn and emits full
 params / enums / events / sub-component metadata for every component into
 `src/Lumeo/registry/`. `scripts/sync-registry.mjs` copies the generated
-`registry.json` (164 components) and `components-api.json` here at `prebuild`
+`registry.json` (166 components) and `components-api.json` here at `prebuild`
 time, so the catalog never drifts from the source.
 
 `src/components.ts` only layers a few extra hand-curated example snippets on top —


### PR DESCRIPTION
Docs-only. The README and the site still carried the 4.2.0 numbers. Everything below was measured today on 5.2.0:

| Claim | Was | Is |
|---|---|---|
| Components | 164 | 166 in the registry, 144 in the core package |
| Tests | 5,900+ | 8,800+ (8,200 core, 37 docs, 137 CLI, 175 registry, 32 source generators, 222 E2E) |
| Packages | 11 | 12 (`Lumeo.DataGrid.Export` added) |
| Blocks | 8 | 25 |
| Core, brotli-11 of the net10.0 WASM | 672 KB | 712 KB (729,545 bytes) |
| Core .nupkg | ~1.18 MB | ~2.5 MB (net8.0 + net10.0, XML docs per TFM) |
| Satellites (brotli) | Charts 128 / DataGrid 120 / Editor 29 / Motion 18 / Scheduler 16 / Gantt 12 KB | 135 / 132 / 27 / 19 / 73 / 82 KB |
| Accessibility tests | 128 of 164 | 114 of 144 core components |
| README callout / pins | 4.2.0 | 5.x summary / 5.1.1 (the published version) |

Icons (51,000+), locales (14), chart types (30) and icon packs (16) were checked and are correct. Bundle Facts keeps its dated competitor rows and states which rows were re-measured when.